### PR TITLE
Add fsGroup to webserver deployment securityContext

### DIFF
--- a/templates/webserver/webserver-deployment.yaml
+++ b/templates/webserver/webserver-deployment.yaml
@@ -64,6 +64,7 @@ spec:
       serviceAccountName: {{ .Release.Name }}-webserver-serviceaccount
       securityContext:
         runAsUser: {{ .Values.uid }}
+        fsGroup: {{ .Values.gid }}
       {{- if or .Values.registry.secretName .Values.registry.connection }}
       imagePullSecrets:
         - name: {{ template "registry_secret" . }}


### PR DESCRIPTION
## Description

EKS 1.17 needs a token in the images to enable role assumption. This PR will ensure the token file is under the right group id and has the proper permissions to be accessed.

## PR Title

Add fsGroup to webserver deployment securityContext

## 🎟 Issue(s)

Resolves astronomer/issues#3086

## 📋 Checklist

- [x] The PR title is informative to the user experience
- [ ] Functional test(s) added
- [ ] Helm chart unit test(s)
