### PR TITLE
Fix duplicate labels "kubernetes-executor" and "kubernetes-pod-operator"

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -136,15 +136,15 @@ data:
     def pod_mutation_hook(pod: Pod):
 
         extra_labels = {
-            "kubernetes-executor": "False",
-            "kubernetes-pod-operator": "False"
+            "kubernetes_executor": "False",
+            "kubernetes_pod_operator": "False"
         }
 
         if 'airflow-worker' in pod.labels.keys() or \
                 conf.get('core', 'EXECUTOR') == "KubernetesExecutor":
-            extra_labels["kubernetes-executor"] = "True"
+            extra_labels["kubernetes_executor"] = "True"
         else:
-            extra_labels["kubernetes-pod-operator"] = "True"
+            extra_labels["kubernetes_pod_operator"] = "True"
 
         pod.labels.update(extra_labels)
         pod.tolerations += {{ toJson .Values.podMutation.tolerations }}


### PR DESCRIPTION
After some testing on my minikube and my company infrastructure, we've
found out that the label "kubernetes-executor" (created by this code) usually appears also with
"kubernetes_executor" (created by airflow code). This produces a breakup on our label processing
in prometheus/metrics.

Also detected same anti-pattern on label "kubernetes-pod-operator" (and
"kubernetes_pod_operator"). 

I think it makes sense for this code to be changed to avoid this
duplication.