### PR TITLE
bump pgbouncer exporter and redis image versions

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -94,7 +94,7 @@ images:
     pullPolicy: IfNotPresent
   redis:
     repository: quay.io/astronomer/ap-redis
-    tag: 6.2.1
+    tag: 6.2.5-1
     pullPolicy: IfNotPresent
   pgbouncer:
     repository: quay.io/astronomer/ap-pgbouncer
@@ -102,7 +102,7 @@ images:
     pullPolicy: IfNotPresent
   pgbouncerExporter:
     repository: quay.io/astronomer/ap-pgbouncer-exporter
-    tag: 0.9.2
+    tag: 0.11.0-1
     pullPolicy: IfNotPresent
 
 # Environment variables for all airflow containers


### PR DESCRIPTION
## Description

Keeping dependent service image up to date for new features and lower security footprint

## PR Title

Bump pgbouncer exporter and redis image versions

## 🎟 Issue(s)

Resolves astronomer/issues#XXXX

## 🧪  Testing

> What are the main risks associated with this change, and how are they addressed by tests added in this PR?

> Please add helm unit testing, if applicable. The docs are regretfully sparse for helm unit testing, [here](https://github.com/astronomer/helm-unittest/blob/main/DOCUMENT.md) is what we have to work with. In general, these kind of tests can be used for specific assertions like 'when these values are set, the resource ends up looking like XYZ' but not for generalized assertions like 'for all resources, make sure the namespace is not set to the release name'.

> Please also add to the system testing [here](../tests/functional-tests). This kind of testing allows you to connect into any live, running pod to make assertions about how they are operating.

## 📸 Screenshots

> Add screenshots to illustrate the changes, if applicable.

## 📋 Checklist

- [ ] The PR title is informative to the user experience
- [ ] Functional test(s) added
- [ ] Helm chart unit test(s)
