### PR TITLE
Add double --version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
           name: "Create pre-commit-cache-key.txt"
           command: |
             cp .pre-commit-config.yaml /tmp/pre-commit-cache-key.txt
-            python --version | sed 's/^/# /' >> /tmp/pre-commit-cache-key.txt
+            python --version --version | sed 's/^/# /' >> /tmp/pre-commit-cache-key.txt
       - restore_cache:
           keys:
             - pre-commit-cache-{{ checksum "/tmp/pre-commit-cache-key.txt" }}


### PR DESCRIPTION
`python --version --version` is used for cache because it is more descriptive.

```
$ python --version
Python 3.8.5
$ python --version --version
Python 3.8.5 (default, Jan 27 2021, 15:41:15)
[GCC 9.3.0]
```