### PR TITLE
Use defaultImageTag for k8s workers

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -88,7 +88,7 @@ data:
     airflow_configmap = {{ include "airflow_config" . }}
     airflow_local_settings_configmap = {{ include "airflow_config" . }}
     worker_container_repository = {{ .Values.images.airflow.repository }}
-    worker_container_tag = {{ .Values.images.airflow.tag }}
+    worker_container_tag = {{ default .Values.defaultAirflowTag .Values.images.airflow.tag }}
     worker_container_image_pull_policy = {{ .Values.images.airflow.pullPolicy }}
     dags_in_image = True
     delete_worker_pods = True

--- a/tests/configmap_test.yaml
+++ b/tests/configmap_test.yaml
@@ -7,3 +7,18 @@ tests:
     asserts:
       - isKind:
           of: ConfigMap
+  - it: honors default image tag
+    set:
+      defaultAirflowTag: hello
+    asserts:
+      - matchRegex:
+          path: data.airflow\.cfg
+          pattern: "worker_container_tag = hello"
+  - it: uses images.airflow.tag over default
+    set:
+      images.airflow.tag: world
+      defaultAirflowTag: hello
+    asserts:
+      - matchRegex:
+          path: data.airflow\.cfg
+          pattern: "worker_container_tag = world"


### PR DESCRIPTION
This change uses the same logic for determining image tag on k8s workers
as is used for other Airflow components (e.g. the scheduler).