### PR TITLE
Fix toYaml indent

### DIFF
--- a/templates/workers/worker-horizontalpodautoscaler.yaml
+++ b/templates/workers/worker-horizontalpodautoscaler.yaml
@@ -13,7 +13,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
 {{- with .Values.labels }}
-{{ toYaml . | indent 8 }}
+{{ toYaml . | indent 4 }}
 {{- end }}
 spec:
   scaleTargetRef:


### PR DESCRIPTION
- Indentation is 8 spaces. Should be 4.
- Causes error when this resource is enabled `Error: YAML parse error on airflow/templates/workers/worker-horizontalpodautoscaler.yaml: error converting YAML to JSON: yaml: line 14`
- Related to astronomer/issues#889