### PR TITLE
Add extraVolumes and extraVolumeMounts options to webserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ The following tables lists the configurable parameters of the Airflow chart and 
 | `webserver.resources.requests.memory`                 | Memory Request of webserver                                                                               | `~`                                                               |    |
 | `webserver.jwtSigningCertificateSecretName`           | Name of secret to mount Airflow Webserver JWT singing certificate from                                    | `~`                                                               |    |
 | `webserver.defaultUser`                               | Optional default airflow user information                                                                 | `{}`                                                              |    |
+| `webserver.extraVolumes`                              | Extra volumes for the webserver                                                                           | `[]`                                                              |    |
+| `webserver.extraVolumeMounts`                         | Extra volume mounts for the webserver                                                                     | `[]`                                                              |    |
 | `extraObjects`                                        | Extra K8s Objects to deploy (these are passed through `tpl`). More about [Extra Objects](#extra-objects). | `[]`                                                              |    |
 | `webserver.extraContainers`                           | Add additional containers to webserver pod(s)                                                             | `[]`                                                              |    |
 

--- a/templates/webserver/webserver-deployment.yaml
+++ b/templates/webserver/webserver-deployment.yaml
@@ -100,6 +100,9 @@ spec:
               mountPath: {{ template "airflow_webserver_jwt_cert_dir" . }}
               readOnly: true
 {{- end }}
+{{- if .Values.webserver.extraVolumeMounts }}
+{{ toYaml .Values.webserver.extraVolumeMounts | indent 12 }}
+{{- end }}
           ports:
             - name: webserver-ui
               containerPort: {{ .Values.ports.airflowUI }}
@@ -140,3 +143,7 @@ spec:
           secret:
             secretName: {{ .Values.webserver.jwtSigningCertificateSecretName }}
 {{- end }}
+{{- if .Values.webserver.extraVolumes }}
+{{ toYaml .Values.webserver.extraVolumes | indent 8 }}
+{{- end }}
+

--- a/tests/webserver_webserver-deployment_test.yaml
+++ b/tests/webserver_webserver-deployment_test.yaml
@@ -42,3 +42,27 @@ tests:
       - equal:
           path: spec.strategy.rollingUpdate.maxUnavailable
           value: 0
+  - it: should have extraVolumes
+    set:
+      webserver:
+        extraVolumes:
+          - name: certificate
+            emptyDir: {}
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: certificate
+            emptyDir: {}
+  - it: should have extraVolumeMounts
+    set:
+      webserver:
+        extraVolumeMounts:
+          - name: certificate
+            mountPath: /certs
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: certificate
+            mountPath: /certs

--- a/values.yaml
+++ b/values.yaml
@@ -299,6 +299,9 @@ webserver:
   # Number of webservers
   replicas: 1
 
+  extraVolumes: []
+  extraVolumeMounts: []
+
   resources:
     {}
     # limits:


### PR DESCRIPTION
## Description

Add `extraVolumes` and `extraVolumeMounts` options to webserver.

Scenario of interest includes being able to mount a client cert/key to authenticate against a remote elasticsearch cluster to display logs.

## 🎟 Issue(s)

Resolves astronomer/issues#XXXX

## 🧪  Testing



## 📸 Screenshots

> Add screenshots to illustrate the changes, if applicable.

## 📋 Checklist

- [ ] The PR title is informative to the user experience
- [ ] Functional test(s) added
- [ ] Helm chart unit test(s)
