### PR TITLE
Update chart to use both 2.0 and 1.10 name of config options

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -19,8 +19,16 @@ data:
   airflow.cfg: |
     [core]
     load_examples = False
-    colored_console_log = False
     executor = {{ .Values.executor }}
+
+{{/* Support old/pre-2.0 config names */}}
+    colored_console_log = False
+{{- if .Values.elasticsearch.enabled }}
+    remote_logging = True
+{{- end }}
+
+    [logging]
+    colored_console_log = False
 {{- if .Values.elasticsearch.enabled }}
     remote_logging = True
 {{- end }}
@@ -38,6 +46,7 @@ data:
 
     [scheduler]
     scheduler_heartbeat_sec = 5
+{{/* Support old/pre-2.0 config names */}}
 {{- if .Values.statsd.enabled }}
     statsd_on = True
     statsd_port = 9125
@@ -47,6 +56,14 @@ data:
     # Restart Scheduler every 41460 seconds (11 hours 31 minutes)
     # The odd time is chosen so it is not always restarting on the same "hour" boundary
     run_duration = 41460
+
+{{- if .Values.statsd.enabled }}
+    [metrics]
+    statsd_on = True
+    statsd_port = 9125
+    statsd_prefix = airflow
+    statsd_host = {{ printf "%s-statsd" .Release.Name }}
+{{- end }}
 
 {{- if .Values.elasticsearch.enabled }}
     [elasticsearch]


### PR DESCRIPTION
Without this we get lots of deprecation warnings in the logs