### PR TITLE
allow namespace be an integer

### DIFF
--- a/templates/rbac/pod-cleanup-rolebinding.yaml
+++ b/templates/rbac/pod-cleanup-rolebinding.yaml
@@ -21,5 +21,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}-cleanup-serviceaccount
-    namespace: {{ .Release.Namespace }}
+    namespace: "{{ .Release.Namespace }}"
 {{- end }}

--- a/templates/rbac/pod-launcher-rolebinding.yaml
+++ b/templates/rbac/pod-launcher-rolebinding.yaml
@@ -24,11 +24,11 @@ subjects:
 {{- if $grantScheduler }}
   - kind: ServiceAccount
     name: {{ .Release.Name }}-scheduler-serviceaccount
-    namespace: {{ .Release.Namespace }}
+    namespace: "{{ .Release.Namespace }}"
 {{- end }}
 {{- if $grantWorker }}
   - kind: ServiceAccount
     name: {{ .Release.Name }}-worker-serviceaccount
-    namespace: {{ .Release.Namespace }}
+    namespace: "{{ .Release.Namespace }}"
 {{- end }}
 {{- end }}

--- a/templates/rbac/pod-log-reader-role.yaml
+++ b/templates/rbac/pod-log-reader-role.yaml
@@ -28,7 +28,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-pod-log-reader-role
 {{- if not .Values.multiNamespaceMode }}
-  namespace: {{ .Release.Namespace }}
+  namespace: "{{ .Release.Namespace }}"
 {{- end }}
   labels:
     tier: airflow

--- a/templates/rbac/pod-log-reader-rolebinding.yaml
+++ b/templates/rbac/pod-log-reader-rolebinding.yaml
@@ -27,7 +27,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
 {{- if not .Values.multiNamespaceMode }}
-  namespace: {{ .Release.Namespace }}
+  namespace: "{{ .Release.Namespace }}"
 {{- end }}
   name: {{ .Release.Name }}-pod-log-reader-rolebinding
   labels:
@@ -49,5 +49,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}-webserver-serviceaccount
-    namespace: {{ .Release.Namespace }}
+    namespace: "{{ .Release.Namespace }}"
 {{- end }}


### PR DESCRIPTION
**before this fix:**
```
kubectl apply -f test.yaml
error: unable to decode "test.yaml": resource.metadataOnlyObject.ObjectMeta: v1.ObjectMeta.Namespace: ReadString: expects " or n, but found 5, error found in #10 byte of ...|mespace":53}}|..., bigger context ...|,"metadata":{"name":"53-build-robot","namespace":53}}|...


cat test.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: 53-build-robot
  namespace: 53
```

after fix:
```
kubectl apply -f test.yaml
serviceaccount/53-build-robot created

cat test.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: 53-build-robot
  namespace: "53"
```