### PR TITLE
Populate airflow_db connection for KubernetesExecutor launched-pods too

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -106,6 +106,7 @@ data:
 
     [kubernetes_secrets]
     AIRFLOW__CORE__SQL_ALCHEMY_CONN = {{ printf "%s=connection" (include "airflow_metadata_secret" .) }}
+    AIRFLOW_CONN_AIRFLOW_DB = {{ printf "%s=connection" (include "airflow_metadata_secret" .) }}
     AIRFLOW__CORE__FERNET_KEY = {{ printf "%s=fernet-key" (include "fernet_key_secret" .) }}
     {{- if .Values.elasticsearch.enabled }}
     AIRFLOW__ELASTICSEARCH__ELASTICSEARCH_HOST = {{ printf "%s=connection" (include "elasticsearch_secret" .) }}


### PR DESCRIPTION
Slack chat: https://astronomerteam.slack.com/archives/CGQSYG25V/p1605863107155800

We allow users to use `airflow_db` connection for Celery and Local Executor. However, with KubernetesExecutor this env var (`AIRFLOW_CONN_AIRFLOW_DB`) is not found on task PODs.

I have NOT tested this, so let me know if the fix is wrong.

https://github.com/astronomer/airflow-chart/blob/b56350b2f4b8930f6b42cb9064ae55caba6b274b/templates/scheduler/scheduler-deployment.yaml#L90-L94

https://github.com/astronomer/airflow-chart/blob/87e27ad70608a957e7102f30cbac5523a4dbb47e/templates/_helpers.yaml#L54-L66

https://github.com/astronomer/airflow-chart/blob/87e27ad70608a957e7102f30cbac5523a4dbb47e/templates/_helpers.yaml#L2-L20


