### PR TITLE
Add support for Azure DB PostgreSQL - airflow chart

### DIFF
--- a/bin/reset-local-dev
+++ b/bin/reset-local-dev
@@ -12,4 +12,5 @@ echo "Deploying Airflow..."
 
 helm install \
   -n airflow \
+  --set pgbouncer.enabled=true \
   $REPO_DIR

--- a/bin/run-ci
+++ b/bin/run-ci
@@ -43,6 +43,7 @@ set -x
 
 helm install \
   -n airflow \
+  --set pgbouncer.enabled=true \
   --wait \
   $HELM_CHART_PATH
 

--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -154,8 +154,8 @@
 
 {{ define "pgbouncer_config" }}
 [databases]
-{{ .Release.Name }}-metadata = host={{ .Values.data.metadataConnection.host }} dbname={{ .Values.data.metadataConnection.db }} port={{ .Values.data.metadataConnection.port }} pool_size={{ .Values.pgbouncer.metadataPoolSize }}
-{{ .Release.Name }}-result-backend = host={{ .Values.data.resultBackendConnection.host }} dbname={{ .Values.data.resultBackendConnection.db }} port={{ .Values.data.resultBackendConnection.port }} pool_size={{ .Values.pgbouncer.resultBackendPoolSize }}
+{{ .Release.Name }}-metadata = host={{ .Values.data.metadataConnection.host }} dbname={{ .Values.data.metadataConnection.db }} port={{ .Values.data.metadataConnection.port }} pool_size={{ .Values.pgbouncer.metadataPoolSize }} {{ if .Values.data.metadataConnection.azureDbServer }}user={{ .Values.data.metadataConnection.user }}{{ .Values.data.metadataConnection.azureDbServer }} password={{ .Values.data.metadataConnection.pass }}{{ end }}
+{{ .Release.Name }}-result-backend = host={{ .Values.data.resultBackendConnection.host }} dbname={{ .Values.data.resultBackendConnection.db }} port={{ .Values.data.resultBackendConnection.port }} pool_size={{ .Values.pgbouncer.resultBackendPoolSize }} {{ if .Values.data.resultBackendConnection.azureDbServer }}user={{ .Values.data.resultBackendConnection.user }}{{ .Values.data.resultBackendConnection.azureDbServer }} password={{ .Values.data.resultBackendConnection.pass }}{{ end }}
 
 [pgbouncer]
 pool_mode = transaction

--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -154,8 +154,8 @@
 
 {{ define "pgbouncer_config" }}
 [databases]
-{{ .Release.Name }}-metadata = host={{ .Values.data.metadataConnection.host }} dbname={{ .Values.data.metadataConnection.db }} port={{ .Values.data.metadataConnection.port }} pool_size={{ .Values.pgbouncer.metadataPoolSize }} {{ if .Values.data.metadataConnection.azureDbServer }}user={{ .Values.data.metadataConnection.user }}{{ .Values.data.metadataConnection.azureDbServer }} password={{ .Values.data.metadataConnection.pass }}{{ end }}
-{{ .Release.Name }}-result-backend = host={{ .Values.data.resultBackendConnection.host }} dbname={{ .Values.data.resultBackendConnection.db }} port={{ .Values.data.resultBackendConnection.port }} pool_size={{ .Values.pgbouncer.resultBackendPoolSize }} {{ if .Values.data.resultBackendConnection.azureDbServer }}user={{ .Values.data.resultBackendConnection.user }}{{ .Values.data.resultBackendConnection.azureDbServer }} password={{ .Values.data.resultBackendConnection.pass }}{{ end }}
+{{ .Release.Name }}-metadata = host={{ .Values.data.metadataConnection.host }} dbname={{ .Values.data.metadataConnection.db }} port={{ .Values.data.metadataConnection.port }} pool_size={{ .Values.pgbouncer.metadataPoolSize }} user={{ .Values.data.metadataConnection.user }} password={{ .Values.data.metadataConnection.pass }}
+{{ .Release.Name }}-result-backend = host={{ .Values.data.resultBackendConnection.host }} dbname={{ .Values.data.resultBackendConnection.db }} port={{ .Values.data.resultBackendConnection.port }} pool_size={{ .Values.pgbouncer.resultBackendPoolSize }} user={{ .Values.data.resultBackendConnection.user }} password={{ .Values.data.resultBackendConnection.pass }}
 
 [pgbouncer]
 pool_mode = transaction


### PR DESCRIPTION
fix issue astronomer/issues#102
- Adds username in format `user@dbserver` and password to `pgbouncer_config` if `azureDbServer` value exists for `metadataConnection` or `resultBackendConnection`
- `azureDbServer` value will be added by `houston-api` if it exists in the username https://github.com/astronomer/houston-api/pull/233
- Required for use with Azure DB for PostgreSQL