### PR TITLE
Change the default airflow version/tag to 2.0.0

### DIFF
--- a/bin/run-ci
+++ b/bin/run-ci
@@ -100,6 +100,16 @@ else
   exit 1
 fi
 
+export SCHEDULER_DEPLOYMENT=$(kubectl get deployments -n airflow | grep scheduler |  awk '{ print $1 }')
+AIRFLOW_IMAGE=$(kubectl get deployment/$SCHEDULER_DEPLOYMENT -n airflow -o jsonpath="{$.spec.template.spec.initContainers[0].image}")
+export AIRFLOW_IMAGE
+echo "Airflow Image: $AIRFLOW_IMAGE"
+
+docker pull "$AIRFLOW_IMAGE"
+AIRFLOW_VERSION=$(docker inspect --format '{{ index .Config.Labels "io.astronomer.docker.airflow.version" }}' "$AIRFLOW_IMAGE")
+export AIRFLOW_VERSION
+echo "Airflow Version: $AIRFLOW_VERSION"
+
 pip3 install virtualenv
 virtualenv --python=python3 /tmp/venv
 source /tmp/venv/bin/activate

--- a/values.yaml
+++ b/values.yaml
@@ -74,13 +74,13 @@ executor: "KubernetesExecutor"
 allowPodLaunching: true
 
 # Airflow version
-airflowVersion: 1.10.10
+airflowVersion: 2.0.0
 
 # Default airflow repository
 defaultAirflowRepository: quay.io/astronomer/ap-airflow
 
 # Default airflow tag to deploy
-defaultAirflowTag: 1.10.10-buster
+defaultAirflowTag: 2.0.0-buster
 
 # Astronomer Airflow images
 images:


### PR DESCRIPTION
Our new users should use performance improvements in 2.0.0 instead of 1.10.x.

We could also update it to 2.0.1 -- I didn't to avoid accidental update for chart + platform users since we had a bug regarding >= 2.0.0

Resolves astronomer/issues#2722

