### PR TITLE
Gcloud in the release step does need a python installed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,10 @@ jobs:
           command: |
             set -e
             sudo apt-get update && sudo apt-get install -y ca-certificates curl
+            pyenv global 3.8.5
+            # Make sure gcloud doesn't try to use python2 - pyenv installs a
+            # "stub" version that won't work unless we install it
+            export CLOUDSDK_PYTHON="$(pyenv which python)"
             HELM_CHART_PATH='/tmp/workspace/airflow-*.tgz' bin/release
 
 commands:


### PR DESCRIPTION
Tested via SSH on CircleCI, this gets as far as actually uploading a
file, so hopefully this time it will work.

The perils of fixing bugs in the release process is you can't very easily run this locally.