### PR TITLE
Don't try to use old python on release step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,6 @@ jobs:
           command: |
             set -e
             sudo apt-get update && sudo apt-get install -y ca-certificates curl
-            pyenv global 2.7.12
             HELM_CHART_PATH='/tmp/workspace/airflow-*.tgz' bin/release
 
 commands:


### PR DESCRIPTION
In #121 we upgraded to a newer CI image and a new python image, but we
didn't fix the release step (as we only noticed it when trying to
release.)

It turns out that the release script doesn't even need python though, so
we can remove this command entirely