### PR TITLE
Make Scheduler livenessProbe HA ready.

### DIFF
--- a/templates/scheduler/scheduler-deployment.yaml
+++ b/templates/scheduler/scheduler-deployment.yaml
@@ -109,11 +109,13 @@ spec:
               - -c
               - |
                 from airflow.jobs.scheduler_job import SchedulerJob
+                from airflow.db import create_session
                 from airflow.utils.net import get_hostname
                 import sys
 
-                job = SchedulerJob.most_recent_job()
-                sys.exit(0 if job.is_alive() and job.hostname == get_hostname() else 1)
+                with create_session() as session:
+                  job = session.query(SchedulerJob).filter_by(hostname=get_hostname()).order_by(SchedulerJob.latest_heartbeat.desc()).limit(1).first()
+                sys.exit(0 if job.is_alive() else 1)
           resources:
 {{ toYaml .Values.scheduler.resources | indent 12 }}
           volumeMounts:


### PR DESCRIPTION
To support running with more than a single scheduler pod we can no
longer rely on `most_recent_job` -- as that would simply select the most
recent row to have updated its heart beat, which could be from a different pod.