### PR TITLE
Add iso8601 date and git short URL to description

### DIFF
--- a/bin/package-and-release
+++ b/bin/package-and-release
@@ -31,7 +31,7 @@ else
   filename="airflow-${version}.tgz"
   extra_args=( '--version' "${version}" )
   max_age=60
-  sed -i "s#^description: .*#description: ${CIRCLE_BRANCH} ${CIRCLE_BUILD_URL}#" airflow/Chart.yaml
+  sed -i "s#^description: .*#description: $(date "+%FT%T%z") ${CIRCLE_BRANCH} ${CIRCLE_BUILD_URL}#" airflow/Chart.yaml
 fi
 
 helm3 package airflow --dependency-update --app-version "${app_version}" "${extra_args[@]}"

--- a/bin/package-and-release
+++ b/bin/package-and-release
@@ -31,7 +31,8 @@ else
   filename="airflow-${version}.tgz"
   extra_args=( '--version' "${version}" )
   max_age=60
-  sed -i "s#^description: .*#description: $(date "+%FT%T%z") ${CIRCLE_BRANCH} ${CIRCLE_BUILD_URL}#" airflow/Chart.yaml
+  short_git_url=$(curl -sS -i https://git.io -F "url=https://github.com/astronomer/airflow-chart/commits/${CIRCLE_SHA1}" | awk '$1 == "Location:" {print $2}')
+  sed -i "s#^description: .*#description: $(date "+%FT%T%z") ${short_git_url} ${CIRCLE_BRANCH} ${CIRCLE_BUILD_URL}#" airflow/Chart.yaml
 fi
 
 helm3 package airflow --dependency-update --app-version "${app_version}" "${extra_args[@]}"


### PR DESCRIPTION
New output:
```
$ helm search repo astronomer-internal/airflow -l --devel --max-col-width 0
2020-11-06 15:32:33-0800
NAME                       	CHART VERSION   	APP VERSION	DESCRIPTION
astronomer-internal/airflow	0.18.0          	           	Helm chart to deploy the Astronomer Platform Airflow module
astronomer-internal/airflow	0.18.0-build6811	1.10.10    	2020-11-06T23:18:56+0000 https://git.io/JTjg7 add-date-to-dev-chart-desc https://circleci.com/gh/astronomer/airflow-chart/6811
```