### PR TITLE
Add extra labels and annotations to task pods

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -147,6 +147,8 @@ data:
             extra_labels["kubernetes-pod-operator"] = "True"
 
         pod.labels.update(extra_labels)
+        pod.labels.update({{ toJson .Values.podMutation.labels }})
+        pod.annotations.update({{ toJson .Values.podMutation.annotations }})
         pod.tolerations += {{ toJson .Values.podMutation.tolerations }}
         pod.affinity.update({{ toJson .Values.podMutation.affinity }})
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -404,6 +404,12 @@ podMutation:
 #                values:
 #                  - "true"
 
+  # Extra labels to apply to all pods spun up using KubernetesExecutor or KubernetesPodOperator
+  labels: {}
+
+  # Extra annotations to apply to all pods spun up using KubernetesExecutor or KubernetesPodOperator
+  annotations: {}
+
 # This runs as a CronJob to cleanup old pods.
 cleanup:
   enabled: false


### PR DESCRIPTION
It is common to the k8s ecosystem having add-ons that are configurable based on pod's annotations/labels (for example, [Istio sidecar injection](https://istio.io/docs/ops/configuration/mesh/injection-concepts/) and [Vault secrets injection](https://www.hashicorp.com/blog/injecting-vault-secrets-into-kubernetes-pods-via-a-sidecar/)).

This PR makes it possible for pods spun up using `KubernetesExecutor` or `KubernetesPodOperator` to better integrate with such add-ons.

