### PR TITLE
Add webserver_config.py configuration value

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -101,6 +101,10 @@ data:
     jwt_audience = {{ printf "%s/%s" ( include "deployments_subdomain" . ) .Release.Name }}
 {{- end }}
 
+{{- if .Values.webserver.webserverConfig }}
+  webserver_config.py: |
+    {{ .Values.webserver.webserverConfig | nindent 4 }}
+{{- else }}
   webserver_config.py: |
     import os
     from airflow import configuration as conf
@@ -116,6 +120,7 @@ data:
     # ----------------------------------------------------
     # AUTHENTICATION CONFIG
     # ----------------------------------------------------
+{{- end }}
 {{- if .Values.webserver.jwtSigningCertificateSecretName }}
     AUTH_TYPE = AUTH_REMOTE_USER
 

--- a/values.yaml
+++ b/values.yaml
@@ -261,6 +261,12 @@ webserver:
     #   cpu: 100m
     #   memory: 128Mi
 
+  # This setting can overwrite
+  # webserver_config.py - be sure
+  # to reference the default if you
+  # are making use of those settings.
+  webserverConfig: ~
+
   # Secret that contains the cert to verify JWTs
   jwtSigningCertificateSecretName: ~
 


### PR DESCRIPTION
## Description

This PR adds webserver_config.py configuration to the helm chart values. Normally authentication settings require custom webserver_config.py setting. Which is currently not supported by Astronomer airflow chart.

## PR Title

Add webserver_config.py configuration value

## 🧪  Testing

> What are the main risks associated with this change, and how are they addressed by tests added in this PR?

This should be backwards compatible.