### PR TITLE
Don't serve_logs in Airflow 2's scheduler

### DIFF
--- a/templates/scheduler/scheduler-deployment.yaml
+++ b/templates/scheduler/scheduler-deployment.yaml
@@ -149,9 +149,9 @@ spec:
           volumeMounts:
             - name: logs
               mountPath: {{ template "airflow_logs" . }}
-{{- if and $local (not $elasticsearch) }}
-        # Start the sidecar log server if we're in local mode and
-        # we don't have elasticsearch enabled.
+{{- if and $local (not $elasticsearch) (semverCompare "<2.0.0" .Values.airflowVersion) }}
+        # Start the sidecar log server if we're in local mode,
+        # we don't have elasticsearch enabled, and we aren't running Airflow 2
         - name: scheduler-logs
           image: {{ template "airflow_image" . }}
           args: ["airflow", "serve_logs"]


### PR DESCRIPTION
Similar to workers, in 2.1.0+ Airflow's scheduler will start a webserver
to serve logs when using a "local" executor.

Closes: #236