### PR TITLE
Remove helm logic for executor specific configurations

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -33,10 +33,8 @@ data:
     expose_config = True
     rbac = True
 
-{{- if eq .Values.executor "CeleryExecutor" }}
     [celery]
     default_queue = celery
-{{- end }}
 
     [scheduler]
     scheduler_heartbeat_sec = 5
@@ -68,7 +66,6 @@ data:
     retry_timeout = True
 {{- end }}
 
-{{- if eq .Values.executor "KubernetesExecutor" }}
     [kubernetes]
     namespace = {{ .Release.Namespace }}
     airflow_configmap = {{ include "airflow_config" . }}
@@ -94,7 +91,6 @@ data:
     release = {{ .Release.Name }}
     platform = {{ .Values.platform.release }}
     workspace = {{ .Values.platform.workspace }}
-{{- end }}
 
     [astronomer]
 {{- if .Values.webserver.jwtSigningCertificateSecretName }}


### PR DESCRIPTION
Resolves https://github.com/astronomer/issues/issues/1087

This removes any executor choice logic from the `airflow.cfg` `ConfigMap`. This was causing an issue where the kubernetes namespace was blank when using the KPO. Using the executor for this logic was not enough.

These configs are simply not used if the executor isn't loaded so there should be no harm in having "extra" config loaded.

The only user-facing difference that I can think of will be what users see when they load the "Admin" > "Configuration" menu in Airflow. Users will see that there are configurations set for an executor they are not actually using. Minor thing, but just wanted to call that out.