### PR TITLE
s/ASTRONOMER__AIRFLOW__WORKER_LOG_RETENTION/ASTRONOMER__AIRFLOW__WORK…

### DIFF
--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -1,7 +1,7 @@
 {{/* Standard Airflow environment variables */}}
 {{- define "standard_airflow_environment" }}
   # Hard Coded Airflow Envs
-  - name: ASTRONOMER__AIRFLOW__WORKER_LOG_RETENTION
+  - name: ASTRONOMER__AIRFLOW__WORKER_LOG_RETENTION_DAYS
     value: "3"
   - name: AIRFLOW__CORE__FERNET_KEY
     valueFrom:


### PR DESCRIPTION
`s/ASTRONOMER__AIRFLOW__WORKER_LOG_RETENTION/ASTRONOMER__AIRFLOW__WORKER_LOG_RETENTION_DAYS/`

## Description

Fix typo in a variable name that was breaking some cleanup jobs.

## 🎟 Issue(s)

Resolves astronomer/issues#2019