### PR TITLE
Allow multiple Celery/KEDA Queues

### DIFF
--- a/templates/scheduler/scheduler-deployment.yaml
+++ b/templates/scheduler/scheduler-deployment.yaml
@@ -8,7 +8,7 @@
 {{- $kube := eq .Values.executor "KubernetesExecutor" }}
 # Is persistence enabled on the _workers_?
 # This is important because in $local mode, the scheduler assumes the role of the worker
-{{- $persistence := .Values.workers.persistence.enabled }}
+{{- $persistence := false }}
 # If we're using a StatefulSet
 {{- $stateful := and $local $persistence }}
 # If we're using elasticsearch logging
@@ -173,15 +173,17 @@ spec:
         - name: logs
           emptyDir: {}
 {{- else }}
+  {{ range .Values.workers }}
   volumeClaimTemplates:
     - metadata:
         name: logs
       spec:
-      {{- if .Values.workers.persistence.storageClassName }}
-        storageClassName: {{ .Values.workers.persistence.storageClassName }}
+      {{- if .persistence.storageClassName }}
+        storageClassName: {{ .persistence.storageClassName }}
       {{- end }}
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:
-            storage: {{ .Values.workers.persistence.size }}
+            storage: {{ .persistence.size }}
+  {{ end }}
 {{- end }}

--- a/templates/workers/worker-deployment.yaml
+++ b/templates/workers/worker-deployment.yaml
@@ -1,141 +1,143 @@
 ################################
 ## Airflow Worker Deployment
 #################################
-{{- $persistence := .Values.workers.persistence.enabled }}
-{{- $additionalVolume := .Values.workers.additionalVolume }}
-{{- if eq .Values.executor "CeleryExecutor" }}
+{{- if eq $.Values.executor "CeleryExecutor" }}
+{{- range $.Values.workers }}
+---
+{{- $persistence := .persistence.enabled }}
+{{- $additionalVolume := .additionalVolume }}
 kind: {{ if $persistence }}StatefulSet{{ else }}Deployment{{ end }}
 apiVersion: apps/v1
 metadata:
-  name: {{ .Release.Name }}-worker
+  name: {{ $.Release.Name }}-worker-{{ .queue }}
   labels:
     tier: airflow
     component: worker
-    release: {{ .Release.Name }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    heritage: {{ .Release.Service }}
-{{- with .Values.labels }}
+    release: {{ $.Release.Name }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    heritage: {{ $.Release.Service }}
+{{- with $.Values.labels }}
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
 {{- if $persistence }}
-  serviceName: {{ .Release.Name }}-worker
+  serviceName: {{ $.Release.Name }}-worker
 {{- end }}
-  replicas: {{ .Values.workers.replicas }}
+  replicas: {{ .replicas }}
   selector:
     matchLabels:
       tier: airflow
       component: worker
-      release: {{ .Release.Name }}
-  {{ if .Values.workers.updateStrategy }}
-{{ toYaml .Values.workers.updateStrategy | indent 2 }}
+      release: {{ $.Release.Name }}
+  {{ if .updateStrategy }}
+{{ toYaml .updateStrategy | indent 2 }}
   {{- end }}
   template:
     metadata:
       labels:
         tier: airflow
         component: worker
-        release: {{ .Release.Name }}
-{{- with .Values.labels }}
+        release: {{ $.Release.Name }}
+{{- with $.Values.labels }}
 {{ toYaml . | indent 8 }}
 {{- end }}
       annotations:
-        checksum/metadata-secret: {{ include (print $.Template.BasePath "/secrets/metadata-connection-secret.yaml") . | sha256sum }}
-        checksum/result-backend-secret: {{ include (print $.Template.BasePath "/secrets/result-backend-connection-secret.yaml") . | sha256sum }}
-        checksum/pgbouncer-config-secret: {{ include (print $.Template.BasePath "/secrets/pgbouncer-config-secret.yaml") . | sha256sum }}
-        checksum/airflow-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- if .Values.workers.safeToEvict }}
+        checksum/metadata-secret: {{ include (print $.Template.BasePath "/secrets/metadata-connection-secret.yaml") $ | sha256sum }}
+        checksum/result-backend-secret: {{ include (print $.Template.BasePath "/secrets/result-backend-connection-secret.yaml") $ | sha256sum }}
+        checksum/pgbouncer-config-secret: {{ include (print $.Template.BasePath "/secrets/pgbouncer-config-secret.yaml") $ | sha256sum }}
+        checksum/airflow-config: {{ include (print $.Template.BasePath "/configmap.yaml") $ | sha256sum }}
+        {{- if .safeToEvict }}
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         {{- end }}
-        {{- if .Values.airflowPodAnnotations }}
-        {{- toYaml .Values.airflowPodAnnotations | nindent 8 }}
+        {{- if $.Values.airflowPodAnnotations }}
+        {{- toYaml $.Values.airflowPodAnnotations | nindent 8 }}
         {{- end }}
     spec:
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
+{{ toYaml $.Values.nodeSelector | indent 8 }}
       affinity:
-{{ toYaml .Values.affinity | indent 8 }}
+{{ toYaml $.Values.affinity | indent 8 }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
-      terminationGracePeriodSeconds: {{ .Values.workers.terminationGracePeriodSeconds }}
+{{ toYaml $.Values.tolerations | indent 8 }}
+      terminationGracePeriodSeconds: {{ .terminationGracePeriodSeconds }}
       restartPolicy: Always
-      serviceAccountName: {{ .Release.Name }}-worker-serviceaccount
+      serviceAccountName: {{ $.Release.Name }}-worker-serviceaccount
       securityContext:
-        runAsUser: {{ .Values.uid }}
-        fsGroup: {{ .Values.gid }}
-      {{- if or .Values.registry.secretName .Values.registry.connection }}
+        runAsUser: {{ $.Values.uid }}
+        fsGroup: {{ $.Values.gid }}
+      {{- if or $.Values.registry.secretName $.Values.registry.connection }}
       imagePullSecrets:
-        - name: {{ template "registry_secret" . }}
+        - name: {{ template "registry_secret" $ }}
       {{- end }}
       initContainers:
-      {{- if and $persistence .Values.workers.persistence.fixPermissions }}
+      {{- if and $persistence .persistence.fixPermissions }}
         - name: volume-permissions
-          image: {{ template "default_airflow_image" . }}
-          imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
+          image:
+          imagePullPolicy: {{ $.Values.images.airflow.pullPolicy }}
           command:
             - chown
             - -R
-            - "{{ .Values.uid }}:{{ .Values.gid }}"
-            - {{ template "airflow_logs" . }}
+            - "{{ $.Values.uid }}:{{ $.Values.gid }}"
+            - {{ template "airflow_logs" $ }}
           securityContext:
             runAsUser: 0
           volumeMounts:
             - name: logs
-              mountPath: {{ template "airflow_logs" . }}
+              mountPath: {{ template "airflow_logs" $ }}
       {{- end }}
         - name: wait-for-airflow-migrations
-          image: {{ template "default_airflow_image" . }}
-          imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
+          image: {{ template "default_airflow_image" $ }}
+          imagePullPolicy: {{ $.Values.images.airflow.pullPolicy }}
           args: ["airflow-migration-spinner", "--timeout=60"]
           env:
-          {{- include "standard_airflow_environment" . | indent 10 }}
+          {{- include "standard_airflow_environment" $ | indent 10 }}
       containers:
         - name: worker
-          image: {{ template "airflow_image" . }}
-          imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
-          {{- if semverCompare ">=2.0.0" .Values.airflowVersion }}
-          args: ["airflow", "celery", "worker"]
+          image: {{ template "airflow_image" $ }}
+          imagePullPolicy: {{ $.Values.images.airflow.pullPolicy }}
+          {{- if semverCompare ">=2.0.0" $.Values.airflowVersion }}
+          args: ["airflow", "celery", "worker", "--queues", "{{ .queue }}}"]
           {{- else }}
           args: ["airflow", "worker"]
           {{- end }}
           resources:
-{{ toYaml .Values.workers.resources | indent 12 }}
+{{ toYaml .resources | indent 12 }}
           ports:
             - name: worker-logs
-              containerPort: {{ .Values.ports.workerLogs }}
+              containerPort: {{ $.Values.ports.workerLogs }}
           volumeMounts:
 {{- if $additionalVolume.enabled }}
             - name: worker-volume
               mountPath: {{ $additionalVolume.mountPath }}
 {{- end }}
             - name: logs
-              mountPath: {{ template "airflow_logs" . }}
+              mountPath: {{ template "airflow_logs" $ }}
             - name: config
-              mountPath: {{ template "airflow_config_path" . }}
+              mountPath: {{ template "airflow_config_path" $ }}
               subPath: airflow.cfg
               readOnly: true
             - name: config
-              mountPath: {{ template "airflow_local_setting_path" . }}
+              mountPath: {{ template "airflow_local_setting_path" $ }}
               subPath: airflow_local_settings.py
               readOnly: true
-          {{- include "airflow_environment_variables" . | indent 10 }}
+          {{- include "airflow_environment_variables" $ | indent 10 }}
 {{- if $persistence }}
         - name: worker-gc
-          image: {{ template "airflow_image" . }}
+          image: {{ template "airflow_image" $ }}
           args: ["/usr/local/bin/clean-airflow-logs"]
           volumeMounts:
             - name: logs
-              mountPath: {{ template "airflow_logs" . }}
+              mountPath: {{ template "airflow_logs" $ }}
 {{- end }}
       volumes:
 {{- if $additionalVolume.enabled }}
         - name: worker-volume
           persistentVolumeClaim:
-            claimName: {{ .Release.Name }}-worker-claim
+            claimName: {{ $.Release.Name }}-worker-claim
 {{- end }}
         - name: config
           configMap:
-            name: {{ template "airflow_config" . }}
+            name: {{ template "airflow_config" $ }}
 {{- if not $persistence }}
         - name: logs
           emptyDir: {}
@@ -144,12 +146,13 @@ spec:
     - metadata:
         name: logs
       spec:
-      {{- if .Values.workers.persistence.storageClassName }}
-        storageClassName: {{ .Values.workers.persistence.storageClassName }}
+      {{- if .persistence.storageClassName }}
+        storageClassName: {{ .persistence.storageClassName }}
       {{- end }}
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:
-            storage: {{ .Values.workers.persistence.size }}
+            storage: {{ .persistence.size }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/workers/worker-horizontalpodautoscaler.yaml
+++ b/templates/workers/worker-horizontalpodautoscaler.yaml
@@ -1,7 +1,9 @@
 ################################
 ## Airflow Worker HorizontalPodAutoscaler
 #################################
-{{- if (and .Values.workers.autoscaling.enabled (eq .Values.executor "CeleryExecutor")) }}
+{{- $executor := .Values.executor }}
+{{- range .Values.workers }}
+{{- if (and .autoscaling.enabled (eq $executor "CeleryExecutor")) }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -31,4 +33,5 @@ spec:
       resource:
         name: memory
         targetAverageUtilization: {{ .Values.workers.autoscaling.targetMemoryUtilization }}
+{{- end }}
 {{- end }}

--- a/templates/workers/worker-kedaautoscaler.yaml
+++ b/templates/workers/worker-kedaautoscaler.yaml
@@ -1,7 +1,9 @@
 ################################
 ## Airflow Worker KEDA Scaler
 #################################
-{{- if (and .Values.workers.keda.enabled (eq .Values.executor "CeleryExecutor")) }}
+{{- $executor := .Values.executor }}
+{{- range .Values.workers }}
+{{- if (and .keda.enabled (eq $executor "CeleryExecutor")) }}
 apiVersion: keda.k8s.io/v1alpha1
 kind: ScaledObject
 metadata:
@@ -19,13 +21,14 @@ metadata:
 spec:
   scaleTargetRef:
     deploymentName: {{ .Release.Name }}-worker
-  pollingInterval:  {{  .Values.workers.keda.pollingInterval }}   # Optional. Default: 30 seconds
-  cooldownPeriod: {{  .Values.workers.keda.cooldownPeriod }}    # Optional. Default: 300 seconds
-  maxReplicaCount: {{ .Values.workers.replicas }}   # Optional. Default: 100
+  pollingInterval:  {{  .keda.pollingInterval }}   # Optional. Default: 30 seconds
+  cooldownPeriod: {{  .keda.cooldownPeriod }}    # Optional. Default: 300 seconds
+  maxReplicaCount: {{ .replicas }}   # Optional. Default: 100
   triggers:
     - type: postgresql
       metadata:
         connection: AIRFLOW_CONN_AIRFLOW_DB
         targetQueryValue: "1"
         query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+{{- end }}
 {{- end }}

--- a/templates/workers/worker-persistentvolume.yaml
+++ b/templates/workers/worker-persistentvolume.yaml
@@ -1,5 +1,7 @@
-{{- $additionalVolume := .Values.workers.additionalVolume }}
-{{- if and $additionalVolume.enabled (eq .Values.executor "CeleryExecutor")}}
+{{- $executor := .Values.executor }}
+{{- range .Values.workers }}
+{{- $additionalVolume := .additionalVolume }}
+{{- if and $additionalVolume.enabled (eq $executor "CeleryExecutor")}}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -23,3 +25,4 @@ spec:
   storageClassName: {{ $additionalVolume.storageClassName }}
 {{- toYaml $additionalVolume.volumePlugin | nindent 2 }}
 {{- end }}
+  {{- end }}

--- a/templates/workers/worker-persistentvolumeclaim.yaml
+++ b/templates/workers/worker-persistentvolumeclaim.yaml
@@ -1,5 +1,7 @@
-{{- $additionalVolume := .Values.workers.additionalVolume }}
-{{- if and $additionalVolume.enabled (eq .Values.executor "CeleryExecutor")}}
+{{- $executor := .Values.executor }}
+{{- range .Values.workers }}
+{{- $additionalVolume := .additionalVolume }}
+{{- if and $additionalVolume.enabled (eq $executor "CeleryExecutor")}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -20,4 +22,5 @@ spec:
   resources:
     requests:
       storage: {{ default "5Gi" $additionalVolume.capacity }}
+{{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -66,7 +66,7 @@ rbacEnabled: true
 
 # Airflow executor
 # Options: SequentialExecutor, LocalExecutor, CeleryExecutor, KubernetesExecutor
-executor: "KubernetesExecutor"
+executor: "CeleryExecutor"
 
 # If this is true and using LocalExecutor/SequentialExecutor/KubernetesExecutor, the scheduler's
 # service account will have access to communicate with the api-server and launch pods.
@@ -151,10 +151,78 @@ fernetKeySecretName: ~
 # Enable security context constraints required for OpenShift
 sccEnabled: false
 
+workerConfig:
+  persistence:
 # Airflow Worker Config
 workers:
   # Number of airflow celery workers in StatefulSet
-  replicas: 1
+- replicas: 1
+  queue: "default"
+  updateStrategy:
+  strategy:
+    rollingUpdate:
+      maxSurge: "100%"
+      maxUnavailable: "50%"
+
+  # Allow KEDA autoscaling.
+  # Persistence.enabled must be set to false to use KEDA.
+  keda:
+    enabled: false
+    namespaceLabels: {}
+
+    # How often KEDA polls the airflow DB to report new scale requests to the HPA
+    pollingInterval: 5
+
+    # How many seconds KEDA will wait before scaling to zero.
+    # Note that HPA has a separate cooldown period for scale-downs
+    cooldownPeriod: 30
+
+  persistence:
+    # Enable persistent volumes
+    enabled: false
+    # Volume size for worker StatefulSet
+    size: 100Gi
+    # If using a custom storageClass, pass name ref to all statefulSets here
+    storageClassName:
+    # Execute init container to chown log directory.
+    # This is currently only needed in KinD, due to usage
+    # of local-path provisioner.
+    fixPermissions: false
+
+  # Attach additional volume to celery workers (such as a shared file system)
+  additionalVolume:
+    enabled: false
+    volumeMode: ~
+    accessMode: ~
+    capacity: ~
+    storageClassName:
+    mountPath: ~
+    volumePlugin: {}
+
+  resources: {}
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+  # Grace period for tasks to finish after SIGTERM is sent from kubernetes
+  terminationGracePeriodSeconds: 600
+
+  # Apply a HorizontalPodAutoscaler
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 10
+    targetCPUUtilization: 80
+    targetMemoryUtilization: 80
+
+  # This setting tells kubernetes that its ok to evict
+  # when it wants to scale a node down.
+  safeToEvict: true
+- replicas: 1
+  queue: "long-running"
   updateStrategy:
   strategy:
     rollingUpdate:


### PR DESCRIPTION
This PR allows our helm chart to define an arbitrary number of
Celery/KEDA queues and edit specs for each queue. Users can even
determine whether a specific Queue should have KEDA enabled or not!


## Description

> Describe the purpose of this pull request.

## PR Title

> Please make the PR title informative to the user experience. For example when adding a feature, say "Add metrics tab for Deployments" instead of "Bump Astro-UI to version X.Y.Z". Bugs are sometimes harder to make customer-facing because they are very detailed, but do what you can. Instead of "Fix metrics cardinality bug" (user does not know what 'cardinality' means and does not matter to them), say "Fix bug slowing down the metrics tab". The PR title will be used for the commit message when it's merged, and these commit messages are used to generate customer-facing release notes.

## 🎟 Issue(s)

Resolves astronomer/issues#XXXX

## 🧪  Testing

> What are the main risks associated with this change, and how are they addressed by tests added in this PR?

> Please add helm unit testing, if applicable. The docs are regretfully sparse for helm unit testing, [here](https://github.com/astronomer/helm-unittest/blob/main/DOCUMENT.md) is what we have to work with. In general, these kind of tests can be used for specific assertions like 'when these values are set, the resource ends up looking like XYZ' but not for generalized assertions like 'for all resources, make sure the namespace is not set to the release name'.

> Please also add to the system testing [here](../tests/functional-tests). This kind of testing allows you to connect into any live, running pod to make assertions about how they are operating.

## 📸 Screenshots

> Add screenshots to illustrate the changes, if applicable.

## 📋 Checklist

- [ ] The PR title is informative to the user experience
- [ ] Functional test(s) added
- [ ] Helm chart unit test(s)
