### PR TITLE
Correct runAsUser in pod-template-file

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v1 is Helm 2
 apiVersion: v1
 name: airflow
-version: 0.18.4
+version: 0.18.5
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://www.astronomer.io/static/airflowNewA.png
 keywords:

--- a/files/pod-template-file.yaml
+++ b/files/pod-template-file.yaml
@@ -61,11 +61,7 @@ spec:
   {{- end }}
   restartPolicy: Never
   securityContext:
-  {{- if contains "alpine"  .Values.defaultAirflowTag }}
-    runAsUser: 100
-  {{- else }}
-    runAsUser: 50000
-  {{- end }}
+    runAsUser: {{ .Values.uid }}
   nodeSelector: {{ toYaml .Values.nodeSelector | nindent 4 }}
   affinity: {{ toYaml .Values.affinity | nindent 4 }}
   tolerations: {{ toYaml .Values.tolerations | nindent 4 }}


### PR DESCRIPTION
## Description

Use UID given by houston, not determined during chart rendering. This fixes permission problems for some edge cases where users have switched from Debian to Alpine.

## Links

- <https://astronomerteam.slack.com/archives/CR6JGBCTA/p1606758088112400>