### PR TITLE
Don't use custom environment variables in init containers

### DIFF
--- a/templates/scheduler/scheduler-deployment.yaml
+++ b/templates/scheduler/scheduler-deployment.yaml
@@ -84,7 +84,6 @@ spec:
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           args: ["airflow", "upgradedb"]
           env:
-          {{- include "custom_airflow_environment" . | indent 10 }}
           {{- include "standard_airflow_environment" . | indent 10 }}
       containers:
         # Always run the main scheduler container.

--- a/templates/webserver/webserver-deployment.yaml
+++ b/templates/webserver/webserver-deployment.yaml
@@ -62,7 +62,6 @@ spec:
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           args: ["airflow-migration-spinner", "--timeout=60"]
           env:
-          {{- include "custom_airflow_environment" . | indent 10 }}
           {{- include "standard_airflow_environment" . | indent 10 }}
       containers:
         - name: webserver

--- a/templates/workers/worker-deployment.yaml
+++ b/templates/workers/worker-deployment.yaml
@@ -84,7 +84,6 @@ spec:
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           args: ["airflow-migration-spinner", "--timeout=60"]
           env:
-          {{- include "custom_airflow_environment" . | indent 10 }}
           {{- include "standard_airflow_environment" . | indent 10 }}
       containers:
         - name: worker

--- a/values.yaml
+++ b/values.yaml
@@ -103,11 +103,13 @@ images:
     pullPolicy: IfNotPresent
 
 # Environment variables for all airflow containers
+# other than init containers.
 env: []
 # - name: ""
 #   value: ""
 
 # Secrets for all airflow containers
+# other than init containers.
 secret: []
 # - envName: ""
 #   secretName: ""


### PR DESCRIPTION
This is follow up from a customer upgrade where custom environmet variables in the Dockerfile of the user-provided container (custom airflow config for airflow secrets backend) caused issues in the database migration (or wait for migration) steps.