### PR TITLE
Bump to the latest released version of OSS Chart: `1.3.0`

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -9,5 +9,5 @@ keywords:
   - airflow
 dependencies:
   - name: airflow
-    version: 1.3.0-dev
-    repository: https://github.com/astronomer/airflow/releases/download/oss-helm-chart/1.3.0-dev
+    version: 1.3.0
+    repository: https://airflow.apache.org

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v2 is Helm 3
 apiVersion: v2
 name: airflow
-version: 1.0.0-rc1
+version: 1.1.0-rc1
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:
@@ -9,5 +9,5 @@ keywords:
   - airflow
 dependencies:
   - name: airflow
-    version: 1.2.0
-    repository: https://airflow.apache.org
+    version: 1.3.0-dev
+    repository: https://github.com/astronomer/airflow/releases/download/oss-helm-chart/1.3.0-dev


### PR DESCRIPTION
This PR bumps the current chart version to `1.1.0-rc1` by bumping the OSS chart version to `1.3.0` to allow Dev/QA testing.

The changes in 1.3.0 version of OSS chart from 1.2.0 are documented at https://airflow.apache.org/docs/helm-chart/stable/changelog.html#airflow-helm-chart-1-3-0-2021-11-08

