### PR TITLE
Update redis-statefulset.yaml to run as non-root

### DIFF
--- a/templates/redis/redis-statefulset.yaml
+++ b/templates/redis/redis-statefulset.yaml
@@ -36,6 +36,8 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         {{- end }}
     spec:
+      securityContext:
+        RunAsUser: 999
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
       affinity:

--- a/templates/redis/redis-statefulset.yaml
+++ b/templates/redis/redis-statefulset.yaml
@@ -37,7 +37,7 @@ spec:
         {{- end }}
     spec:
       securityContext:
-        RunAsUser: 999
+        runAsUser: 999
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
       affinity:


### PR DESCRIPTION
## Description

It's best practice to run the service as non-root. Some cluster enforce this as a matter of policy.
UID 999 is already present in the docker image.

## PR Title

Add RunAsUser to the Redis statefulset.

## 🎟 Issue(s)

No issue logged for this, I can log it if needed.

## 🧪  Testing

> What are the main risks associated with this change, and how are they addressed by tests added in this PR?

Pods from the generated Statefulset is working as non-root user.