### PR TITLE
Move GCP auth to the right spot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,9 @@ jobs:
       - run:
           name: Release the Airflow chart
           command: |
+            set -e
+            printf "%s" $${GCP_TOKEN} > /tmp/gcs_token.json
+            gcloud auth activate-service-account --key-file=/tmp/gcs_token.json
             HELM_CHART_PATH='/tmp/workspace/airflow-*.tgz' bin/release
 
 commands:
@@ -130,10 +133,6 @@ commands:
           name: Create a release on GitHub
           command: |
             set -xe
-
-            printf "%s" $${GCP_TOKEN} > /tmp/gcs_token.json
-            gcloud auth activate-service-account --key-file=/tmp/gcs_token.json
-
             pip3 install --user astronomer_e2e_test
             # We can remove --debug after we are happy with it
             astronomer-ci --debug publish-github-release --github-repository $CIRCLE_PROJECT_REPONAME --github-organization $CIRCLE_PROJECT_USERNAME --commitish $CIRCLE_SHA1


### PR DESCRIPTION
<!--
Thank you for contributing to the Airflow Helm chart!
-->
the GCP_TOKEN auth was accidentally placed in the github release part instead of the helm chart release part.
**Checklist**
n/a
- [ ]  Chart.yaml version updated
