### PR TITLE
Fix imagePullSecrets for create-user-job

### DIFF
--- a/templates/create-user-job.yaml
+++ b/templates/create-user-job.yaml
@@ -33,6 +33,10 @@ spec:
 {{ toYaml .Values.affinity | indent 8 }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
+      {{- if or .Values.registry.secretName .Values.registry.connection }}
+      imagePullSecrets:
+        - name: {{ template "registry_secret" . }}
+      {{- end }}
       containers:
         - name: create-user
           image: {{ template "airflow_image" . }}


### PR DESCRIPTION
As my company has been deploying with an internal GCR registry we've found out this imagePullSecrets is missing (all other components, like webserver, scheduler and pods created with KubernetesExecutor can download private images easily)