### PR TITLE
Change default uid/gid to values for Debian image

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -3,8 +3,8 @@
 # Declare variables to be passed into your templates.
 
 # User and group of airflow user
-uid: 100
-gid: 101
+uid: 50000
+gid: 50000
 
 # Select certain nodes for airflow pods.
 nodeSelector: {}


### PR DESCRIPTION
This matches the current default airflow tag used in the chart.

Part of astronomer/issues#2100 -- there will be a companion change in Houston.