### PR TITLE
Allow retrying on ES timeouts

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -56,6 +56,11 @@ data:
     elasticsearch_write_stdout = True
     elasticsearch_json_format = True
     elasticsearch_log_id_template = {dag_id}_{task_id}_{execution_date}_{try_number}
+    
+    [elasticsearch_configs]
+    max_retries = 3
+    timeout = 30
+    retry_timeout = True
 {{- end }}
 
 {{- if eq .Values.executor "KubernetesExecutor" }}


### PR DESCRIPTION
This would help us in case we have some networking issues or our index grows massive