### PR TITLE
Update ci machine image to ubuntu-2004:202008-01

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
 
   airflow-test:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202008-01
       resource_class: large
     parameters:
       executor:
@@ -97,7 +97,7 @@ jobs:
 
   release:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202008-01
     steps:
       - attach_workspace:
           at: /tmp/workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
       - run:
           name: Install Airflow chart
           command: |
-            pyenv global 3.7.0
+            pyenv global 3.8.5
             export KUBE_VERSION=<< parameters.kube_version >>
             export EXECUTOR=<< parameters.executor >>
             HELM_CHART_PATH='/tmp/workspace/airflow-*.tgz' bin/run-ci
@@ -123,7 +123,7 @@ commands:
           name: Create a release on GitHub
           command: |
             set -xe
-            pyenv global 3.7.0
+            pyenv global 3.8.5
             pip install astronomer_e2e_test
             # We can remove --debug after we are happy with it
             astronomer-ci --debug publish-github-release --github-repository $CIRCLE_PROJECT_REPONAME --github-organization $CIRCLE_PROJECT_USERNAME --commitish $CIRCLE_SHA1


### PR DESCRIPTION
## Description

Bump CircleCI machine image to ubuntu-2004:202008-01 and CI python to 3.8.5. Changes only affect CI runs.

## PR Title

The machine image we have been using is being deprecated, and is 4.5 years old. This change modernizes the software running our CI pipelines.