### PR TITLE
Update to new helm stable repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
           name: unittest the Airflow chart
           command: |
             apk add git bash
-            helm repo add stable https://kubernetes-charts.storage.googleapis.com
+            helm repo add stable https://charts.helm.sh/stable
             helm dep update
             helm plugin install https://github.com/astronomer/helm-unittest/
             cp files/pod-template-file.yaml templates

--- a/bin/install-ci-tools
+++ b/bin/install-ci-tools
@@ -38,7 +38,7 @@ else
 fi
 
 # Add stable helm repo
-helm repo add stable https://kubernetes-charts.storage.googleapis.com
+helm repo add stable https://charts.helm.sh/stable
 
 echo "Installing the latest, stable kubectl..."
 if [[ -f /tmp/bin/kubectl ]]; then

--- a/requirements.lock
+++ b/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable
   version: 6.3.12
 digest: sha256:58d88cf56e78b2380091e9e16cc6ccf58b88b3abe4a1886dd47cd9faef5309af
 generated: "2020-07-15T09:39:30.837647681-03:00"


### PR DESCRIPTION
Switch out deprecated helm repo for new stable repo.

- <https://www.cncf.io/blog/2020/11/05/helm-chart-repository-deprecation-update/>
- <https://helm.sh/docs/faq/#i-am-getting-a-warning-about-unable-to-get-an-update-from-the-stable-chart-repository>

Relates to astronomer/issues#2003