### PR TITLE
Allow configuration of Elasticsearch protocol

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v1 is Helm 2
 apiVersion: v1
 name: airflow
-version: 0.18.0
+version: 0.18.1
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://www.astronomer.io/static/airflowNewA.png
 keywords:

--- a/templates/secrets/elasticsearch-secret.yaml
+++ b/templates/secrets/elasticsearch-secret.yaml
@@ -15,5 +15,5 @@ metadata:
 {{- end }}
 type: Opaque
 data:
-  connection: {{ (printf "http://%s:%s@%s:%s" .Values.elasticsearch.connection.user .Values.elasticsearch.connection.pass .Values.elasticsearch.connection.host (.Values.elasticsearch.connection.port | toString)) | b64enc | quote }}
+  connection: {{ (printf "%s://%s:%s@%s:%s" ( .Values.elasticsearch.connection.scheme | default "http" ) .Values.elasticsearch.connection.user .Values.elasticsearch.connection.pass .Values.elasticsearch.connection.host (.Values.elasticsearch.connection.port | toString)) | b64enc | quote }}
 {{- end }}

--- a/tests/secrets_elasticsearch-secret_test.yaml
+++ b/tests/secrets_elasticsearch-secret_test.yaml
@@ -3,14 +3,70 @@ suite: Test templates/secrets/elasticsearch-secret.yaml
 templates:
   - templates/secrets/elasticsearch-secret.yaml
 tests:
-  - it: should work
+  - it: HTTP is default scheme (unset)
     set:
       elasticsearch:
         connection:
-          user: date.murphy
+          user: elastic
           pass: secretpassword
           host: localhost
           port: 9200
     asserts:
       - isKind:
           of: Secret
+      # $ echo "aHR0cDovL2VsYXN0aWM6c2VjcmV0cGFzc3dvcmRAbG9jYWxob3N0OjkyMDA=" | base64 --decode
+      # http://elastic:secretpassword@localhost:9200
+      - equal:
+          path: data.connection
+          value: "aHR0cDovL2VsYXN0aWM6c2VjcmV0cGFzc3dvcmRAbG9jYWxob3N0OjkyMDA="
+  - it: HTTP is default scheme (explicit null)
+    set:
+      elasticsearch:
+        connection:
+          user: elastic
+          pass: secretpassword
+          host: localhost
+          port: 9200
+          scheme: ~
+    asserts:
+      - isKind:
+          of: Secret
+      # $ echo "aHR0cDovL2VsYXN0aWM6c2VjcmV0cGFzc3dvcmRAbG9jYWxob3N0OjkyMDA=" | base64 --decode
+      # http://elastic:secretpassword@localhost:9200
+      - equal:
+          path: data.connection
+          value: "aHR0cDovL2VsYXN0aWM6c2VjcmV0cGFzc3dvcmRAbG9jYWxob3N0OjkyMDA="
+  - it: HTTP configured explictly
+    set:
+      elasticsearch:
+        connection:
+          user: elastic
+          pass: secretpassword
+          host: localhost
+          port: 9200
+          scheme: http
+    asserts:
+      - isKind:
+          of: Secret
+      # $ echo "aHR0cDovL2VsYXN0aWM6c2VjcmV0cGFzc3dvcmRAbG9jYWxob3N0OjkyMDA=" | base64 --decode
+      # http://elastic:secretpassword@localhost:9200
+      - equal:
+          path: data.connection
+          value: "aHR0cDovL2VsYXN0aWM6c2VjcmV0cGFzc3dvcmRAbG9jYWxob3N0OjkyMDA="
+  - it: HTTPS configured explictly
+    set:
+      elasticsearch:
+        connection:
+          user: elastic
+          pass: secretpassword
+          host: localhost
+          port: 9200
+          scheme: https
+    asserts:
+      - isKind:
+          of: Secret
+      # $ echo "aHR0cHM6Ly9lbGFzdGljOnNlY3JldHBhc3N3b3JkQGxvY2FsaG9zdDo5MjAw" | base64 --decode
+      # https://elastic:secretpassword@localhost:9200
+      - equal:
+          path: data.connection
+          value: "aHR0cHM6Ly9lbGFzdGljOnNlY3JldHBhc3N3b3JkQGxvY2FsaG9zdDo5MjAw"

--- a/values.yaml
+++ b/values.yaml
@@ -408,7 +408,8 @@ elasticsearch:
   # A secret containing the connection
   secretName: ~
   # Or an object representing the connection
-  connection: {}
+  connection:
+    scheme: http
     # user: ~
     # pass: ~
     # host: ~


### PR DESCRIPTION
## Description

When integrating with an external elasticsearch cluster, we will use HTTPS instead of HTTP. This change allows configuration of the protocol to use with Elasticsearch

## 🎟 Issue(s)

part of https://github.com/astronomer/issues/issues/2074

## 🧪  Testing

This was tested manually in practice on an openshift cluster with an external elastic search, and also unit tests are added to ensure that the configuration is set as expected.

## 📸 Screenshots

> Add screenshots to illustrate the changes, if applicable.

## 📋 Checklist

- [x] The PR title is informative to the user experience
- [ ] Functional test(s) added
not a default configuration, so can't add functional tests
- [x] Helm chart unit test(s)
