### PR TITLE
Update docker images. Bump some versions. Auto-formatting.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
       - run:
           name: Install Airflow chart
           command: |
-            pyenv global 3.8.5
+            pyenv global 3.9.1
             export KUBE_VERSION=<< parameters.kube_version >>
             export EXECUTOR=<< parameters.executor >>
             HELM_CHART_PATH=$(find /tmp/workspace/ -name 'airflow-*.tgz')

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
 
   build-and-release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2021-03
+      - image: quay.io/astronomer/ci-helm-release:2021-04
     steps:
       - checkout
       - run:
@@ -106,7 +106,7 @@ jobs:
 
   release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2021-03
+      - image: quay.io/astronomer/ci-helm-release:2021-04
     steps:
       - checkout
       - run:
@@ -115,7 +115,7 @@ jobs:
 
   copy-release-from-internal-to-prod:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2021-03
+      - image: quay.io/astronomer/ci-helm-release:2021-04
     steps:
       - checkout
       - publish-github-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ workflows:
           matrix:
             parameters:
               # https://hub.docker.com/r/kindest/node/tags
-              kube_version: ["1.16.15", "1.17.11", "1.18.8", "1.19.4"]
+              kube_version: ["1.16.15", "1.17.17", "1.18.15", "1.19.7"]
               executor: ["CeleryExecutor", "LocalExecutor", "KubernetesExecutor"]
           requires:
           - build-and-release-internal
@@ -41,7 +41,7 @@ workflows:
 jobs:
   lint:
     docker:
-      - image: alpine/helm:3.2.4
+      - image: alpine/helm:3.5.3
     steps:
       - checkout
       - run:
@@ -50,7 +50,7 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: alpine/helm:3.2.4
+      - image: alpine/helm:3.5.3
         entrypoint: /bin/sh
     steps:
       - checkout
@@ -66,7 +66,7 @@ jobs:
 
   build-and-release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2020-11-03
+      - image: quay.io/astronomer/ci-helm-release:2021-03
     steps:
       - checkout
       - run:
@@ -79,7 +79,8 @@ jobs:
 
   airflow-test:
     machine:
-      image: ubuntu-2004:202008-01
+      # https://circleci.com/docs/2.0/configuration-reference/#available-machine-images
+      image: ubuntu-2004:202101-01
       resource_class: large
     parameters:
       executor:
@@ -105,7 +106,7 @@ jobs:
 
   release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2020-11-03
+      - image: quay.io/astronomer/ci-helm-release:2021-03
     steps:
       - checkout
       - run:
@@ -114,7 +115,7 @@ jobs:
 
   copy-release-from-internal-to-prod:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2020-11-03
+      - image: quay.io/astronomer/ci-helm-release:2021-03
     steps:
       - checkout
       - publish-github-release

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: check-case-conflict
       - id: check-executables-have-shebangs
@@ -29,7 +29,7 @@ repos:
       - id: sort-simple-yaml
       - id: trailing-whitespace
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.0
     hooks:
       - id: flake8
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ---
-exclude: '(venv|.vscode)'  # regex
+exclude: '^(venv|\.vscode)' # regex
 repos:
   - repo: https://github.com/psf/black
     rev: 20.8b1
@@ -15,17 +15,17 @@ repos:
       - id: check-toml
       - id: check-xml
       - id: check-yaml
-        args: ['--allow-multiple-documents']
-        exclude: '(charts|templates|files)'
+        args: ["--allow-multiple-documents"]
+        exclude: "(charts|templates|files)"
       - id: detect-private-key
       - id: end-of-file-fixer
       - id: file-contents-sorter
-        args: ['--ignore-case']
-        files: .gitignore
+        args: ["--ignore-case", "--unique"]
+        files: '^\.gitignore$'
       - id: no-commit-to-branch
-        args: ['-b', 'master']
+        args: ["-b", "master"]
       - id: mixed-line-ending
-        args: ['--fix=lf']
+        args: ["--fix=lf"]
       - id: sort-simple-yaml
       - id: trailing-whitespace
   - repo: https://gitlab.com/pycqa/flake8

--- a/tests/scheduler_scheduler-deployment_test.yaml
+++ b/tests/scheduler_scheduler-deployment_test.yaml
@@ -17,7 +17,7 @@ tests:
           value: 2
   - it: "should create one scheduler if replicas is not specified"
     set:
-        replicas: ~
+      replicas: ~
     asserts:
       - equal:
           path: spec.replicas

--- a/tests/webserver_webserver-deployment_test.yaml
+++ b/tests/webserver_webserver-deployment_test.yaml
@@ -42,4 +42,3 @@ tests:
       - equal:
           path: spec.strategy.rollingUpdate.maxUnavailable
           value: 0
-

--- a/values.yaml
+++ b/values.yaml
@@ -94,15 +94,15 @@ images:
     pullPolicy: IfNotPresent
   redis:
     repository: quay.io/astronomer/ap-redis
-    tag: 0.11.0
+    tag: 6.2.1
     pullPolicy: IfNotPresent
   pgbouncer:
     repository: quay.io/astronomer/ap-pgbouncer
-    tag: 0.11.0
+    tag: 1.8.1
     pullPolicy: IfNotPresent
   pgbouncerExporter:
     repository: quay.io/astronomer/ap-pgbouncer-exporter
-    tag: 0.11.0
+    tag: 0.9.2
     pullPolicy: IfNotPresent
 
 # Environment variables for all airflow containers
@@ -242,19 +242,19 @@ scheduler:
   #   cpu: 100m
   #   memory: 128Mi
 
-  affinity: 
+  affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-            - key: component
-              operator: In
-              values:
-              - scheduler
-          topologyKey: "kubernetes.io/hostname"
-          
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                    - scheduler
+            topologyKey: "kubernetes.io/hostname"
+
   # This setting can overwrite
   # podMutation settings - be sure
   # to reference the default if you
@@ -293,7 +293,8 @@ webserver:
   # Number of webservers
   replicas: 1
 
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -319,7 +320,8 @@ webserver:
 
 # Flower settings
 flower:
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -330,7 +332,8 @@ flower:
 # Statsd settings
 statsd:
   enabled: true
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -360,7 +363,8 @@ pgbouncer:
     config:
       maxUnavailable: 1
 
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -375,11 +379,11 @@ pgbouncer:
   # TLS connection is always requested first from PostgreSQL, when refused connection will be established
   # over plain TCP. Server certificate is not validated.
   serverTlsSslmode: prefer
-  
+
   # ability to add more custom pgbouncer configuration
-  extraIniDatabaseMetatdata: ''
-  extraIniDatabaseResultBackend: ''
-  extraIniPgbouncerConfig: ''
+  extraIniDatabaseMetatdata: ""
+  extraIniDatabaseResultBackend: ""
+  extraIniPgbouncerConfig: ""
 redis:
   terminationGracePeriodSeconds: 600
 
@@ -416,7 +420,8 @@ redis:
 registry:
   secretName: ~
 
-  connection: {}
+  connection:
+    {}
     # user: ~
     # pass: ~
     # host: ~


### PR DESCRIPTION
The main purpose of this PR is to bump the docker images in values.yaml to use the latest images that have the latest security fixes. See https://github.com/astronomer/issues/issues/2702

- Bumped version of astronomer images in values.yaml
- Bumped CI kind versions to newer patch releases
- Bumped CircleCI machine image of ubuntu, and its version of python
- Bumped CI version of helm
- Bumped to latest ci-helm-release image
- `pre-commit autoupdate` and improve some configs, which is in line with what is being used elsewhere
- Auto-applied `prettier` formatting to some files via vscode plugin

I have deployed this version of the chart to dev as `airflowChartVersion: 0.18.7-build9321` <https://github.com/astronomer/google-environments/commit/f031e1af3ae25b2bb96211379add8450a83099ec>