### PR TITLE
Don't use platform.workspace in Reids/Flower resources

### DIFF
--- a/templates/flower/flower-service.yaml
+++ b/templates/flower/flower-service.yaml
@@ -21,7 +21,6 @@ spec:
     tier: airflow
     component: flower
     release: {{ .Release.Name }}
-    workspace: {{ .Values.platform.workspace | quote }}
   ports:
     - name: flower-ui
       protocol: TCP

--- a/templates/secrets/redis-secrets.yaml
+++ b/templates/secrets/redis-secrets.yaml
@@ -32,7 +32,6 @@ metadata:
   name: {{ .Release.Name }}-broker-url
   labels:
     release: {{ .Release.Name }}
-    workspace: {{ .Values.platform.workspace | quote }}
     chart: {{ .Chart.Name }}
     heritage: {{ .Release.Service }}
   annotations:


### PR DESCRIPTION
In using this chart outside of the Astronomer platform we noticed that
two places were using the `platform.workspace` that didn't need it.

The broker-url secret is just using it as a label, and that doesn't make
any sense (but also doesn't break anything).

The flower service has it specified in the label selector, so this
service wasn't working if the workspace wasn't provided. For
comparison, the webserver service just has component, release and tier
as its selector.