### PR TITLE
Fix labels set by pod_mutation_hook

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -159,7 +159,7 @@ data:
             "kubernetes_pod_operator": "False"
         }
 
-        if 'airflow-worker' in pod.labels.keys() or \
+        if 'airflow-worker' in pod.labels.keys() and \
                 conf.get('core', 'EXECUTOR') == "KubernetesExecutor":
             extra_labels["kubernetes_executor"] = "True"
         else:
@@ -181,7 +181,7 @@ data:
         }
 
 
-        if 'airflow-worker' in pod.metadata.labels.keys() or \
+        if 'airflow-worker' in pod.metadata.labels.keys() and \
                 conf.get('core', 'EXECUTOR') == "KubernetesExecutor":
             extra_labels["kubernetes_executor"] = "True"
         else:


### PR DESCRIPTION
Set the proper values for `kubernetes_executor` and
`kubernetes_pod_operator` labels.

This is critical, especially when using 2.0+, KubernetesExecutor, KPO and
`is_delete_operator_pod=False`, as the `kubernetes_executor` label is used
in the completed pod adoption logic in KubernetesExecutor. With the wrong
labels, the executor tries to adopt the task pod.

Before:
```
task:
  kubernetes_executor=True                                                                                                                                                                                
  kubernetes_pod_operator=False

```

After:
```
task:
  kubernetes_executor=False                                                                    
  kubernetes_pod_operator=True 
```

And in both cases workers get:
```
worker:
  kubernetes_executor=True
  kubernetes_pod_operator=False
```