### PR TITLE
Add functional testing and PR template

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,7 @@ jobs:
       - run:
           name: Install Airflow chart
           command: |
+            pyenv global 3.7.0
             export KUBE_VERSION=<< parameters.kube_version >>
             export EXECUTOR=<< parameters.executor >>
             HELM_CHART_PATH='/tmp/workspace/airflow-*.tgz' bin/run-ci

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+
+## Description
+
+> Describe the purpose of this pull request.
+
+## PR Title
+
+> Please make the PR title informative to the user experience. For example when adding a feature, say "Add metrics tab for Deployments" instead of "Bump Astro-UI to version X.Y.Z". Bugs are sometimes harder to make customer-facing because they are very detailed, but do what you can. Instead of "Fix metrics cardinality bug" (user does not know what 'cardinality' means and does not matter to them), say "Fix bug slowing down the metrics tab". The PR title will be used for the commit message when it's merged, and these commit messages are used to generate customer-facing release notes.
+
+## 🎟 Issue(s)
+
+Resolves astronomer/issues#XXXX
+
+## 🧪  Testing
+
+> What are the main risks associated with this change, and how are they addressed by tests added in this PR?
+
+> Please add helm unit testing, if applicable. The docs are regretfully sparse for helm unit testing, [here](https://github.com/astronomer/helm-unittest/blob/main/DOCUMENT.md) is what we have to work with. In general, these kind of tests can be used for specific assertions like 'when these values are set, the resource ends up looking like XYZ' but not for generalized assertions like 'for all resources, make sure the namespace is not set to the release name'.
+
+> Please also add to the system testing [here](../tests/functional-tests). This kind of testing allows you to connect into any live, running pod to make assertions about how they are operating.
+
+## 📸 Screenshots
+
+> Add screenshots to illustrate the changes, if applicable.
+
+## 📋 Checklist
+
+- [ ] The PR title is informative to the user experience
+- [ ] Functional test(s) added
+- [ ] Helm chart unit test(s)

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ dev-account.json
 *.swp
 # Chart dependencies
 **/charts/*.tgz
+**pycache**
+kubeconfig
+**kubeconfig**

--- a/bin/run-ci
+++ b/bin/run-ci
@@ -91,3 +91,12 @@ else
   get_debugging_info
   exit 1
 fi
+
+pip3 install virtualenv
+virtualenv --python=python3 /tmp/venv
+source /tmp/venv/bin/activate
+pip install -r $REPO_DIR/tests/functional-tests/requirements.txt
+export NAMESPACE=airflow
+export RELEASE_NAME=airflow
+pytest $REPO_DIR/tests/functional-tests/
+deactivate

--- a/tests/functional-tests/requirements.txt
+++ b/tests/functional-tests/requirements.txt
@@ -1,0 +1,5 @@
+pre-commit==2.4.0
+pytest==6.0.1
+kubernetes==11.0.0
+testinfra==3.2.1
+docker==4.1.0

--- a/tests/functional-tests/test_chart.py
+++ b/tests/functional-tests/test_chart.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""
+This file is for configuration testing Airflow images.
+The Airflow image is started in Docker, configured to access an
+instance of postgres, which is also running in Docker.
+
+Testinfra is used to configuration test the image. In effect,
+testinfra simplifies and provides syntactic sugar for doing
+execs into a running container.
+"""
+
+import json
+import os
+import pytest
+import subprocess
+import testinfra
+import docker
+from time import sleep
+
+from kubernetes import client, config
+from packaging.version import parse as semantic_version
+
+
+def create_kube_client(in_cluster=False):
+    """
+    Load and store authentication and cluster information from kube-config
+    file; if running inside a pod, use Kubernetes service account. Use that to
+    instantiate Kubernetes client.
+    """
+    if in_cluster:
+        print("Using in cluster kubernetes configuration")
+        config.load_incluster_config()
+    else:
+        print("Using kubectl kubernetes configuration")
+        config.load_kube_config()
+    return client.CoreV1Api()
+
+
+def test_airflow_in_path(webserver):
+    """ Ensure Airflow is in PATH
+    """
+    assert webserver.exists('airflow'), \
+        "Expected 'airflow' to be in PATH"
+
+
+def test_tini_in_path(webserver):
+    """ Ensure 'tini' is in PATH
+    """
+    assert webserver.exists('tini'), \
+        "Expected 'tini' to be in PATH"
+
+
+def test_entrypoint(webserver):
+    """ There should be a file '/entrypoint'
+    """
+    assert webserver.file("/entrypoint").exists, \
+        "Expected to find /entrypoint"
+
+
+def test_elasticsearch_version(webserver):
+    """ Astronomer runs a version of ElasticSearch that requires
+    our users to run the client code of version 5.5.3 or greater
+    """
+    try:
+        elasticsearch_module = webserver.pip_package.get_packages()['elasticsearch']
+    except KeyError:
+        raise Exception("elasticsearch pip module is not installed")
+    version = elasticsearch_module['version']
+    assert semantic_version(version) >= semantic_version('5.5.3'), \
+        "elasticsearch module must be version 5.5.3 or greater"
+
+
+def test_werkzeug_version(webserver):
+    """ Werkzeug pip module version >= 1.0.0 has an issue
+    """
+    try:
+        werkzeug_module = webserver.pip_package.get_packages()['Werkzeug']
+    except KeyError:
+        raise Exception("Werkzeug pip module is not installed")
+    version = werkzeug_module['version']
+    assert semantic_version(version) < semantic_version('1.0.0'), \
+        "Werkzeug pip module version must be less than 1.0.0"
+
+
+def test_redis_version(webserver):
+    """ Redis pip module version 3.4.0 has an issue in the Astronomer platform
+    """
+    try:
+        redis_module = webserver.pip_package.get_packages()['redis']
+    except KeyError:
+        raise Exception("redis pip module is not installed")
+    version = redis_module['version']
+    assert semantic_version(version) != semantic_version('3.4.0'), \
+        "redis module must not be 3.4.0"
+
+
+def test_astronomer_airflow_check_version(webserver):
+    """ astronomer-airflow-version-check 1.0.0 has an issue in the Astronomer platform
+    """
+    try:
+        version_check_module = webserver.pip_package.get_packages()['astronomer-airflow-version-check']
+    except KeyError:
+        print("astronomer-airflow-version-check pip module is not installed")
+        return
+    version = version_check_module['version']
+    assert semantic_version(version) >= semantic_version('1.0.1'), \
+        "astronomer-airflow-version-check module must be greater than 1.0.0"
+
+
+def test_airflow_connections(scheduler):
+    """Test Connections can be added and deleted"""
+    test_conn_uri = "postgresql://postgres_user:postgres_test@1.1.1.1:5432"
+    test_conn_id = "test"
+
+    # Assert Connection can be added
+    assert f"Successfully added `conn_id`={test_conn_id} : {test_conn_uri}" in scheduler.check_output(
+        'airflow connections -a --conn_uri %s --conn_id %s', test_conn_uri, test_conn_id)
+
+    # Assert Connection can be removed
+    assert f"Successfully deleted `conn_id`={test_conn_id}" in scheduler.check_output(
+        'airflow connections -d --conn_id %s', test_conn_id)
+
+
+def test_airflow_variables(scheduler):
+    """Test Variables can be added, retrieved and deleted"""
+    # Assert Variables can be added
+    assert "" in scheduler.check_output("airflow variables --set test_key test_value")
+
+    # Assert Variables can be retrieved
+    assert "test_value" in scheduler.check_output("airflow variables --get test_key")
+
+    # Assert Variables can be deleted
+    assert "" in scheduler.check_output("airflow variables --delete test_key")
+
+
+@pytest.fixture(scope='session')
+def webserver(request):
+    """ This is the host fixture for testinfra. To read more, please see
+    the testinfra documentation:
+    https://testinfra.readthedocs.io/en/latest/examples.html#test-docker-images
+    """
+    namespace = os.environ.get('NAMESPACE')
+    if not namespace:
+        print("NAMESPACE env var is not present, using 'airflow' namespace")
+        namespace = 'airflow'
+    kube = create_kube_client()
+    pods = kube.list_namespaced_pod(namespace, label_selector=f"component=webserver")
+    pods = pods.items
+    assert len(pods) > 0, "Expected to find at least one pod with label 'component: webserver'"
+    pod = pods[0]
+    yield testinfra.get_host(f'kubectl://{pod.metadata.name}?container=webserver&namespace={namespace}')
+
+
+@pytest.fixture(scope='session')
+def scheduler(request):
+    """ This is the host fixture for testinfra. To read more, please see
+    the testinfra documentation:
+    https://testinfra.readthedocs.io/en/latest/examples.html#test-docker-images
+    """
+    namespace = os.environ.get('NAMESPACE')
+    if not namespace:
+        print("NAMESPACE env var is not present, using 'airflow' namespace")
+        namespace = 'airflow'
+    kube = create_kube_client()
+    pods = kube.list_namespaced_pod(namespace, label_selector=f"component=scheduler")
+    pods = pods.items
+    assert len(pods) > 0, "Expected to find at least one pod with label 'component: scheduler'"
+    pod = pods[0]
+    yield testinfra.get_host(f'kubectl://{pod.metadata.name}?container=scheduler&namespace={namespace}')
+
+
+@pytest.fixture(scope='session')
+def docker_client(request):
+    """ This is a text fixture for the docker client,
+    should it be needed in a test
+    """
+    client = docker.from_env()
+    yield client
+    client.close()

--- a/values.yaml
+++ b/values.yaml
@@ -73,7 +73,7 @@ allowPodLaunching: true
 defaultAirflowRepository: astronomerinc/ap-airflow
 
 # Default airflow tag to deploy
-defaultAirflowTag: 1.10.7-alpine3.10
+defaultAirflowTag: 1.10.10-alpine3.10
 
 # Astronomer Airflow images
 images:


### PR DESCRIPTION
- Adding a PR template to make sure we are adding tests when we are merging PRs.
- Adding a place for developers to add more functional testing, started from what we have in ap-airflow

After this, astronomer/astronomer, astronomer/airflow-chart, and astronomer/ap-airflow all will use the same testinfra-based pytest approach for functional testing.
