### PR TITLE
Add extraInitContainers and git-sync example

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ extraObjects:
               restartPolicy: OnFailure
 ```
 
-## git-sync
+## Deploying DAGs using `git-sync`
 
 `extraObjects`, `extraContainers`, `extraInitContainers`, `extraVolumes`, and `extraVolumeMounts` can be combined to deploy git-sync. The following example relies on `emptyDir` volumes and works with `KubernetesExecutor`.
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ The following tables lists the configurable parameters of the Airflow chart and 
 | `workers.persistence.enabled`                         | Enable log persistence in workers via StatefulSet                                                            | `false`                                           |
 | `workers.persistence.size`                            | Size of worker volumes if enabled                                                                            | `100Gi`                                           |
 | `workers.persistence.storageClassName`                | StorageClass worker volumes should use if enabled                                                            | `default`                                         |
+| `workers.extraInitContainers`                         | Extra init containers for workers, including `pod_template_file`                                             | `[]`                                              |
 | `workers.extraVolumes`                                | Extra volumes for workers, including `pod_template_file`                                                     | `[]`                                              |
 | `workers.extraVolumeMounts`                           | Extra volume mounts for workers, including `pod_template_file`                                               | `[]`                                              |
 | `workers.resources.limits.cpu`                        | CPU Limit of workers                                                                                         | `~`                                               |
@@ -174,9 +175,10 @@ The following tables lists the configurable parameters of the Airflow chart and 
 | `scheduler.resources.requests.memory`                 | Memory Request of scheduler                                                                                  | `~`                                               |
 | `scheduler.airflowLocalSettings`                      | Custom Airflow local settings python file                                                                    | `~`                                               |
 | `scheduler.safeToEvict`                               | Allow Kubernetes to evict scheduler pods if needed (node downscaling)                                        | `true`                                            |
+| `scheduler.extraContainers`                           | Extra containers for the scheduler                                                                           | `[]`                                              |
+| `scheduler.extraInitContainers`                       | Extra init containers for the scheduler                                                                      | `[]`                                              |
 | `scheduler.extraVolumes`                              | Extra volumes for the scheduler                                                                              | `[]`                                              |
 | `scheduler.extraVolumeMounts`                         | Extra volume mounts for the scheduler                                                                        | `[]`                                              |
-| `scheduler.extraContainers`                           | Add additional containers to scheduler pod(s)                                                                | `[]`                                              |
 | `webserver.livenessProbe.initialDelaySeconds`         | Webserver LivenessProbe initial delay                                                                        | `15`                                              |
 | `webserver.livenessProbe.timeoutSeconds`              | Webserver LivenessProbe timeout seconds                                                                      | `30`                                              |
 | `webserver.livenessProbe.failureThreshold`            | Webserver LivenessProbe failure threshold                                                                    | `20`                                              |
@@ -328,6 +330,81 @@ extraObjects:
                 args:
                 - hello
               restartPolicy: OnFailure
+```
+
+## git-sync
+
+`extraObjects`, `extraContainers`, `extraInitContainers`, `extraVolumes`, and `extraVolumeMounts` can be combined to deploy git-sync. The following example relies on `emptyDir` volumes and works with `KubernetesExecutor`.
+
+```yaml
+env:
+  - name: AIRFLOW__CORE__DAGS_FOLDER
+    value: /usr/local/airflow/dags/dags/airflow/example_dags
+scheduler:
+  extraInitContainers:
+    - name: init-gitsync
+      image: k8s.gcr.io/git-sync/git-sync:v3.2.2
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: GIT_SYNC_REPO
+          value: https://github.com/apache/airflow.git
+        - name: GIT_SYNC_ROOT
+          value: /usr/local/airflow/dags
+        - name: GIT_SYNC_DEST
+          value: dags
+        - name: GIT_SYNC_ONE_TIME
+          value: "true"
+      volumeMounts:
+        - mountPath: /usr/local/airflow/dags
+          name: dags
+          readOnly: false
+  extraContainers:
+    - name: gitsync
+      image: k8s.gcr.io/git-sync/git-sync:v3.2.2
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: GIT_SYNC_REPO
+          value: https://github.com/apache/airflow.git
+        - name: GIT_SYNC_ROOT
+          value: /usr/local/airflow/dags
+        - name: GIT_SYNC_DEST
+          value: dags
+        - name: GIT_SYNC_WAIT
+          value: "10"
+      volumeMounts:
+        - mountPath: /usr/local/airflow/dags
+          name: dags
+          readOnly: false
+  extraVolumeMounts:
+    - name: dags
+      mountPath: /usr/local/airflow/dags
+  extraVolumes:
+    - name: dags
+      emptyDir: {}
+workers:
+  extraInitContainers:
+    - name: gitsync
+      image: k8s.gcr.io/git-sync/git-sync:v3.2.2
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: GIT_SYNC_REPO
+          value: https://github.com/apache/airflow.git
+        - name: GIT_SYNC_ROOT
+          value: /usr/local/airflow/dags
+        - name: GIT_SYNC_DEST
+          value: dags
+        - name: GIT_SYNC_ONE_TIME
+          value: "true"
+      volumeMounts:
+        - mountPath: /usr/local/airflow/dags
+          name: dags
+          readOnly: false
+  extraVolumeMounts:
+    - name: dags
+      mountPath: /usr/local/airflow/dags
+  extraVolumes:
+    - name: dags
+      emptyDir: {}
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -334,12 +334,12 @@ extraObjects:
 
 ## Deploying DAGs using `git-sync`
 
-`extraObjects`, `extraContainers`, `extraInitContainers`, `extraVolumes`, and `extraVolumeMounts` can be combined to deploy git-sync. The following example relies on `emptyDir` volumes and works with `KubernetesExecutor`.
+`extraContainers`, `extraInitContainers`, `extraVolumes`, and `extraVolumeMounts` can be combined to deploy git-sync. The following example relies on `emptyDir` volumes and works with `KubernetesExecutor`.
 
 ```yaml
 env:
   - name: AIRFLOW__CORE__DAGS_FOLDER
-    value: /usr/local/airflow/dags/dags/airflow/example_dags
+    value: /usr/local/airflow/dags/latest/airflow/example_dags
 scheduler:
   extraInitContainers:
     - name: init-gitsync
@@ -351,7 +351,7 @@ scheduler:
         - name: GIT_SYNC_ROOT
           value: /usr/local/airflow/dags
         - name: GIT_SYNC_DEST
-          value: dags
+          value: latest
         - name: GIT_SYNC_ONE_TIME
           value: "true"
       volumeMounts:
@@ -368,7 +368,7 @@ scheduler:
         - name: GIT_SYNC_ROOT
           value: /usr/local/airflow/dags
         - name: GIT_SYNC_DEST
-          value: dags
+          value: latest
         - name: GIT_SYNC_WAIT
           value: "10"
       volumeMounts:
@@ -392,7 +392,7 @@ workers:
         - name: GIT_SYNC_ROOT
           value: /usr/local/airflow/dags
         - name: GIT_SYNC_DEST
-          value: dags
+          value: latest
         - name: GIT_SYNC_ONE_TIME
           value: "true"
       volumeMounts:

--- a/files/pod-template-file.yaml
+++ b/files/pod-template-file.yaml
@@ -22,6 +22,10 @@ metadata:
     platform: "{{ .Values.platform.release }}"
     workspace: "{{ .Values.platform.workspace }}"
 spec:
+{{- if .Values.workers.extraInitContainers }}
+  initContainers:
+{{- toYaml .Values.workers.extraInitContainers | nindent 4 }}
+{{- end }}
   containers:
     - args: []
       name: "base"

--- a/templates/scheduler/scheduler-deployment.yaml
+++ b/templates/scheduler/scheduler-deployment.yaml
@@ -85,6 +85,9 @@ spec:
           args: ["airflow-migration-spinner", "--timeout=60"]
           env:
       {{- include "standard_airflow_environment" . | indent 10 }}
+{{- if .Values.scheduler.extraInitContainers }}
+{{- toYaml .Values.scheduler.extraInitContainers | nindent 8 }}
+{{- end }}
       containers:
         # Always run the main scheduler container.
         - name: scheduler

--- a/templates/workers/worker-deployment.yaml
+++ b/templates/workers/worker-deployment.yaml
@@ -89,6 +89,9 @@ spec:
           args: ["airflow-migration-spinner", "--timeout=60"]
           env:
           {{- include "standard_airflow_environment" . | indent 10 }}
+{{- if .Values.workers.extraInitContainers }}
+{{- toYaml .Values.workers.extraInitContainers | nindent 8 }}
+{{- end }}
       containers:
         - name: worker
           image: {{ template "airflow_image" . }}

--- a/tests/pod-template-file_test.yaml
+++ b/tests/pod-template-file_test.yaml
@@ -39,9 +39,8 @@ tests:
           content:
             name: test-volume
             mountPath: /opt/test
-  - it: "should add extraContainer"
+  - it: "should add extraContainers"
     set:
-      executor: KubernetesExecutor
       workers:
         extraContainers:
           - name: test
@@ -50,6 +49,20 @@ tests:
     asserts:
       - contains:
           path: spec.containers
+          content:
+            name: test
+            image: test/image:tag
+            imagePullPolicy: IfNotPresent
+  - it: "should add extraInitContainer"
+    set:
+      workers:
+        extraInitContainers:
+          - name: test
+            image: test/image:tag
+            imagePullPolicy: IfNotPresent
+    asserts:
+      - contains:
+          path: spec.initContainers
           content:
             name: test
             image: test/image:tag

--- a/tests/scheduler_scheduler-deployment_test.yaml
+++ b/tests/scheduler_scheduler-deployment_test.yaml
@@ -17,7 +17,7 @@ tests:
           value: 2
   - it: "should create one scheduler if replicas is not specified"
     set:
-        replicas: ~
+      replicas: ~
     asserts:
       - equal:
           path: spec.replicas
@@ -55,7 +55,7 @@ tests:
           content:
             name: test-volume
             mountPath: /opt/test
-  - it: "should add extraContainer"
+  - it: "should add extraContainers"
     set:
       executor: CeleryExecutor
       scheduler:
@@ -66,6 +66,20 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers
+          content:
+            name: test
+            image: test/image:tag
+            imagePullPolicy: IfNotPresent
+  - it: "should add extraInitContainers"
+    set:
+      scheduler:
+        extraInitContainers:
+          - name: test
+            image: test/image:tag
+            imagePullPolicy: IfNotPresent
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
           content:
             name: test
             image: test/image:tag

--- a/tests/workers_worker-deployment_test.yaml
+++ b/tests/workers_worker-deployment_test.yaml
@@ -62,7 +62,7 @@ tests:
           content:
             name: test-volume
             mountPath: /opt/test
-  - it: "should add extraContainer"
+  - it: "should add extraContainers"
     set:
       executor: CeleryExecutor
       workers:
@@ -73,6 +73,21 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers
+          content:
+            name: test
+            image: test/image:tag
+            imagePullPolicy: IfNotPresent
+  - it: "should add extraInitContainer"
+    set:
+      executor: CeleryExecutor
+      workers:
+        extraInitContainers:
+          - name: test
+            image: test/image:tag
+            imagePullPolicy: IfNotPresent
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
           content:
             name: test
             image: test/image:tag

--- a/values.yaml
+++ b/values.yaml
@@ -226,6 +226,9 @@ workers:
   # Add additional containers to workers.
   extraContainers: []
 
+  # Add additional init containers to workers.
+  extraInitContainers: []
+
 # Airflow scheduler settings
 scheduler:
   livenessProbe:
@@ -267,6 +270,9 @@ scheduler:
 
   # Add additional containers to scheduler.
   extraContainers: []
+
+  # Add additional init containers to scheduler.
+  extraInitContainers: []
 
   # Number of schedulers to run
   replicas: 1


### PR DESCRIPTION
This adds the ability to provide extra init containers for both the scheduler and workers. It also provides a working example of git-sync.