### PR TITLE
Deploy redis secrets regardless of executor

### DIFF
--- a/templates/secrets/redis-secrets.yaml
+++ b/templates/secrets/redis-secrets.yaml
@@ -1,8 +1,6 @@
 ################################
 ## Airflow Redis Password Secret
 #################################
-# If both of these secret names are not set, we will either use the set password, or generate one
-{{- if eq .Values.executor "CeleryExecutor" }}
 {{ $random_redis_password := randAlphaNum 10 }}
 {{- if and .Values.redis.enabled (not .Values.redis.passwordSecretName) }}
 kind: Secret
@@ -49,5 +47,4 @@ data:
   {{- else }}
   connection: {{ required "`data.brokerUrl` is required if `redis.enabled` is false" .Values.data.brokerUrl | b64enc | quote }}
   {{- end }}
-{{- end }}
 {{- end }}

--- a/tests/secrets_redis-secrets_test.yaml
+++ b/tests/secrets_redis-secrets_test.yaml
@@ -58,9 +58,9 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-  - it: should not create any secrets if we aren't using CeleryExecutor
+  - it: should create secrets even if we aren't using CeleryExecutor
     set:
       executor: KubernetesExecutor
     asserts:
       - hasDocuments:
-          count: 0
+          count: 2


### PR DESCRIPTION
We will create these secrets (if necessary) _even if_ we aren't
currently using CeleryExecutor. As we are relying on the
"pre-install" hack to prevent changing randomly generated passwords,
updating the executor later doesn't give us the opportunity to
deploy them when we need them. We will always deploy them
defensively to make the executor update path actually work.