### PR TITLE
Fix init containers to use default airflow version

### DIFF
--- a/templates/scheduler/scheduler-deployment.yaml
+++ b/templates/scheduler/scheduler-deployment.yaml
@@ -80,7 +80,7 @@ spec:
       {{- end }}
       initContainers:
         - name: run-airflow-migrations
-          image: {{ template "airflow_image" . }}
+          image: {{ template "default_airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           args: ["airflow", "upgradedb"]
           env:

--- a/templates/webserver/webserver-deployment.yaml
+++ b/templates/webserver/webserver-deployment.yaml
@@ -58,7 +58,7 @@ spec:
       {{- end }}
       initContainers:
         - name: wait-for-airflow-migrations
-          image: {{ template "airflow_image" . }}
+          image: {{ template "default_airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           args: ["airflow-migration-spinner", "--timeout=60"]
           env:

--- a/templates/workers/worker-deployment.yaml
+++ b/templates/workers/worker-deployment.yaml
@@ -66,7 +66,7 @@ spec:
       initContainers:
       {{- if and $persistence .Values.workers.persistence.fixPermissions }}
         - name: volume-permissions
-          image: {{ template "airflow_image" . }}
+          image: {{ template "default_airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           command:
             - chown
@@ -80,7 +80,7 @@ spec:
               mountPath: {{ template "airflow_logs" . }}
       {{- end }}
         - name: wait-for-airflow-migrations
-          image: {{ template "airflow_image" . }}
+          image: {{ template "default_airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           args: ["airflow-migration-spinner", "--timeout=60"]
           env:


### PR DESCRIPTION
Backporting https://github.com/astronomer/airflow-chart/commit/30070967e698c7c6a29c20f846f03aeb7f4b1413 to `main`.

This is an important commit that was made directly on both `release-0.15` and `release-0.16` but was never cherry-picked to main, so we keep loosing it. This PR ensures that this change persists into future releases. 