### PR TITLE
Add namespace in the port-forward command

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -16,9 +16,9 @@ Flower dashboard:         https://deployments.{{ .Values.ingress.baseDomain }}/{
 
 You can now access your dashboard(s) by executing the following command(s) and visiting the corresponding port at localhost in your browser:
 
-Airflow dashboard:        kubectl port-forward svc/{{ .Release.Name }}-webserver {{ .Values.ports.airflowUI }}:{{ .Values.ports.airflowUI }}
+Airflow dashboard:        kubectl port-forward svc/{{ .Release.Name }}-webserver {{ .Values.ports.airflowUI }}:{{ .Values.ports.airflowUI }} --namespace {{ .Release.Namespace }}
 {{- if eq .Values.executor "CeleryExecutor"}}
-Flower dashboard:         kubectl port-forward svc/{{ .Release.Name }}-flower {{ .Values.ports.flowerUI }}:{{ .Values.ports.flowerUI }}
+Flower dashboard:         kubectl port-forward svc/{{ .Release.Name }}-flower {{ .Values.ports.flowerUI }}:{{ .Values.ports.flowerUI }} --namespace {{ .Release.Namespace }}
 {{- end }}
 
 {{- end }}


### PR DESCRIPTION
Could not test by running the chart locally, as it was failing with the following error `Error: found in Chart.yaml, but missing in charts/ directory: postgresql`