### PR TITLE
Tweak CI. Bump to 0.20.0-rc1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ workflows:
           matrix:
             parameters:
               # https://hub.docker.com/r/kindest/node/tags
-              kube_version: ["1.16.15", "1.17.17", "1.18.15", "1.19.7"]
+              kube_version: ["1.16.15", "1.17.17", "1.18.19", "1.19.11", "1.20.7"]
               executor: ["CeleryExecutor", "LocalExecutor", "KubernetesExecutor"]
           requires:
           - build-and-release-internal
@@ -68,7 +68,7 @@ jobs:
             - ~/.cache/pre-commit
       - run:
           name: Run pre-commit
-          command: pre-commit run --all-files || { git --no-pager diff && false ; }
+          command: pre-commit run --all-files --show-diff-on-failure
           environment:
             SKIP: no-commit-to-branch
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 exclude: '^(venv|\.vscode)' # regex
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.5b1
+    rev: 21.6b0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,8 +1,8 @@
 # apiVersion v1 is Helm 2
 apiVersion: v1
 name: airflow
-version: 0.19.1
-description: Helm chart to deploy the Astronomer Platform Airflow module
+version: 0.20.0-rc1
+description: Airflow component of Astronomer Platform
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:
   - astronomer


### PR DESCRIPTION
- Bump kube_versions to what is supported by Astronomer
- Improve pre-commit run syntax
- Bump `black`
- Improve chart description text
- Bump chart version to 0.20.0-rc1, which will be the first version in the release-0.20 branch