### PR TITLE
user-provided image for DB migration wait

### DIFF
--- a/templates/workers/worker-deployment.yaml
+++ b/templates/workers/worker-deployment.yaml
@@ -80,7 +80,7 @@ spec:
               mountPath: {{ template "airflow_logs" . }}
       {{- end }}
         - name: wait-for-airflow-migrations
-          image: {{ template "default_airflow_image" . }}
+          image: {{ template "airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           args: ["airflow-migration-spinner", "--timeout=60"]
           env:


### PR DESCRIPTION
forgot this part in https://github.com/astronomer/airflow-chart/pull/68