### PR TITLE
Fix indent error in run-airflow-migrations

### DIFF
--- a/templates/run-airflow-migrations.yaml
+++ b/templates/run-airflow-migrations.yaml
@@ -12,9 +12,9 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-  {{- with .Values.labels }}
-  {{ toYaml . | indent 4 }}
-  {{- end }}
+{{- with .Values.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "1"


### PR DESCRIPTION

## Description

- Airflow chart 0.18.0 fails to deploy via astronomer platform due to indentation error in `run-airflow-migrations.yaml`

```
time="2020-10-22T13:32:10Z" level=error msg="YAML parse error on airflow/templates/run-airflow-migrations.yaml: error converting YAML to JSON: yaml: line 15: mapping values are not allowed in this context" function=InstallDeployment package=kubernetes
```
- We only see this if passing in `.Values.labels` (which astronomer platform will do)

## 🎟 Issue(s)

Resolves astronomer/issues#2011
