### PR TITLE
Flower deployment should use Flower image

### DIFF
--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -101,7 +101,7 @@
 {{- end }}
 
 {{ define "flower_image" -}}
-{{ printf "%s:%s" .Values.images.airflow.repository (default .Values.defaultAirflowTag .Values.images.airflow.tag) }}
+{{ printf "%s:%s" .Values.images.flower.repository (default .Values.defaultAirflowTag .Values.images.flower.tag) }}
 {{- end }}
 
 {{ define "statsd_image" -}}


### PR DESCRIPTION
This is follow up from a customer upgrade where we found a custom setting in their user-provided image was causing flower to crashloop. The expected behavior is for flower to use the flower image configured rather than the user-provided airflow image.