### PR TITLE
Add pod_template_file as that is the only way to use K8sExecutor in 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,7 @@ jobs:
             helm repo add stable https://kubernetes-charts.storage.googleapis.com
             helm dep update
             helm plugin install https://github.com/astronomer/helm-unittest/
+            cp files/pod-template-file.yaml templates
             helm unittest .
 
   build-artifact:

--- a/files/pod-template-file.yaml
+++ b/files/pod-template-file.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dummy-name
+  labels:
+    tier: airflow
+    component: worker
+    release: '{{ .Release.Name }}'
+    platform: "{{ .Values.platform.release }}"
+    workspace: "{{ .Values.platform.workspace }}"
+spec:
+  containers:
+    - args: []
+      name: "base"
+      command: []
+      env:
+      - name: AIRFLOW__CORE__EXECUTOR
+        value: LocalExecutor
+{{- include "standard_airflow_environment" . | indent 4 }}
+      envFrom: []
+      image: dummy_image
+      imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
+      name: base
+      ports: []
+      volumeMounts:
+        - mountPath: {{ template "airflow_logs" . }}
+          name: airflow-logs
+  hostNetwork: false
+  {{- if or .Values.registry.secretName .Values.registry.connection }}
+  imagePullSecrets:
+    - name: {{ template "registry_secret" . }}
+  {{- end }}
+  restartPolicy: Never
+  securityContext:
+    runAsUser: {{ .Values.uid }}
+  nodeSelector:
+    {{ toYaml .Values.nodeSelector | indent 8 }}
+  affinity:
+    {{ toYaml .Values.affinity | indent 8 }}
+  tolerations:
+    {{ toYaml .Values.tolerations | indent 8 }}
+  serviceAccountName: '{{ .Release.Name }}-worker-serviceaccount'
+  volumes:
+  - configMap:
+      name: {{ include "airflow_config" . }}
+    name: airflow-config
+  - configMap:
+      name: {{ include "airflow_config" . }}
+    name: airflow-local-settings

--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -135,6 +135,10 @@ env:
 {{ printf "%s:%s" .Values.images.pgbouncer.repository .Values.images.pgbouncer.tag }}
 {{- end }}
 
+{{ define "airflow_pod_template_file" -}}
+{{ (printf "%s/pod_templates" .Values.airflowHome) }}
+{{- end }}
+
 {{ define "pgbouncer_exporter_image" -}}
 {{ printf "%s:%s" .Values.images.pgbouncerExporter.repository .Values.images.pgbouncerExporter.tag }}
 {{- end }}

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -73,24 +73,27 @@ data:
     worker_container_repository = {{ .Values.images.airflow.repository }}
     worker_container_tag = {{ .Values.images.airflow.tag }}
     worker_container_image_pull_policy = {{ .Values.images.airflow.pullPolicy }}
-    worker_service_account_name = {{ .Release.Name }}-worker-serviceaccount
-    image_pull_secrets = {{ template "registry_secret" . }}
     dags_in_image = True
     delete_worker_pods = True
-
-    [kubernetes_secrets]
-    AIRFLOW__CORE__SQL_ALCHEMY_CONN = {{ printf "%s=connection" (include "airflow_metadata_secret" .) }}
-    AIRFLOW__CORE__FERNET_KEY = {{ printf "%s=fernet-key" (include "fernet_key_secret" .) }}
-{{- if .Values.elasticsearch.enabled }}
-    AIRFLOW__ELASTICSEARCH__ELASTICSEARCH_HOST = {{ printf "%s=connection" (include "elasticsearch_secret" .) }}
-{{- end }}
-
+    {{- if semverCompare ">=1.10.12" .Values.airflowVersion }}
+    pod_template_file = {{ include "airflow_pod_template_file" . }}/pod_template_file.yaml
+    {{- else }}
+    worker_service_account_name = {{ .Release.Name }}-worker-serviceaccount
+    image_pull_secrets = {{ template "registry_secret" . }}
     [kubernetes_labels]
     tier = airflow
     component = worker
     release = {{ .Release.Name }}
     platform = {{ .Values.platform.release }}
     workspace = {{ .Values.platform.workspace }}
+
+    [kubernetes_secrets]
+    AIRFLOW__CORE__SQL_ALCHEMY_CONN = {{ printf "%s=connection" (include "airflow_metadata_secret" .) }}
+    AIRFLOW__CORE__FERNET_KEY = {{ printf "%s=fernet-key" (include "fernet_key_secret" .) }}
+    {{- if .Values.elasticsearch.enabled }}
+    AIRFLOW__ELASTICSEARCH__ELASTICSEARCH_HOST = {{ printf "%s=connection" (include "elasticsearch_secret" .) }}
+    {{- end }}
+    {{- end }}
 
     [astronomer]
 {{- if .Values.webserver.jwtSigningCertificateSecretName }}
@@ -125,6 +128,8 @@ data:
     {{ .Values.scheduler.airflowLocalSettings | nindent 4 }}
 {{- else }}
   airflow_local_settings.py: |
+    {{- if semverCompare ">=1.10.12" .Values.airflowVersion }}
+
     from airflow.contrib.kubernetes.pod import Pod
     from airflow.configuration import conf
 
@@ -145,4 +150,37 @@ data:
         pod.labels.update(extra_labels)
         pod.tolerations += {{ toJson .Values.podMutation.tolerations }}
         pod.affinity.update({{ toJson .Values.podMutation.affinity }})
+    {{- else }}
+    from kubernetes.client import models as k8s
+    from airflow.configuration import conf
+
+
+    def pod_mutation_hook(pod: k8s.V1Pod):
+
+        extra_labels = {
+            "kubernetes_executor": "False",
+            "kubernetes_pod_operator": "False"
+        }
+
+
+        if 'airflow-worker' in pod.metadata.labels.keys() or \
+                conf.get('core', 'EXECUTOR') == "KubernetesExecutor":
+            extra_labels["kubernetes_executor"] = "True"
+        else:
+            extra_labels["kubernetes_pod_operator"] = "True"
+
+        pod.metadata.labels.update(extra_labels)
+        pod.metadata.tolerations += {{ toJson .Values.podMutation.tolerations }}
+        pod.metadata.affinity.update({{ toJson .Values.podMutation.affinity }})
+    {{- end }}
+{{- end }}
+{{- if eq .Values.executor "KubernetesExecutor" }}
+{{- if semverCompare ">=1.10.12" .Values.airflowVersion }}
+  pod_template_file.yaml: |-
+    {{- if .Values.podTemplate }}
+    {{ .Values.podTemplate | nindent 4 }}
+    {{- else }}
+    {{ tpl (.Files.Get "files/pod-template-file.yaml") . | nindent 4 }}
+    {{- end }}
+{{- end }}
 {{- end }}

--- a/templates/create-user-job.yaml
+++ b/templates/create-user-job.yaml
@@ -50,7 +50,12 @@ spec:
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           args:
             - "airflow"
+            {{- if semverCompare ">=2.0.0" .Values.airflowVersion }}
+            - "users"
+            - "create"
+            {{- else }}
             - "create_user"
+            {{- end }}
             - "-r"
             - {{ .Values.webserver.defaultUser.role }}
             - "-u"

--- a/templates/scheduler/scheduler-deployment.yaml
+++ b/templates/scheduler/scheduler-deployment.yaml
@@ -159,6 +159,10 @@ spec:
               mountPath: {{ template "airflow_config_path" . }}
               subPath: airflow.cfg
               readOnly: true
+            - name: config
+              mountPath: {{ include "airflow_pod_template_file" . }}/pod_template_file.yaml
+              subPath: pod_template_file.yaml
+              readOnly: true
           {{- include "airflow_environment_variables" . | indent 10 }}
 {{- end }}
       volumes:

--- a/templates/scheduler/scheduler-deployment.yaml
+++ b/templates/scheduler/scheduler-deployment.yaml
@@ -135,6 +135,10 @@ spec:
               mountPath: {{ template "airflow_local_setting_path" . }}
               subPath: airflow_local_settings.py
               readOnly: true
+            - name: config
+              subPath: pod_template_file.yaml
+              mountPath: {{ include "airflow_pod_template_file" . }}/pod_template_file.yaml
+              readOnly: true
         # Always start the garbage collector sidecar.
         - name: scheduler-gc
           image: {{ template "airflow_image" . }}

--- a/tests/pod-template-file_test.yaml
+++ b/tests/pod-template-file_test.yaml
@@ -1,0 +1,24 @@
+---
+suite: Test templates/pod-template-file.yaml
+templates:
+  - pod-template-file.yaml
+tests:
+  - it: should work
+    asserts:
+      - isKind:
+          of: Pod
+      - equal:
+          path: spec.containers[0].image
+          value: dummy_image
+      - equal:
+          path: spec.containers[0].name
+          value: base
+  - it: should add registry secrets
+    set:
+      registry.secretName: foo
+    asserts:
+      - isKind:
+          of: Pod
+      - equal:
+          path: spec.imagePullSecrets[0].name
+          value: foo

--- a/values.yaml
+++ b/values.yaml
@@ -70,19 +70,19 @@ executor: "KubernetesExecutor"
 allowPodLaunching: true
 
 # Airflow version
-airflowVersion: 1.10.10
+airflowVersion: 2.0.0
 
 # Default airflow repository
-defaultAirflowRepository: astronomerinc/ap-airflow
+defaultAirflowRepository: astronomerio/ap-airflow
 
 # Default airflow tag to deploy
-defaultAirflowTag: 1.10.10-buster
+defaultAirflowTag: 2.0.0-1.dev-buster-onbuild
 
 # Astronomer Airflow images
 images:
   airflow:
-    repository: astronomerinc/ap-airflow
-    tag: ~
+    repository: astronomerio/ap-airflow
+    tag: 2.0.0-1.dev-buster-onbuild
     pullPolicy: IfNotPresent
   flower:
     repository: astronomerinc/ap-airflow

--- a/values.yaml
+++ b/values.yaml
@@ -70,19 +70,19 @@ executor: "KubernetesExecutor"
 allowPodLaunching: true
 
 # Airflow version
-airflowVersion: 2.0.0
+airflowVersion: 1.10.10
 
 # Default airflow repository
-defaultAirflowRepository: astronomerio/ap-airflow
+defaultAirflowRepository: astronomerinc/ap-airflow
 
 # Default airflow tag to deploy
-defaultAirflowTag: 2.0.0-1.dev-buster-onbuild
+defaultAirflowTag: 1.10.10-buster
 
 # Astronomer Airflow images
 images:
   airflow:
-    repository: astronomerio/ap-airflow
-    tag: 2.0.0-1.dev-buster-onbuild
+    repository: astronomerinc/ap-airflow
+    tag: ~
     pullPolicy: IfNotPresent
   flower:
     repository: astronomerinc/ap-airflow


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

## PR Title

> Please make the PR title informative to the user experience. For example when adding a feature, say "Add metrics tab for Deployments" instead of "Bump Astro-UI to version X.Y.Z". Bugs are sometimes harder to make customer-facing because they are very detailed, but do what you can. Instead of "Fix metrics cardinality bug" (user does not know what 'cardinality' means and does not matter to them), say "Fix bug slowing down the metrics tab". The PR title will be used for the commit message when it's merged, and these commit messages are used to generate customer-facing release notes.

## 🎟 Issue(s)

Resolves astronomer/issues#XXXX

## 🧪  Testing

> What are the main risks associated with this change, and how are they addressed by tests added in this PR?

> Please add helm unit testing, if applicable. The docs are regretfully sparse for helm unit testing, [here](https://github.com/astronomer/helm-unittest/blob/main/DOCUMENT.md) is what we have to work with. In general, these kind of tests can be used for specific assertions like 'when these values are set, the resource ends up looking like XYZ' but not for generalized assertions like 'for all resources, make sure the namespace is not set to the release name'.

> Please also add to the system testing [here](../tests/functional-tests). This kind of testing allows you to connect into any live, running pod to make assertions about how they are operating.

## 📸 Screenshots

> Add screenshots to illustrate the changes, if applicable.

## 📋 Checklist

- [ ] The PR title is informative to the user experience
- [ ] Functional test(s) added
- [ ] Helm chart unit test(s)
