### PR TITLE
Add an initContainer to chown worker logs directory

### DIFF
--- a/bin/reset-local-dev
+++ b/bin/reset-local-dev
@@ -17,4 +17,5 @@ fi
 helm install \
   -n airflow \
   --set executor=$EXECUTOR \
+  --set workers.persistence.fixPermissions=true \
   $REPO_DIR

--- a/templates/workers/worker-deployment.yaml
+++ b/templates/workers/worker-deployment.yaml
@@ -64,6 +64,21 @@ spec:
         - name: {{ template "registry_secret" . }}
       {{- end }}
       initContainers:
+      {{- if and $persistence .Values.workers.persistence.fixPermissions }}
+        - name: volume-permissions
+          image: {{ template "airflow_image" . }}
+          imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
+          command:
+            - chown
+            - -R
+            - "{{ .Values.uid }}:{{ .Values.gid }}"
+            - {{ template "airflow_logs" . }}
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: logs
+              mountPath: {{ template "airflow_logs" . }}
+      {{- end }}
         - name: wait-for-airflow-migrations
           image: {{ template "default_airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}

--- a/values.yaml
+++ b/values.yaml
@@ -161,6 +161,10 @@ workers:
     size: 100Gi
     # If using a custom storageClass, pass name ref to all statefulSets here
     storageClassName:
+    # Execute init container to chown log directory
+    # This is currently only needed in KinD, due to usage
+    # of local-path provisioner.
+    fixPermissions: false
 
   resources: {}
   #  limits:

--- a/values.yaml
+++ b/values.yaml
@@ -161,7 +161,7 @@ workers:
     size: 100Gi
     # If using a custom storageClass, pass name ref to all statefulSets here
     storageClassName:
-    # Execute init container to chown log directory
+    # Execute init container to chown log directory.
     # This is currently only needed in KinD, due to usage
     # of local-path provisioner.
     fixPermissions: false


### PR DESCRIPTION
This PR adds an `initContainer` to the workers to prevent a `Permission Denied` issue on boot when running in KinD using the `local-path` provisioner.