### PR TITLE
Add networkPolicy for keda-apiserver

### DIFF
--- a/templates/pgbouncer/pgbouncer-networkpolicy.yaml
+++ b/templates/pgbouncer/pgbouncer-networkpolicy.yaml
@@ -40,6 +40,16 @@ spec:
 {{- end }}
         matchLabels:
           app: keda-operator
+{{- if .Values.workers.keda.namespaceLabels }}
+    - namespaceSelector:
+       matchLabels:
+{{ toYaml .Values.workers.keda.namespaceLabels | indent 10}}
+      podSelector:
+{{- else }}
+    - podSelector:
+{{- end }}
+        matchLabels:
+          app: keda-operator-metrics-apiserver
 {{- end}}
 {{- if .Values.pgbouncer.extraNetworkPolicies}}
 {{ toYaml .Values.pgbouncer.extraNetworkPolicies | indent 4}}


### PR DESCRIPTION
In new versions of KEDA, the apiserver is a seperate pod
with a different label. This PR adds a networkPolicy that
allows the KEDA apiserver to communicate with pgbouncer