### PR TITLE
Local executor patch for Helm 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ workflows:
 jobs:
   lint:
     docker:
-      - image: alpine/helm:2.16.1
+      - image: alpine/helm:3.2.1
     steps:
       - checkout
       - run:
@@ -43,7 +43,7 @@ jobs:
 
   build-artifact:
     docker:
-      - image: alpine/helm:2.16.1
+      - image: alpine/helm:3.2.1
     steps:
       - checkout
       - run:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v1 is Helm 2
 apiVersion: v1
 name: airflow
-version: 0.13.0-alpha.3
+version: 0.15.2
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://www.astronomer.io/static/airflowNewA.png
 keywords:

--- a/bin/clean-slate
+++ b/bin/clean-slate
@@ -4,7 +4,6 @@ source $REPO_DIR/bin/install-ci-tools
 
 # Install the postgresql subchart
 echo "Installing Helm subchart(s)..."
-helm init --client-only > /dev/null 2>&1
 helm dep update > /dev/null 2>&1
 
 # Fail fast for helm syntax errors

--- a/bin/install-ci-tools
+++ b/bin/install-ci-tools
@@ -6,7 +6,7 @@ if [[ -z "${KIND_VERSION}" ]]; then
 fi
 
 if [[ -z "${HELM_VERSION}" ]]; then
-  export HELM_VERSION="2.16.1"
+  export HELM_VERSION="3.2.1"
 fi
 
 # Determine the platform we are running on
@@ -36,6 +36,9 @@ else
   tar -zxvf ./helm-v${HELM_VERSION}-${OS}-amd64.tar.gz
   mv ${OS}-amd64/helm /tmp/bin/
 fi
+
+# Add stable helm repo
+helm repo add stable https://kubernetes-charts.storage.googleapis.com
 
 echo "Installing the latest, stable kubectl..."
 if [[ -f /tmp/bin/kubectl ]]; then

--- a/bin/package
+++ b/bin/package
@@ -10,7 +10,6 @@ rm -rf /tmp/airflow-chart-package/ || true
 mkdir -p /tmp/airflow-chart-package
 cp -R . /tmp/airflow-chart-package/airflow
 cd /tmp/airflow-chart-package/airflow
-helm init --client-only
 helm dep update
 cd ..
 helm package /tmp/airflow-chart-package/airflow

--- a/bin/package
+++ b/bin/package
@@ -10,6 +10,7 @@ rm -rf /tmp/airflow-chart-package/ || true
 mkdir -p /tmp/airflow-chart-package
 cp -R . /tmp/airflow-chart-package/airflow
 cd /tmp/airflow-chart-package/airflow
+helm repo add stable https://kubernetes-charts.storage.googleapis.com
 helm dep update
 cd ..
 helm package /tmp/airflow-chart-package/airflow

--- a/bin/reset-local-dev
+++ b/bin/reset-local-dev
@@ -18,4 +18,5 @@ helm install \
   -n airflow \
   --set executor=$EXECUTOR \
   --set workers.persistence.fixPermissions=true \
+  airflow \
   $REPO_DIR

--- a/bin/run-ci
+++ b/bin/run-ci
@@ -45,6 +45,7 @@ helm install \
   -n airflow \
   --set executor=$EXECUTOR \
   --wait \
+  airflow \
   $HELM_CHART_PATH
 
 if [ ! $? -eq 0 ]; then

--- a/bin/start-kind-cluster
+++ b/bin/start-kind-cluster
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 if [[ -z "${KUBE_VERSION}" ]]; then
-  export KUBE_VERSION='1.15.6'
+  export KUBE_VERSION='1.18.2'
 fi
 
 # Create a kind cluster
@@ -17,11 +17,3 @@ if ! [[ $? -eq 0 ]]; then
   kind create cluster --image kindest/node:${KUBE_VERSION}
 fi
 set -e
-
-echo "Installing service account..."
-# Update the service account for tiller to work.
-kubectl create serviceaccount --namespace kube-system tiller
-kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
-echo "Installing Tiller in the cluster..."
-helm init --service-account tiller --upgrade --wait
-echo "Tiller installed."

--- a/bin/start-kind-cluster
+++ b/bin/start-kind-cluster
@@ -17,3 +17,5 @@ if ! [[ $? -eq 0 ]]; then
   kind create cluster --image kindest/node:${KUBE_VERSION}
 fi
 set -e
+
+kubectl create namespace airflow

--- a/templates/scheduler/scheduler-deployment.yaml
+++ b/templates/scheduler/scheduler-deployment.yaml
@@ -32,8 +32,10 @@ spec:
   serviceName: {{ .Release.Name }}-scheduler
 {{- end }}
   replicas: 1
+{{- if not $stateful }}
   strategy:
     type: Recreate
+{{- end }}
   selector:
     matchLabels:
       tier: airflow


### PR DESCRIPTION
In helm 2, extra values in kube YAML are ignored, but in helm 3, it throws an error. 'strategy' is not a valid key for StatefulSetSpec https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#statefulsetspec-v1-apps

this bug was discovered when I was writing the 0.15 regression testing for the pgbouncer issue on commander