### PR TITLE
Disable the scheduler PodDisruptionBudget

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,6 @@ commands:
           command: |
             set -xe
             pyenv global 3.7.0
-            pip install --user astronomer_e2e_test
+            pip install astronomer_e2e_test
             # We can remove --debug after we are happy with it
             astronomer-ci --debug publish-github-release --github-repository $CIRCLE_PROJECT_REPONAME --github-organization $CIRCLE_PROJECT_USERNAME --commitish $CIRCLE_SHA1

--- a/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -19,6 +19,7 @@ spec:
   replicas: 1
   strategy:
     rollingUpdate:
+      maxSurge: 1
       maxUnavailable: 0
   selector:
     matchLabels:

--- a/templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml
+++ b/templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml
@@ -1,8 +1,7 @@
 ################################
 ## Pgbouncer PodDisruptionBudget
 #################################
-# Mimic scheduler pdb. Scheduler isn't too useful if it can't talk to postgres
-{{- if and .Values.pgbouncer.enabled .Values.scheduler.podDisruptionBudget.enabled }}
+{{- if and .Values.pgbouncer.enabled .Values.pgbouncer.podDisruptionBudget.enabled }}
 kind: PodDisruptionBudget
 apiVersion: policy/v1beta1
 metadata:
@@ -22,5 +21,5 @@ spec:
       tier: airflow
       component: pgbouncer
       release: {{ .Release.Name }}
-{{ toYaml .Values.scheduler.podDisruptionBudget.config | indent 2 }}
+{{ toYaml .Values.pgbouncer.podDisruptionBudget.config | indent 2 }}
 {{- end }}

--- a/templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml
+++ b/templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml
@@ -2,7 +2,7 @@
 ## Pgbouncer PodDisruptionBudget
 #################################
 # Mimic scheduler pdb. Scheduler isn't too useful if it can't talk to postgres
-{{- if .Values.pgbouncer.enabled }}
+{{- if and .Values.pgbouncer.enabled .Values.scheduler.podDisruptionBudget.enabled }}
 kind: PodDisruptionBudget
 apiVersion: policy/v1beta1
 metadata:
@@ -22,5 +22,5 @@ spec:
       tier: airflow
       component: pgbouncer
       release: {{ .Release.Name }}
-{{ toYaml .Values.scheduler.podDisruptionBudget | indent 2 }}
+{{ toYaml .Values.scheduler.podDisruptionBudget.config | indent 2 }}
 {{- end }}

--- a/templates/scheduler/scheduler-poddisruptionbudget.yaml
+++ b/templates/scheduler/scheduler-poddisruptionbudget.yaml
@@ -5,7 +5,7 @@
 kind: PodDisruptionBudget
 apiVersion: policy/v1beta1
 metadata:
-  name: {{ .Release.Name }}-pdb
+  name: {{ .Release.Name }}-scheduler-pdb
   labels:
     tier: airflow
     component: scheduler

--- a/templates/scheduler/scheduler-poddisruptionbudget.yaml
+++ b/templates/scheduler/scheduler-poddisruptionbudget.yaml
@@ -1,6 +1,7 @@
 ################################
 ## Airflow Scheduler PodDisruptionBudget
 #################################
+{{- if .Values.scheduler.podDisruptionBudget.enabled }}
 kind: PodDisruptionBudget
 apiVersion: policy/v1beta1
 metadata:
@@ -20,4 +21,5 @@ spec:
       tier: airflow
       component: scheduler
       release: {{ .Release.Name }}
-{{ toYaml .Values.scheduler.podDisruptionBudget | indent 2 }}
+{{ toYaml .Values.scheduler.podDisruptionBudget.config | indent 2 }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -175,9 +175,13 @@ workers:
 
 # Airflow scheduler settings
 scheduler:
-  # Ensure we have one replica always running
   podDisruptionBudget:
-    maxUnavailable: 1
+    enabled: false
+
+    # PDB configuration
+    config:
+      # Ensure we have one replica always running
+      maxUnavailable: 1
 
   resources: {}
   #  limits:

--- a/values.yaml
+++ b/values.yaml
@@ -175,12 +175,12 @@ workers:
 
 # Airflow scheduler settings
 scheduler:
+  # Scheduler pod disruption budget
   podDisruptionBudget:
     enabled: false
 
     # PDB configuration
     config:
-      # Ensure we have one replica always running
       maxUnavailable: 1
 
   resources: {}
@@ -266,6 +266,14 @@ pgbouncer:
 
   # Maximum clients that can connect to pgbouncer (higher = more file descriptors)
   maxClientConn: 100
+
+  # Pgbouner pod disruption budget
+  podDisruptionBudget:
+    enabled: false
+
+    # PDB configuration
+    config:
+      maxUnavailable: 1
 
   resources: {}
     # limits:


### PR DESCRIPTION
This PR makes the PDB on the scheduler and pgbouncer optional and disabled by default. By disabling in our cloud we may be able to avoid needing to do the manual compaction.

https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node