### PR TITLE
Bump and tweak dev component versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ workflows:
 jobs:
   run_pre_commit:
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2021-05
+      - image: quay.io/astronomer/ci-pre-commit:2021-10
     steps:
       - checkout
       - run:
@@ -97,7 +97,7 @@ jobs:
 
   build-and-release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2021-04
+      - image: quay.io/astronomer/ci-helm-release:2021-10
     steps:
       - checkout
       - run:
@@ -111,7 +111,7 @@ jobs:
   airflow-test:
     machine:
       # https://circleci.com/docs/2.0/configuration-reference/#available-machine-images
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:202107-02
       resource_class: large
     parameters:
       executor:
@@ -119,7 +119,7 @@ jobs:
         default: "LocalExecutor"
       kube_version:
         type: string
-        default: "1.18.8"
+        default: "1.18.19"
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -127,7 +127,7 @@ jobs:
       - run:
           name: Install Airflow chart
           command: |
-            pyenv global 3.9.1
+            pyenv global 3.9.4
             export KUBE_VERSION=<< parameters.kube_version >>
             export EXECUTOR=<< parameters.executor >>
             HELM_CHART_PATH=$(find /tmp/workspace/ -name 'airflow-*.tgz')
@@ -137,7 +137,7 @@ jobs:
 
   release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2021-04
+      - image: quay.io/astronomer/ci-helm-release:2021-10
     steps:
       - checkout
       - run:
@@ -146,7 +146,7 @@ jobs:
 
   release-public:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2021-04
+      - image: quay.io/astronomer/ci-helm-release:2021-10
     steps:
       - checkout
       - publish-github-release

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 exclude: '^(venv|\.vscode)' # regex
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.6b0
+    rev: 21.9b0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -35,10 +35,10 @@ repos:
       - id: flake8
         args:
           - --ignore=E501,W503
-  - repo: https://github.com/detailyang/pre-commit-shell
-    rev: 1.0.5
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.7.2.1
     hooks:
-      - id: shell-lint
+      - id: shellcheck
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.10
     hooks:


### PR DESCRIPTION
- Bump CI runner image tag
- Bump machine image and associated python version references
- Swap out pre-commit shellcheck hook for one that installs shellcheck automatically
- `pre-commit autoupdate`
- Fix a config default that referenced an older kube patch version