### PR TITLE
Adds TargetQueryValue field to KEDA ScaledObject

### DIFF
--- a/templates/workers/worker-kedaautoscaler.yaml
+++ b/templates/workers/worker-kedaautoscaler.yaml
@@ -26,5 +26,6 @@ spec:
     - type: postgresql
       metadata:
         connection: AIRFLOW_CONN_AIRFLOW_DB
+        targetQueryValue: "1"
         query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
 {{- end }}


### PR DESCRIPTION
Newer versions of KEDA require the TargetQueryValue to be filled.
I've defaulted it to one so that autoscaling will always happen