### PR TITLE
Replace Kubernetes Secrets w/ correct value

### DIFF
--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -73,7 +73,7 @@
   {{- if eq .Values.executor "KubernetesExecutor" }}
     {{- range $i, $config := .Values.secret }}
   - name: AIRFLOW__KUBERNETES_SECRETS__{{ $config.envName }}
-    value: {{ printf "%s-env=%s" $.Release.Name $config.envName }}
+    value: {{ printf "%s=%s" $config.secretName $config.secretKey }}
     {{- end }}
   {{ end }}
 {{- end }}


### PR DESCRIPTION
Adds correct templated values from Kubernetes Secrets to AIRFLOW__KUBERNETES_SECRETS environment variables.  Previously was resulting in CreateContainerConfigError on the Task Pods, since the Secrets were not being referenced by the right name (secrets not found).