### PR TITLE
Doc: Chart: Update the docs to create Kind cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,11 +326,11 @@ helm install airflow \
 
 **Install kind, and create a cluster:**
 
-We recommend testing with Kubernetes 1.15, as this image doesn't support Kubernetes 1.16+ for CeleryExecutor presently.
+We recommend testing with Kubernetes 1.16+, example:
 
 ```
 kind create cluster \
-  --image kindest/node:v1.15.7@sha256:e2df133f80ef633c53c0200114fce2ed5e1f6947477dbc83261a6a921169488d
+  --image kindest/node:v1.18.15
 ```
 
 Confirm it's up:


### PR DESCRIPTION
The old description was outdated. We run with this Helm chart in CI with Kubernetes 1.16+
