### PR TITLE
Add fsgroup for IAM credentials files

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v1 is Helm 2
 apiVersion: v1
 name: airflow
-version: 0.18.5
+version: 0.18.6
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://www.astronomer.io/static/airflowNewA.png
 keywords:

--- a/files/pod-template-file.yaml
+++ b/files/pod-template-file.yaml
@@ -62,6 +62,7 @@ spec:
   restartPolicy: Never
   securityContext:
     runAsUser: {{ .Values.uid }}
+    fsGroup: {{ .Values.gid }}
   nodeSelector: {{ toYaml .Values.nodeSelector | nindent 4 }}
   affinity: {{ toYaml .Values.affinity | nindent 4 }}
   tolerations: {{ toYaml .Values.tolerations | nindent 4 }}


### PR DESCRIPTION
## Description
Per @danielhoherd, the [original PR for this ](https://github.com/astronomer/airflow-chart/pull/187) failed CI checks due to it coming from a fork instead of a branch. Daniel created a new branch; this is a PR on that. 

Add fsGroup to the Kubernetes Pod Template definition. The current pod operator template overrides any template from the airflow image and if an IAM credential exists it won't be added with the proper ownership causing issues with it being accessed by the pod
## PR Title


## 🎟 Issue(s)
Resolves https://github.com/astronomer/issues/issues/2587
and https://github.com/astronomer/issues/issues/2100


## 📋 Checklist

- [x] The PR title is informative to the user experience
- [ ] Functional test(s) added
- [ ] Helm chart unit test(s)
