### PR TITLE
Decrease PGbouncer logging verbosity

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v1 is Helm 2
 apiVersion: v1
 name: airflow
-version: 0.12.1
+version: 0.12.0-alpha.5
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://www.astronomer.io/static/airflowNewA.png
 keywords:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v1 is Helm 2
 apiVersion: v1
 name: airflow
-version: 0.12.0-alpha.2
+version: 0.12.1
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://www.astronomer.io/static/airflowNewA.png
 keywords:

--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -166,6 +166,9 @@ auth_file = /etc/pgbouncer/users.txt
 stats_users = {{ .Values.data.metadataConnection.user }}
 ignore_startup_parameters = extra_float_digits
 max_client_conn = {{ .Values.pgbouncer.maxClientConn }}
+verbose = {{ .Values.pgbouncer.verbose }}
+log_disconnections = {{ .Values.pgbouncer.logDisconnections }}
+log_connections = {{ .Values.pgbouncer.logConnections }}
 {{- end }}
 
 {{ define "pgbouncer_users" }}

--- a/values.yaml
+++ b/values.yaml
@@ -292,6 +292,11 @@ pgbouncer:
     #   cpu: 100m
     #   memory: 128Mi
 
+  # https://www.pgbouncer.org/config.html
+  verbose: 0
+  logDisconnections: 0
+  logConnections: 0
+
 redis:
   terminationGracePeriodSeconds: 600
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Airflow Helm chart!
-->

A customer reported using these configurations to avoid verbose logging from pgbouncer, which was causing issues for them. I think that connect / disconnect logging is not that helpful in this scenario where there are many components that are constantly connecting and disconnecting, by design. The 'verbose' configuration of 0 is the default for pgbouncer, and is the least verbose.

**Checklist**

- [x]  Chart.yaml version updated
