### PR TITLE
Add support for using an external Celery broker

### DIFF
--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -32,7 +32,7 @@
   - name: AIRFLOW__CELERY__BROKER_URL
     valueFrom:
       secretKeyRef:
-        name: {{ .Release.Name }}-broker-url
+        name: {{ template "airflow_broker_url_secret" . }}
         key: connection
   {{- end }}
   {{- if .Values.elasticsearch.enabled }}
@@ -153,6 +153,10 @@ env:
 
 {{ define "airflow_result_backend_secret" -}}
 {{ default (printf "%s-airflow-result-backend" .Release.Name) .Values.data.resultBackendSecretName }}
+{{- end }}
+
+{{ define "airflow_broker_url_secret" -}}
+{{ default (printf "%s-broker-url" .Release.Name) .Values.data.brokerUrlSecretName }}
 {{- end }}
 
 {{ define "pgbouncer_config_secret" -}}

--- a/templates/redis/redis-networkpolicy.yaml
+++ b/templates/redis/redis-networkpolicy.yaml
@@ -1,7 +1,7 @@
 ################################
 ## Airflow Redis NetworkPolicy
 #################################
-{{- if (and .Values.networkPolicies.enabled (eq .Values.executor "CeleryExecutor")) }}
+{{- if (and .Values.networkPolicies.enabled .Values.redis.enabled (eq .Values.executor "CeleryExecutor")) }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/templates/redis/redis-service.yaml
+++ b/templates/redis/redis-service.yaml
@@ -1,7 +1,7 @@
 ################################
 ## Airflow Redis Service
 #################################
-{{- if eq .Values.executor "CeleryExecutor" }}
+{{- if and .Values.redis.enabled (eq .Values.executor "CeleryExecutor") }}
 kind: Service
 apiVersion: v1
 metadata:

--- a/templates/redis/redis-statefulset.yaml
+++ b/templates/redis/redis-statefulset.yaml
@@ -1,7 +1,7 @@
 ################################
 ## Airflow Redis StatefulSet
 #################################
-{{- if eq .Values.executor "CeleryExecutor" }}
+{{- if and .Values.redis.enabled (eq .Values.executor "CeleryExecutor") }}
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:

--- a/templates/secrets/redis-secrets.yaml
+++ b/templates/secrets/redis-secrets.yaml
@@ -2,8 +2,9 @@
 ## Airflow Redis Password Secret
 #################################
 # If both of these secret names are not set, we will either use the set password, or generate one
-{{- if not (and .Values.redis.passwordSecretName .Values.redis.brokerURLSecretName) }}
+{{- if eq .Values.executor "CeleryExecutor" }}
 {{ $random_redis_password := randAlphaNum 10 }}
+{{- if and .Values.redis.enabled (not .Values.redis.passwordSecretName) }}
 kind: Secret
 apiVersion: v1
 metadata:
@@ -23,6 +24,9 @@ type: Opaque
 data:
   password: {{ (default $random_redis_password .Values.redis.password) | b64enc | quote }}
 ---
+{{- end }}
+{{- if not .Values.data.brokerUrlSecretName }}
+##################################
 ################################
 ## Airflow Redis Connection Secret
 #################################
@@ -40,5 +44,10 @@ metadata:
     "helm.sh/hook-weight": "0"
 type: Opaque
 data:
+  {{- if .Values.redis.enabled }}
   connection: {{ (printf "redis://:%s@%s-redis:6379/0" (default $random_redis_password .Values.redis.password) .Release.Name) | b64enc | quote }}
+  {{- else }}
+  connection: {{ required "`data.brokerUrl` is required if `redis.enabled` is false" .Values.data.brokerUrl | b64enc | quote }}
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/tests/airflow_environment_variables_test.yaml
+++ b/tests/airflow_environment_variables_test.yaml
@@ -1,0 +1,52 @@
+---
+suite: Test templates/workers/worker-deployment.yaml
+templates:
+  - templates/flower/flower-deployment.yaml
+  - templates/scheduler/scheduler-deployment.yaml
+  - templates/workers/worker-deployment.yaml
+  - templates/webserver/webserver-deployment.yaml
+  - templates/create-user-job.yaml
+tests:
+  # By NOT setting a documentIndex on the tests, all the templates get checked
+  - it: should use the default broker url secret
+    set:
+      executor: CeleryExecutor
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AIRFLOW__CELERY__BROKER_URL
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-broker-url
+                key: connection
+  - it: should use the default broker url secret even with a set redis password
+    set:
+      executor: CeleryExecutor
+      redis:
+        password: helloworld
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AIRFLOW__CELERY__BROKER_URL
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-broker-url
+                key: connection
+  - it: should allow a custom broker url secret
+    set:
+      executor: CeleryExecutor
+      redis:
+        enabled: false
+      data:
+        brokerUrlSecretName: helloworld
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AIRFLOW__CELERY__BROKER_URL
+            valueFrom:
+              secretKeyRef:
+                name: helloworld
+                key: connection

--- a/tests/redis_redis-networkpolicy_test.yaml
+++ b/tests/redis_redis-networkpolicy_test.yaml
@@ -10,3 +10,20 @@ tests:
     asserts:
       - isKind:
           of: NetworkPolicy
+  - it: can be disabled
+    set:
+      executor: CeleryExecutor
+      networkPolicies.enabled: true
+      redis:
+        enabled: false
+      data:
+        brokerUrl: redis://example:6379/0
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: shoudn't be created if we aren't using CeleryExecutor
+    set:
+      executor: KubernetesExecutor
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/tests/redis_redis-service_test.yaml
+++ b/tests/redis_redis-service_test.yaml
@@ -9,3 +9,19 @@ tests:
     asserts:
       - isKind:
           of: Service
+  - it: can be disabled
+    set:
+      executor: CeleryExecutor
+      redis:
+        enabled: false
+      data:
+        brokerUrl: redis://example:6379/0
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: shoudn't be created if we aren't using CeleryExecutor
+    set:
+      executor: KubernetesExecutor
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/tests/redis_redis-statefulset_test.yaml
+++ b/tests/redis_redis-statefulset_test.yaml
@@ -9,3 +9,19 @@ tests:
     asserts:
       - isKind:
           of: StatefulSet
+  - it: can be disabled
+    set:
+      executor: CeleryExecutor
+      redis:
+        enabled: false
+      data:
+        brokerUrl: redis://example:6379/0
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: shoudn't be created if we aren't using CeleryExecutor
+    set:
+      executor: KubernetesExecutor
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/tests/secrets_redis-secrets_test.yaml
+++ b/tests/secrets_redis-secrets_test.yaml
@@ -3,13 +3,64 @@ suite: Test templates/secrets/redis-secrets.yaml
 templates:
   - templates/secrets/redis-secrets.yaml
 tests:
-  - it: should work
-    DocumentIndex: 0
+  - it: should create a redis password secret
+    set:
+      executor: CeleryExecutor
+      redis:
+        password: helloworld
+    documentIndex: 0
     asserts:
       - isKind:
           of: Secret
-  - it: should work
-    DocumentIndex: 1
+      # $ echo -n "aGVsbG93b3JsZA==" | base64 -d
+      # helloworld
+      - equal:
+          path: data.password
+          value: aGVsbG93b3JsZA==
+  - it: should create a broker url secret
+    set:
+      executor: CeleryExecutor
+      redis:
+        password: helloworld
+    documentIndex: 1
     asserts:
       - isKind:
           of: Secret
+      # $ echo -n "cmVkaXM6Ly86aGVsbG93b3JsZEBSRUxFQVNFLU5BTUUtcmVkaXM6NjM3OS8w" | base64 -d
+      # redis://:helloworld@RELEASE-NAME-redis:6379/0
+      - equal:
+          path: data.connection
+          value: cmVkaXM6Ly86aGVsbG93b3JsZEBSRUxFQVNFLU5BTUUtcmVkaXM6NjM3OS8w
+  - it: should only create the broker_url secret if redis is disabled
+    set:
+      executor: CeleryExecutor
+      redis:
+        enabled: false
+      data:
+        brokerUrl: redis://example:6379/0
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      # $ echo -n "cmVkaXM6Ly9leGFtcGxlOjYzNzkvMA==" | base64 -d
+      # redis://example:6379/0
+      - equal:
+          path: data.connection
+          value: cmVkaXM6Ly9leGFtcGxlOjYzNzkvMA==
+  - it: should not create any secrets if brokerUrlSecretName is set and redis is disabled
+    set:
+      executor: CeleryExecutor
+      redis:
+        enabled: false
+      data:
+        brokerUrlSecretName: somesecretname
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should not create any secrets if we aren't using CeleryExecutor
+    set:
+      executor: KubernetesExecutor
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/values.yaml
+++ b/values.yaml
@@ -127,6 +127,7 @@ data:
   # If secret names are provided, use those secrets
   metadataSecretName: ~
   resultBackendSecretName: ~
+  brokerUrlSecretName: ~
 
   # Otherwise pass connection values in
   metadataConnection:
@@ -143,6 +144,7 @@ data:
     port: 5432
     db: postgres
     sslmode: disable
+  brokerUrl: ~
 
 # Fernet key settings
 fernetKey: ~
@@ -397,6 +399,7 @@ pgbouncer:
   extraIniDatabaseResultBackend: ""
   extraIniPgbouncerConfig: ""
 redis:
+  enabled: true
   terminationGracePeriodSeconds: 600
 
   persistence:
@@ -417,7 +420,6 @@ redis:
 
   # If set use as redis secret
   passwordSecretName: ~
-  brokerURLSecretName: ~
 
   # Else, if password is set, create secret with it,
   # else generate a new one on install


### PR DESCRIPTION
This allows Redis to be disabled and a separate Celery broker to be
configured in its place with `data.brokerUrl` or
`data.brokerUrlSecretName`.