### PR TITLE
KEDA maxReplicaCount matches celery worker replicas

### DIFF
--- a/templates/workers/worker-kedaautoscaler.yaml
+++ b/templates/workers/worker-kedaautoscaler.yaml
@@ -21,7 +21,7 @@ spec:
     deploymentName: {{ .Release.Name }}-worker
   pollingInterval:  {{  .Values.workers.keda.pollingInterval }}   # Optional. Default: 30 seconds
   cooldownPeriod: {{  .Values.workers.keda.cooldownPeriod }}    # Optional. Default: 300 seconds
-  maxReplicaCount: {{  .Values.workers.keda.maxReplicaCount }}   # Optional. Default: 100
+  maxReplicaCount: {{ .Values.workers.replicas }}   # Optional. Default: 100
   triggers:
     - type: postgresql
       metadata:

--- a/values.yaml
+++ b/values.yaml
@@ -151,9 +151,6 @@ workers:
     # Note that HPA has a seperate cooldwon period for scale-downs
     cooldownPeriod: 30
 
-    # Maximum number of workers created by keda
-    maxReplicaCount: 10
-
   persistence:
     # Enable persistent volumes
     enabled: true


### PR DESCRIPTION
We want to bill based on the maximum *POSSIBLE* workers, so if a user
turns on KEDA autoscaling, they should still be limited based on their
billing