### PR TITLE
Adding support for pod anti-affinity on airflow scheduler pods

### DIFF
--- a/templates/scheduler/scheduler-deployment.yaml
+++ b/templates/scheduler/scheduler-deployment.yaml
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
       affinity:
-{{ toYaml .Values.affinity | indent 8 }}
+{{ toYaml .Values.scheduler.affinity | indent 8 }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       restartPolicy: Always

--- a/tests/scheduler_scheduler-deployment_test.yaml
+++ b/tests/scheduler_scheduler-deployment_test.yaml
@@ -17,16 +17,16 @@ tests:
           value: 2
   - it: "should create one scheduler if replicas is not specified"
     set:
-      replicas: ~
+        replicas: ~
     asserts:
       - equal:
           path: spec.replicas
           value: 1
-  - it: "should have pod antiAffinity"
-    assert:
-      - equal:
-          path: deployment.spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution.topologyKey
-          value: "kubernetes.io/hostname"
+  # - it: "should have pod antiAffinity"
+  #   assert:
+  #     - equal:
+  #         path: deployment.spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution.topologyKey
+  #         value: "kubernetes.io/hostname"
 
   - it: "should wait for migrations"
     set:

--- a/tests/scheduler_scheduler-deployment_test.yaml
+++ b/tests/scheduler_scheduler-deployment_test.yaml
@@ -17,11 +17,17 @@ tests:
           value: 2
   - it: "should create one scheduler if replicas is not specified"
     set:
-        replicas: ~
+      replicas: ~
     asserts:
       - equal:
           path: spec.replicas
           value: 1
+  - it: "should have pod antiAffinity"
+    assert:
+      - equal:
+          path: deployment.spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution.topologyKey
+          value: "kubernetes.io/hostname"
+
   - it: "should wait for migrations"
     set:
       executor: CeleryExecutor

--- a/values.yaml
+++ b/values.yaml
@@ -8,16 +8,7 @@ gid: 101
 
 # Select certain nodes for airflow pods.
 nodeSelector: {}
-affinity: 
-  podAntiAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-    - labelSelector:
-        matchExpressions:
-        - key: component
-          operator: In
-          values:
-          - scheduler
-      topologyKey: "kubernetes.io/hostname"
+affinity: {}
 
 tolerations: []
 
@@ -233,6 +224,19 @@ scheduler:
   #   cpu: 100m
   #   memory: 128Mi
 
+  affinity: 
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: component
+              operator: In
+              values:
+              - scheduler
+          topologyKey: "kubernetes.io/hostname"
+          
   # This setting can overwrite
   # podMutation settings - be sure
   # to reference the default if you

--- a/values.yaml
+++ b/values.yaml
@@ -8,7 +8,17 @@ gid: 101
 
 # Select certain nodes for airflow pods.
 nodeSelector: {}
-affinity: {}
+affinity: 
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchExpressions:
+        - key: component
+          operator: In
+          values:
+          - scheduler
+      topologyKey: "kubernetes.io/hostname"
+
 tolerations: []
 
 # Add common labels to all objects and pods defined in this chart.


### PR DESCRIPTION
## Description

Adding support for pod anti-affinity on airflow scheduler pods


## 🎟 Issue(s)

Resolves https://github.com/astronomer/issues/issues/1988

## 🧪  Testing

Added helm unit test to confirm anti-affinity is exists.


## 📋 Checklist

- [x] The PR title is informative to the user experience
- [ ] Functional test(s) added
- [x] Helm chart unit test(s)
