### PR TITLE
Upgrade Statsd Version and Add Additional Statsd Metrics

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -87,7 +87,7 @@ images:
     pullPolicy: IfNotPresent
   statsd:
     repository: astronomerinc/ap-statsd-exporter
-    tag: 0.17.0
+    tag: 0.18.0
     pullPolicy: IfNotPresent
   redis:
     repository: astronomerinc/ap-redis


### PR DESCRIPTION
## Description
Upgraded image to 0.18.0 with the following changes

[ENHANCEMENT] Allow turning off tagging extensions (#325)
[ENHANCEMENT] Add a lifecycle API for configuration reloads and restarts (#329)
In the previous work to improve how/what statsd metrics are collected a handful of them were unintentionally dropped. This PR puts the specific metrics back that Houston UI and our airflow Grafana dashboard are looking for back.


## 🎟 Issue(s)

Resolves https://github.com/astronomer/issues/issues/1780

## 🧪  Testing

I tested this by deploying an AWS test cluster and running airflow deployments and querying for those metrics and I was getting results.

## 📸 Screenshots
![94192890-9016c580-fe7d-11ea-91ff-b76daf43b96e](https://user-images.githubusercontent.com/942071/94850933-aa105500-03f5-11eb-9c66-b1ba8f943d1e.png)


## 📋 Checklist

- [ ] The PR title is informative to the user experience
- [ ] Functional test(s) added
- [ ] Helm chart unit test(s)
