### PR TITLE
Allow passing Environment Variables to Flower

### DIFF
--- a/templates/flower/flower-deployment.yaml
+++ b/templates/flower/flower-deployment.yaml
@@ -80,8 +80,7 @@ spec:
               port: {{ .Values.ports.flowerUI }}
             initialDelaySeconds: 10
             periodSeconds: 5
-          env:
-          {{- include "standard_airflow_environment" . | indent 10 }}
+          {{- include "airflow_environment_variables" . | indent 10 }}
       volumes:
         - name: config
           configMap:

--- a/tests/flower_flower-deployment_test.yaml
+++ b/tests/flower_flower-deployment_test.yaml
@@ -25,3 +25,16 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].args
           value: ["airflow", "celery", "flower"]
+  - it: "should run with customs envs passed through"
+    set:
+      executor: CeleryExecutor
+      airflowVersion: "2.0.0"
+      env:
+        - name: FLOWER_PURGE_OFFLINE_WORKERS
+          value: "300"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FLOWER_PURGE_OFFLINE_WORKERS
+            value: "300"

--- a/tests/workers_worker-deployment_test.yaml
+++ b/tests/workers_worker-deployment_test.yaml
@@ -26,19 +26,19 @@ tests:
             path: deployment.spec.strategy.rollingUpdate.maxUnavailable
             value: "50%"
   - it: "should add correct updateStrategy for Worker StatefulSet"
-      set:
-        persistence:
-          enabled: true
-        workers:
-          updateStrategy:
-            rollingUpdate:
-              partition: 0
-        asserts:
-          - isKind:
-              of: StatefulSet
-          - equal:
-              path: deployment.spec.updateStrategy.rollingUpdate.partition
-              value: 0
+    set:
+      persistence:
+        enabled: true
+      workers:
+        updateStrategy:
+          rollingUpdate:
+            partition: 0
+      asserts:
+        - isKind:
+            of: StatefulSet
+        - equal:
+            path: deployment.spec.updateStrategy.rollingUpdate.partition
+            value: 0
   - it: "should run the correct worker command for airflow 1.x"
     set:
       executor: CeleryExecutor


### PR DESCRIPTION
closes https://github.com/astronomer/issues/issues/1897

Use can now pass the following in `.Values.env`:

```
FLOWER_PURGE_OFFLINE_WORKERS=300
```

Until now these vars were only passed to Airflow Pods (scheduler, webserver & workers)

