### PR TITLE
Quick fix to allow postgresql dependency to install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ dev-account.json
 kubeconfig
 letsencrypt*
 repository
+requirements.lock

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ helm install --namespace airflow .
 To install the chart with the release name `my-release`:
 
 ```bash
+helm dependency update
 helm install --name my-release .
 ```
 

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: postgresql
     version: 6.3.12
-    repository: "@stable"
+    repository: "https://charts.helm.sh/stable"
     condition: postgresql.enabled


### PR DESCRIPTION
## Description

Fixes the repository for the postgresql dependency.

## PR Title

Quick fix to allow postgresql chart to install

## 🧪  Testing

> What are the main risks associated with this change, and how are they addressed by tests added in this PR?
There were no new features added, however the change may not work for all platforms. I tested by deploying airflow to minikube and AWS EKS, and both times it did not work until I made the change submitted in this PR

## 📋 Checklist

- [ x] The PR title is informative to the user experience
- [x] Functional test(s) added
- [ ] Helm chart unit test(s)
