### PR TITLE
Support for modifying celery worker deployment strategy

### DIFF
--- a/templates/workers/worker-deployment.yaml
+++ b/templates/workers/worker-deployment.yaml
@@ -26,6 +26,9 @@ spec:
       tier: airflow
       component: worker
       release: {{ .Release.Name }}
+  {{ if .Values.workers.updateStrategy }}
+{{ toYaml .Values.workers.updateStrategy | indent 2 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/tests/workers_worker-deployment_test.yaml
+++ b/tests/workers_worker-deployment_test.yaml
@@ -8,4 +8,21 @@ tests:
       executor: CeleryExecutor
     asserts:
       - isKind:
-          of: StatefulSet
+          of: Deployment
+
+  - it: should work
+    set:
+      workers.updateStrategy:
+        strategy:
+          rollingUpdate:
+            maxSurge: "100%"
+            maxUnavailable: "50%"
+      asserts:
+        - isKind:
+            of: Deployment
+        - equal:
+            path: deployment.spec.strategy.rollingUpdate.maxSurge
+            value: "100%"
+        - equal:
+            path: deployment.spec.strategy.rollingUpdate.maxUnavailable
+            value: "50%"

--- a/values.yaml
+++ b/values.yaml
@@ -147,6 +147,11 @@ fernetKeySecretName: ~
 workers:
   # Number of airflow celery workers in StatefulSet
   replicas: 1
+  updateStrategy:
+  strategy:
+    rollingUpdate:
+      maxSurge: "100%"
+      maxUnavailable: "50%"
 
   # Allow KEDA autoscaling.
   # Persistence.enabled must be set to false to use KEDA.

--- a/values.yaml
+++ b/values.yaml
@@ -168,7 +168,7 @@ workers:
 
   persistence:
     # Enable persistent volumes
-    enabled: true
+    enabled: false
     # Volume size for worker StatefulSet
     size: 100Gi
     # If using a custom storageClass, pass name ref to all statefulSets here


### PR DESCRIPTION
## Description

This PR modifies the worker template to allow passing a non-default deployment update strategy to worker deployments, in particular celery workers. The values have been set to allow 100% maxSurge and 50% maxUnavailable allowing new deployments of celery workers to launch a full set of replicas before the old set goes away. Allowing the new workers to pick up work as quickly as possible, rather than the current default which is 1 at a time.

## 🎟 Issue(s)

Resolves https://github.com/astronomer/issues/issues/1410

## 🧪  Testing

helm chart unit test added. 

## 📋 Checklist

- [x] The PR title is informative to the user experience
- [ ] Functional test(s) added
- [x] Helm chart unit test(s)
