### PR TITLE
Fix Elasticsearch secret test

### DIFF
--- a/tests/secrets_elasticsearch-secret_test.yaml
+++ b/tests/secrets_elasticsearch-secret_test.yaml
@@ -5,8 +5,12 @@ templates:
 tests:
   - it: should work
     set:
-      elasticsearch.connection: true
-      elasticsearch.connection.user: dade.murphy
+      elasticsearch:
+        connection:
+          user: date.murphy
+          pass: secretpassword
+          host: localhost
+          port: 9200
     asserts:
       - isKind:
           of: Secret


### PR DESCRIPTION
I was getting both successful and failed runs using the same test. This PR sets the `elasticsearch.connection` value to an object, rather than setting individual fields via dot separations.

This more closely mirrors what we'd pass in via production. I feel like the previous version should have evaluated fine, but it seems like setting the `elasticsearch.connection` to `true`, instead of an object was causing it to flake out occasionally.