### PR TITLE
fix keda version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ helm repo update
 
 kubectl create namespace keda
 helm install keda \
-    --namespace keda kedacore/keda
+    --namespace keda kedacore/keda \
+    --version "v1.5.0"
 
 kubectl create namespace airflow
 


### PR DESCRIPTION
This chart expects keda version 1.5.0.  Here i update readme to reference it.

closes https://github.com/astronomer/airflow-chart/issues/176