### PR TITLE
Add ability to enable/disable statsd component

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -40,10 +40,12 @@ data:
 
     [scheduler]
     scheduler_heartbeat_sec = 5
+{{- if .Values.statsd.enabled }}
     statsd_on = True
     statsd_port = 9125
     statsd_prefix = airflow
     statsd_host = {{ printf "%s-statsd" .Release.Name }}
+{{- end }}
     # Restart Scheduler every 41460 seconds (11 hours 31 minutes)
     # The odd time is chosen so it is not always restarting on the same "hour" boundary
     run_duration = 41460

--- a/templates/statsd/statsd-deployment.yaml
+++ b/templates/statsd/statsd-deployment.yaml
@@ -1,6 +1,7 @@
 ################################
 ## Airflow StatsD Deployment
 #################################
+{{- if .Values.statsd.enabled }}
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -66,3 +67,4 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
+{{- end }}

--- a/templates/statsd/statsd-networkpolicy.yaml
+++ b/templates/statsd/statsd-networkpolicy.yaml
@@ -1,7 +1,7 @@
 ################################
 ## Airflow StatsD NetworkPolicy
 #################################
-{{- if .Values.networkPolicies.enabled }}
+{{- if and .Values.networkPolicies.enabled .Values.statsd.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/templates/statsd/statsd-service.yaml
+++ b/templates/statsd/statsd-service.yaml
@@ -1,6 +1,7 @@
 ################################
 ## Airflow StatsD Service
 #################################
+{{- if .Values.statsd.enabled }}
 kind: Service
 apiVersion: v1
 metadata:
@@ -35,3 +36,4 @@ spec:
       protocol: TCP
       port: {{ .Values.ports.statsdScrape }}
       targetPort: {{ .Values.ports.statsdScrape }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -255,6 +255,7 @@ flower:
 
 # Statsd settings
 statsd:
+  enabled: true
   resources: {}
     # limits:
     #   cpu: 100m


### PR DESCRIPTION
- Allows user to enable/disable `statsd`
- `statsd` is not necessary when running this chart on its own
- I left the default `enabled` for now, but may be better to default to `disabled` and override this value with `houston`
- Related to astronomer/issues#822