### PR TITLE
Add pgbouncer.networkPolicies.enabled flag

### DIFF
--- a/files/README.md
+++ b/files/README.md
@@ -1,0 +1,1 @@
+This dir is used for templates that need to be rendered, but are not meant to be submitted directly to k8s as manifests.

--- a/templates/pgbouncer/pgbouncer-networkpolicy.yaml
+++ b/templates/pgbouncer/pgbouncer-networkpolicy.yaml
@@ -1,7 +1,7 @@
 ################################
 ## Pgbouncer NetworkPolicy
 #################################
-{{- if .Values.networkPolicies.enabled }}
+{{- if and .Values.networkPolicies.enabled .Values.pgbouncer.networkPolicies.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/templates/pgbouncer/pgbouncer-networkpolicy.yaml
+++ b/templates/pgbouncer/pgbouncer-networkpolicy.yaml
@@ -1,7 +1,7 @@
 ################################
 ## Pgbouncer NetworkPolicy
 #################################
-{{- if and .Values.networkPolicies.enabled .Values.pgbouncer.networkPolicies.enabled }}
+{{- if and  .Values.pgbouncer.enabled .Values.networkPolicies.enabled .Values.pgbouncer.networkPolicies.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/tests/pgbouncer_pgbouncer-networkpolicy_test.yaml
+++ b/tests/pgbouncer_pgbouncer-networkpolicy_test.yaml
@@ -3,9 +3,40 @@ suite: Test templates/pgbouncer/pgbouncer-networkpolicy.yaml
 templates:
   - templates/pgbouncer/pgbouncer-networkpolicy.yaml
 tests:
-  - it: should work
+  - it: "should work with pgbouncer.enabled: True, networkPolicies.enabled: True"
     set:
+      pgbouncer.enabled: True
       networkPolicies.enabled: true
     asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: NetworkPolicy
+
+  - it: "should work with pgbouncer.enabled: True, networkPolicies.enabled: False"
+    set:
+      pgbouncer.enabled: True
+      networkPolicies.enabled: False
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: "should work with pgbouncer.enabled: True, networkPolicies.enabled: True, pgbouncer.networkPolicies.enabled: False"
+    set:
+      pgbouncer.enabled: True
+      networkPolicies.enabled: True
+      pgbouncer.networkPolicies.enabled: False
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: "should work with pgbouncer.enabled: True, networkPolicies.enabled: True, pgbouncer.networkPolicies.enabled: True"
+    set:
+      pgbouncer.enabled: True
+      networkPolicies.enabled: True
+      pgbouncer.networkPolicies.enabled: True
+    asserts:
+      - hasDocuments:
+          count: 1
       - isKind:
           of: NetworkPolicy

--- a/tests/pod-template-file_test.yaml
+++ b/tests/pod-template-file_test.yaml
@@ -1,7 +1,11 @@
 ---
+# files/pod-template-file.yaml file must be copied from files in order to be
+# tested, but must remain in files/ so it is not submitted directly to k8s
+# when doing a helm install.
+
 suite: Test templates/pod-template-file.yaml
 templates:
-  - pod-template-file.yaml
+  - templates/pod-template-file.yaml
 tests:
   - it: should work
     asserts:

--- a/values.yaml
+++ b/values.yaml
@@ -155,7 +155,7 @@ sccEnabled: false
 workers:
   # Number of airflow celery workers in StatefulSet
   replicas: 1
-  updateStrategy:
+  updateStrategy: ~
   strategy:
     rollingUpdate:
       maxSurge: "100%"
@@ -242,19 +242,19 @@ scheduler:
   #   cpu: 100m
   #   memory: 128Mi
 
-  affinity: 
+  affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-            - key: component
-              operator: In
-              values:
-              - scheduler
-          topologyKey: "kubernetes.io/hostname"
-          
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                    - scheduler
+            topologyKey: "kubernetes.io/hostname"
+
   # This setting can overwrite
   # podMutation settings - be sure
   # to reference the default if you
@@ -293,7 +293,8 @@ webserver:
   # Number of webservers
   replicas: 1
 
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -319,7 +320,8 @@ webserver:
 
 # Flower settings
 flower:
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -330,7 +332,8 @@ flower:
 # Statsd settings
 statsd:
   enabled: true
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -340,8 +343,9 @@ statsd:
 
 # Pgbouncer settings
 pgbouncer:
-  # Enable pgbouncer
   enabled: false
+  networkPolicies:
+    enabled: true
   # additional network policies as needed
   extraNetworkPolicies: []
 
@@ -360,7 +364,8 @@ pgbouncer:
     config:
       maxUnavailable: 1
 
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -375,11 +380,11 @@ pgbouncer:
   # TLS connection is always requested first from PostgreSQL, when refused connection will be established
   # over plain TCP. Server certificate is not validated.
   serverTlsSslmode: prefer
-  
+
   # ability to add more custom pgbouncer configuration
-  extraIniDatabaseMetatdata: ''
-  extraIniDatabaseResultBackend: ''
-  extraIniPgbouncerConfig: ''
+  extraIniDatabaseMetatdata: ""
+  extraIniDatabaseResultBackend: ""
+  extraIniPgbouncerConfig: ""
 redis:
   terminationGracePeriodSeconds: 600
 
@@ -416,7 +421,8 @@ redis:
 registry:
   secretName: ~
 
-  connection: {}
+  connection:
+    {}
     # user: ~
     # pass: ~
     # host: ~


### PR DESCRIPTION
* Add pgbouncer.networkPolicies.enabled flag
* Document pod-template-file behavior
* Auto-format via vscode 'prettier' plugin

This should solve https://github.com/astronomer/issues/issues/2516

I've verified that the new tests pass in the quintush fork of helm-unittest which we plan on switching to.