### PR TITLE
add proxy_pass if old airflow url has api rather than redirect

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -24,6 +24,9 @@ metadata:
     nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.ingress.baseDomain }}/login
     nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
     nginx.ingress.kubernetes.io/proxy-cookie-path: / /{{ .Release.Name }}/
+    # To support people who are using Airflow's experimental API on the old URL, but don't
+    # have their client set up to follow redirects correctly: We proxy it to the right location
+    # for them.
     nginx.ingress.kubernetes.io/server-snippet: |
       location ^~ /api/ {
         proxy_pass {{ printf "https://%s/%s/airflow/$request_uri" ( include "deployments_subdomain" .) .Release.Name }};

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -29,6 +29,9 @@ metadata:
     # for them.
     nginx.ingress.kubernetes.io/server-snippet: |
       location ^~ /api/ {
+        if ($host = '{{- include "deployments_subdomain" . }}' ) {
+          return 404;
+        }
         proxy_pass {{ printf "https://%s/%s/airflow/$request_uri" ( include "deployments_subdomain" .) .Release.Name }};
       }
     nginx.ingress.kubernetes.io/configuration-snippet: |

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -24,6 +24,10 @@ metadata:
     nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.ingress.baseDomain }}/login
     nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
     nginx.ingress.kubernetes.io/proxy-cookie-path: / /{{ .Release.Name }}/
+    nginx.ingress.kubernetes.io/server-snippet: |
+      location ^~ /api/ {
+        proxy_pass {{ printf "https://%s/%s/airflow/$request_uri" ( include "deployments_subdomain" .) .Release.Name }};
+      }
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($host = '{{- include "airflow_subdomain" . }}' ) {
         return 308 {{ printf "https://%s/%s/airflow/$request_uri" ( include "deployments_subdomain" .) .Release.Name }};


### PR DESCRIPTION
tl;dr Fix without adding flag

**it works without follow redirect for old links:**

```
 curl -X GET 'https://heliocentric-spectrum-1721-airflow.staging.astronomer.io/api/experimental/dags/example_dag/dag_runs' -H 'cookie: astronomer_staging_astronomer_io_auth=token'

   {
    "dag_id": "example_dag",
    "dag_run_url": "/heliocentric-spectrum-1721/airflow/graph?dag_id=example_dag&execution_date=2020-03-17+12%3A21%3A53%2B00%3A00",
    "execution_date": "2020-03-17T12:21:53+00:00",
    "id": 7,
    "run_id": "manual__2020-03-17T12:21:53+00:00",
    "start_date": "2020-03-17T12:21:53.828586+00:00",
    "state": "running"
  },
  {
    "dag_id": "example_dag",
    "dag_run_url": "/heliocentric-spectrum-1721/airflow/graph?dag_id=example_dag&execution_date=2020-03-17+12%3A25%3A01%2B00%3A00",
    "execution_date": "2020-03-17T12:25:01+00:00",
    "id": 8,
    "run_id": "manual__2020-03-17T12:25:01+00:00",
    "start_date": "2020-03-17T12:25:01.909693+00:00",
    "state": "running"
  }
]



 curl -X POST 'https://heliocentric-spectrum-1721-airflow.staging.astronomer.io/api/experimental/dags/example_dag/dag_runs' -d '{}' -H 'cookie: astronomer_staging_astronomer_io_auth=token' --compressed
{"execution_date":"2020-03-17T12:50:11+00:00","message":"Created <DagRun example_dag @ 2020-03-17 12:50:11+00:00: manual__2020-03-17T12:50:11+00:00, externally triggered: True>"}
```

**New style links:**

```
curl -X GET 'https://deployments.staging.astronomer.io/heliocentric-spectrum-1721/airflow/api/experimental/dags/example_dag/dag_runs' -d '{}' -H 'cookie: astronomer_staging_astronomer_io_auth=token' --compressed

  {
    "dag_id": "example_dag",
    "dag_run_url": "/heliocentric-spectrum-1721/airflow/graph?dag_id=example_dag&execution_date=2020-03-17+12%3A50%3A11%2B00%3A00",
    "execution_date": "2020-03-17T12:50:11+00:00",
    "id": 9,
    "run_id": "manual__2020-03-17T12:50:11+00:00",
    "start_date": "2020-03-17T12:50:11.908580+00:00",
    "state": "running"
  },
  {
    "dag_id": "example_dag",
    "dag_run_url": "/heliocentric-spectrum-1721/airflow/graph?dag_id=example_dag&execution_date=2020-03-17+12%3A51%3A06%2B00%3A00",
    "execution_date": "2020-03-17T12:51:06+00:00",
    "id": 10,
    "run_id": "manual__2020-03-17T12:51:06+00:00",
    "start_date": "2020-03-17T12:51:06.073597+00:00",
    "state": "running"
  }
]

curl -X POST 'https://heliocentric-spectrum-1721-airflow.staging.astronomer.io/api/experimental/dags/example_dag/dag_runs' -d '{}' -H 'cookie: astronomer_staging_astronomer_io_auth=token' --compressed
{"execution_date":"2020-03-17T12:50:11+00:00","message":"Created <DagRun example_dag @ 2020-03-17 12:50:11+00:00: manual__2020-03-17T12:50:11+00:00, externally triggered: True>"}
```