### PR TITLE
Allow webserver to read pod logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ workflows:
           matrix:
             parameters:
               # https://hub.docker.com/r/kindest/node/tags
-              kube_version: ["1.14.10", "1.15.12", "1.16.15", "1.17.11", "1.18.8"]
+              kube_version: ["1.16.15", "1.17.11", "1.18.8", "1.19.4"]
               executor: ["CeleryExecutor", "LocalExecutor", "KubernetesExecutor"]
           requires:
           - build-and-release-internal

--- a/templates/rbac/pod-log-reader-role.yaml
+++ b/templates/rbac/pod-log-reader-role.yaml
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+################################
+## Airflow Pod Reader Role
+#################################
+{{- if and .Values.rbacEnabled .Values.webserver.allowPodLogReading }}
+{{- if .Values.multiNamespaceMode }}
+kind: ClusterRole
+{{- else }}
+kind: Role
+{{- end }}
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-pod-log-reader-role
+{{- if not .Values.multiNamespaceMode }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+  labels:
+    tier: airflow
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+{{- with .Values.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+    verbs:
+      - "list"
+      - "get"
+      - "watch"
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/log"
+    verbs:
+      - "get"
+{{- end }}

--- a/templates/rbac/pod-log-reader-rolebinding.yaml
+++ b/templates/rbac/pod-log-reader-rolebinding.yaml
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+################################
+## Airflow Pod Reader Role Binding
+#################################
+{{- if and .Values.rbacEnabled .Values.webserver.allowPodLogReading }}
+{{- if .Values.multiNamespaceMode }}
+kind: ClusterRoleBinding
+{{- else }}
+kind: RoleBinding
+{{- end }}
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+{{- if not .Values.multiNamespaceMode }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+  name: {{ .Release.Name }}-pod-log-reader-rolebinding
+  labels:
+    tier: airflow
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+{{- with .Values.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+{{- if .Values.multiNamespaceMode }}
+  kind: ClusterRole
+{{- else }}
+  kind: Role
+{{- end }}
+  name: {{ .Release.Name }}-pod-log-reader-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-webserver
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -267,7 +267,7 @@ scheduler:
 
 # Airflow webserver settings
 webserver:
-  allowPodLogReading: true
+  allowPodLogReading: false
   livenessProbe:
     initialDelaySeconds: 15
     timeoutSeconds: 30

--- a/values.yaml
+++ b/values.yaml
@@ -267,6 +267,7 @@ scheduler:
 
 # Airflow webserver settings
 webserver:
+  allowPodLogReading: true
   livenessProbe:
     initialDelaySeconds: 15
     timeoutSeconds: 30


### PR DESCRIPTION
Allows webserver to read pod logs for tasks launched by k8sexecutor
without needing an external log store. Note: logs will only be
accessible while the pod is running (or after if you don't delete it)


## Description

> Describe the purpose of this pull request.

## PR Title

> Please make the PR title informative to the user experience. For example when adding a feature, say "Add metrics tab for Deployments" instead of "Bump Astro-UI to version X.Y.Z". Bugs are sometimes harder to make customer-facing because they are very detailed, but do what you can. Instead of "Fix metrics cardinality bug" (user does not know what 'cardinality' means and does not matter to them), say "Fix bug slowing down the metrics tab". The PR title will be used for the commit message when it's merged, and these commit messages are used to generate customer-facing release notes.

## 🎟 Issue(s)

Resolves astronomer/issues#XXXX

## 🧪  Testing

> What are the main risks associated with this change, and how are they addressed by tests added in this PR?

> Please add helm unit testing, if applicable. The docs are regretfully sparse for helm unit testing, [here](https://github.com/astronomer/helm-unittest/blob/main/DOCUMENT.md) is what we have to work with. In general, these kind of tests can be used for specific assertions like 'when these values are set, the resource ends up looking like XYZ' but not for generalized assertions like 'for all resources, make sure the namespace is not set to the release name'.

> Please also add to the system testing [here](../tests/functional-tests). This kind of testing allows you to connect into any live, running pod to make assertions about how they are operating.

## 📸 Screenshots

> Add screenshots to illustrate the changes, if applicable.

## 📋 Checklist

- [ ] The PR title is informative to the user experience
- [ ] Functional test(s) added
- [ ] Helm chart unit test(s)
