### PR TITLE
Only run no-commit-to-branch hook locally

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,8 @@ jobs:
       - run:
           name: Run pre-commit
           command: pre-commit run --all-files || { git --no-pager diff && false ; }
+          environment:
+            SKIP: no-commit-to-branch
 
   lint:
     docker:


### PR DESCRIPTION
We don't need to run no-commit-to-branch on CI as that ends up failing
when we run precommit on master.

Edit: A little more color: That check is really meant to protect against accidents locally.