### PR TITLE
Reduce cardinality of Airflow metrics

### DIFF
--- a/templates/statsd/statsd-deployment.yaml
+++ b/templates/statsd/statsd-deployment.yaml
@@ -44,7 +44,7 @@ spec:
           image: {{- include "statsd_image" . | indent 1 }}
           imagePullPolicy: {{ .Values.images.statsd.pullPolicy }}
           args:
-            - "-statsd.mapping-config=/etc/statsd-exporter/mappings.yml"
+            - "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"
           resources:
 {{ toYaml .Values.statsd.resources | indent 12 }}
           ports:

--- a/values.yaml
+++ b/values.yaml
@@ -84,7 +84,7 @@ images:
     pullPolicy: IfNotPresent
   statsd:
     repository: astronomerinc/ap-statsd-exporter
-    tag: 0.11.0
+    tag: 0.17.0
     pullPolicy: IfNotPresent
   redis:
     repository: astronomerinc/ap-redis


### PR DESCRIPTION
I have this running on staging.

grafana: https://grafana.staging.astronomer.io/d/E5LsXoamz/airflow-deployment-overview?orgId=1&refresh=10s&var-deployment=devoid-solar-9786
deployment metrics view: https://app.staging.astronomer.io/w/ck7byis5o07li0915r814ir4c/d/devoid-solar-9786/metrics