### PR TITLE
Use users image for migrations

### DIFF
--- a/templates/scheduler/scheduler-deployment.yaml
+++ b/templates/scheduler/scheduler-deployment.yaml
@@ -76,7 +76,7 @@ spec:
       {{- end }}
       initContainers:
         - name: run-airflow-migrations
-          image: {{ template "default_airflow_image" . }}
+          image: {{ template "airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           args: ["airflow", "upgradedb"]
           env:


### PR DESCRIPTION
Uses the user image to run the migrations, ensuring the correct versions migrations run.

Closes https://github.com/astronomer/issues/issues/1050