### PR TITLE
Add code to be able to add annotations to create-user-job

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 6.3.12
-digest: sha256:1750ddcc948f15716d157d6a854b59e37571473b2a3390a3673b224b71a56308
-generated: "2019-10-24T16:03:26.569269284-04:00"
+digest: sha256:58d88cf56e78b2380091e9e16cc6ccf58b88b3abe4a1886dd47cd9faef5309af
+generated: "2020-07-15T09:39:30.837647681-03:00"

--- a/templates/create-user-job.yaml
+++ b/templates/create-user-job.yaml
@@ -1,6 +1,7 @@
 ################################
 ## Airflow Create User Job
 #################################
+{{ $ctx := . }}
 {{- if .Values.webserver.defaultUser.enabled }}
 apiVersion: batch/v1
 kind: Job
@@ -25,6 +26,10 @@ spec:
         tier: airflow
         component: create-user-job
         release: {{ .Release.Name }}
+      annotations:
+      {{- range $k, $v := .Values.createUserJobAnnotations }}
+        {{ $k | quote }}: {{ tpl $v $ctx | toYaml }}
+      {{- end }}
     spec:
       restartPolicy: OnFailure
       nodeSelector:

--- a/values.yaml
+++ b/values.yaml
@@ -51,6 +51,9 @@ airflowHome: "/usr/local/airflow"
 # Airflow pods
 airflowPodAnnotations: {}
 
+# Extra annotations to apply to Create user job
+createUserJobAnnotations: {}
+
 # Extra annotations to apply to service accounts
 serviceAccountAnnotations: {}
 


### PR DESCRIPTION
Our company is using Istio, this is making the _create-user-job_ not being able to end, and also crashing our CD. In order to fix this we are adding a parameter to be able to add an annotation to that job so we can disable the istio sidecar injection.

Issue reported:

- Istio: https://github.com/istio/istio/issues/11045 and https://github.com/istio/istio/issues/6324
- Kubernetes: https://github.com/kubernetes/kubernetes/issues/65502

More details on the issue:

- https://medium.com/redbox-techblog/handling-istio-sidecars-in-kubernetes-jobs-c392661c4af7


### How to lint the change:

Add "sidecar.istio.io/inject": "False" to createUserJobAnnotations

Execute `helm template .`  and search for ## Airflow Create User Job the new annotation added.