### PR TITLE
Adding support for Openshift Security Context Constraints

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v1 is Helm 2
 apiVersion: v1
 name: airflow
-version: 0.18.1
+version: 0.18.0
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://www.astronomer.io/static/airflowNewA.png
 keywords:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v1 is Helm 2
 apiVersion: v1
 name: airflow
-version: 0.18.0
+version: 0.18.1
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://www.astronomer.io/static/airflowNewA.png
 keywords:

--- a/templates/airflow-scc-anyuid.yaml
+++ b/templates/airflow-scc-anyuid.yaml
@@ -38,6 +38,7 @@ allowHostIPC: false
 allowHostNetwork: false
 allowHostPID: false
 allowHostPorts: false
+allowPrivilegeEscalation: false
 allowPrivilegedContainer: false
 allowedCapabilities: null
 {{- end }}

--- a/templates/airflow-scc-anyuid.yaml
+++ b/templates/airflow-scc-anyuid.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.sccEnabled }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    release.openshift.io/create-only: "true"
+    "helm.sh/hook": "pre-install,pre-upgrade"
+  name: {{ .Release.Name }}-anyuid
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:{{ .Release.Namespace }}:default
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-scheduler-serviceaccount
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-webserver-serviceaccount
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-worker-serviceaccount
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups:
+- system:cluster-admins
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+{{- end }}

--- a/templates/airflow-scc-anyuid.yaml
+++ b/templates/airflow-scc-anyuid.yaml
@@ -31,14 +31,12 @@ volumes:
 defaultAddCapabilities: null
 fsGroup:
   type: RunAsAny
-groups:
-- system:cluster-admins
 allowHostDirVolumePlugin: false
 allowHostIPC: false
 allowHostNetwork: false
 allowHostPID: false
 allowHostPorts: false
-allowPrivilegeEscalation: false
+allowPrivilegeEscalation: true
 allowPrivilegedContainer: false
 allowedCapabilities: null
 {{- end }}

--- a/templates/airflow-scc-anyuid.yaml
+++ b/templates/airflow-scc-anyuid.yaml
@@ -38,7 +38,6 @@ allowHostIPC: false
 allowHostNetwork: false
 allowHostPID: false
 allowHostPorts: false
-allowPrivilegeEscalation: true
 allowPrivilegedContainer: false
 allowedCapabilities: null
 {{- end }}

--- a/tests/scc_test.yaml
+++ b/tests/scc_test.yaml
@@ -1,0 +1,17 @@
+---
+suite: Test Security Context Constraints
+templates:
+  - templates/airflow-scc-anyuid.yaml
+tests:
+  - it: Should not be created by default
+    asserts:
+      - not: yes
+        isKind:
+          of: SecurityContextConstraint
+  - it: Should be created with configuration enabled
+    set:
+      global:
+        sccEnabled: true
+    asserts:
+      - isKind:
+          of: SecurityContextConstraint

--- a/values.yaml
+++ b/values.yaml
@@ -150,7 +150,7 @@ data:
 fernetKey: ~
 fernetKeySecretName: ~
 
-#
+# Enable security context constraints required for OpenShift
 sccEnabled: false
 
 # Airflow Worker Config

--- a/values.yaml
+++ b/values.yaml
@@ -150,6 +150,9 @@ data:
 fernetKey: ~
 fernetKeySecretName: ~
 
+#
+sccEnabled: false
+
 # Airflow Worker Config
 workers:
   # Number of airflow celery workers in StatefulSet


### PR DESCRIPTION
## Description

Peer programmed with @ianstanton 

Adding support for Openshift Security Context Constraints

## 🎟 Issue(s)

Part of https://github.com/astronomer/issues/issues/2039

## 🧪  Testing

This configuration is default disabled. For the enabled case, a unit test has been added.

## 📋 Checklist

- [x] The PR title is informative to the user experience
- [ ] Functional test(s) added
- [x] Helm chart unit test(s)
