### PR TITLE
Add option to override airflow_local_settings.py

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v1 is Helm 2
 apiVersion: v1
 name: airflow
-version: 0.11.0
+version: 0.11.1
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://www.astronomer.io/static/airflowNewA.png
 keywords:

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -119,9 +119,9 @@ data:
     SECURITY_MANAGER_CLASS = AirflowAstroSecurityManager
 {{- end }}
 
-{{- if .Values.scheduler.airflowLocalSettingsOverride }}
+{{- if .Values.scheduler.airflowLocalSettings }}
   airflow_local_settings.py: |
-    {{ .Values.scheduler.airflowLocalSettingsOverride | nindent 4 }}
+    {{ .Values.scheduler.airflowLocalSettings | nindent 4 }}
 {{- else }}
   airflow_local_settings.py: |
     from airflow.contrib.kubernetes.pod import Pod

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -119,6 +119,10 @@ data:
     SECURITY_MANAGER_CLASS = AirflowAstroSecurityManager
 {{- end }}
 
+{{- if .Values.scheduler.airflowLocalSettingsOverride }}
+  airflow_local_settings.py: |
+    {{ .Values.scheduler.airflowLocalSettingsOverride | nindent 4 }}
+{{- else }}
   airflow_local_settings.py: |
     from airflow.contrib.kubernetes.pod import Pod
     from airflow.configuration import conf
@@ -140,3 +144,4 @@ data:
         pod.labels.update(extra_labels)
         pod.tolerations += {{ toJson .Values.podMutation.tolerations }}
         pod.affinity.update({{ toJson .Values.podMutation.affinity }})
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -187,6 +187,12 @@ scheduler:
   #   cpu: 100m
   #   memory: 128Mi
 
+  # This setting can overwrite
+  # podMutation settings - be sure
+  # to reference the default if you
+  # are making use of those settings.
+  airflowLocalSettingsOverride: ~
+
 # Airflow webserver settings
 webserver:
   livenessProbe:

--- a/values.yaml
+++ b/values.yaml
@@ -191,7 +191,7 @@ scheduler:
   # podMutation settings - be sure
   # to reference the default if you
   # are making use of those settings.
-  airflowLocalSettingsOverride: ~
+  airflowLocalSettings: ~
 
 # Airflow webserver settings
 webserver:


### PR DESCRIPTION
<!--
Thank you for contributing to the Airflow Helm chart!
-->
Some users may need to override the Airflow pod mutation hook.

Example of this change at work:
```
e4384cda2b17:  ~/shared/airflow-chart 
_ helm template . -f ./config.yaml | grep -A9 'airflow_local_settings.py:'
  airflow_local_settings.py: |

    from airflow.contrib.kubernetes.pod import Pod
    from airflow.configuration import conf

    def pod_mutation_hook(pod: Pod):
      pass


---

e4384cda2b17:  ~/shared/airflow-chart 
_ cat config.yaml
scheduler:
  airflowLocalSettingsOverride: |
    from airflow.contrib.kubernetes.pod import Pod
    from airflow.configuration import conf

    def pod_mutation_hook(pod: Pod):
      pass

e4384cda2b17:  ~/shared/airflow-chart 
_ helm template . | grep -A25 'airflow_local_settings.py:'
  airflow_local_settings.py: |
    from airflow.contrib.kubernetes.pod import Pod
    from airflow.configuration import conf


    def pod_mutation_hook(pod: Pod):

        extra_labels = {
            "kubernetes-executor": "False",
            "kubernetes-pod-operator": "False"
        }

        if 'airflow-worker' in pod.labels.keys() or \
                conf.get('core', 'EXECUTOR') == "KubernetesExecutor":
            extra_labels["kubernetes-executor"] = "True"
        else:
            extra_labels["kubernetes-pod-operator"] = "True"

        pod.labels.update(extra_labels)
        pod.tolerations += []
        pod.affinity.update({})

---
# Source: airflow/templates/scheduler/scheduler-serviceaccount.yaml
################################
## Airflow Scheduler ServiceAccount

e4384cda2b17:  ~/shared/airflow-chart 
```
**Checklist**

- [x]  Chart.yaml version updated
