### PR TITLE
Allow for configurable scheduler livenessProbe values

### DIFF
--- a/templates/scheduler/scheduler-deployment.yaml
+++ b/templates/scheduler/scheduler-deployment.yaml
@@ -98,10 +98,10 @@ spec:
           # If the scheduler stops heartbeating for 5 minutes (10*30s) kill the
           # scheduler and let Kubernetes restart it
           livenessProbe:
-            failureThreshold: 10
-            periodSeconds: 30
-            exec:
-              command:
+            initialDelaySeconds: {{ .Values.scheduler.livenessProbe.initialDelaySeconds | default 0 }}
+            timeoutSeconds: {{ .Values.scheduler.livenessProbe.timeoutSeconds | default 5 }}
+            failureThreshold: {{ .Values.scheduler.livenessProbe.failureThreshold | default 10 }}
+            periodSeconds: {{ .Values.scheduler.livenessProbe.periodSeconds | default 30 }}
               - /usr/bin/env
               - AIRFLOW__CORE__LOGGING_LEVEL=ERROR
               - python3

--- a/templates/scheduler/scheduler-deployment.yaml
+++ b/templates/scheduler/scheduler-deployment.yaml
@@ -102,6 +102,8 @@ spec:
             timeoutSeconds: {{ .Values.scheduler.livenessProbe.timeoutSeconds | default 5 }}
             failureThreshold: {{ .Values.scheduler.livenessProbe.failureThreshold | default 10 }}
             periodSeconds: {{ .Values.scheduler.livenessProbe.periodSeconds | default 30 }}
+            exec:
+              command:
               - /usr/bin/env
               - AIRFLOW__CORE__LOGGING_LEVEL=ERROR
               - python3

--- a/values.yaml
+++ b/values.yaml
@@ -191,7 +191,12 @@ workers:
 
 # Airflow scheduler settings
 scheduler:
-
+  livenessProbe:
+    initialDelaySeconds: 0
+    timeoutSeconds: 5
+    failureThreshold: 10
+    periodSeconds: 30
+    
   resources: {}
   #  limits:
   #   cpu: 100m


### PR DESCRIPTION
- Allows for users to configure scheduler livenessProbe values from the top level `values.yaml`
- Increased timeoutSeconds from `1` to `5`
- Related to https://github.com/astronomer/issues/issues/1496