### PR TITLE
Update defaultAirflowTag

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -60,7 +60,7 @@ allowPodLaunching: true
 defaultAirflowRepository: astronomerinc/ap-airflow
 
 # Default airflow tag to deploy
-defaultAirflowTag: 1.10.5-alpine3.10
+defaultAirflowTag: 1.10.7-alpine3.10
 
 # Astronomer Airflow images
 images:


### PR DESCRIPTION
This bumps the version pre-baked into the chart. From Astronomer POV, we'll continue to override this from the platform level. This just makes the default 1.10.7.