### PR TITLE
Add pre-commit, tweak CircleCI configs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 workflows:
-  version: 2.1
+  version: 2
   install-airflow-chart:
     jobs:
       - lint
@@ -49,7 +49,7 @@ workflows:
 jobs:
   run_pre_commit:
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2021-10
+      - image: quay.io/astronomer/ci-pre-commit:2021-11
     steps:
       - checkout
       - run:
@@ -75,7 +75,7 @@ jobs:
 
   lint:
     docker:
-      - image: alpine/helm:3.5.3
+      - image: alpine/helm:3.7.1
     steps:
       - checkout
       - run:
@@ -84,7 +84,7 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: alpine/helm:3.5.3
+      - image: alpine/helm:3.7.1
         entrypoint: /bin/sh
     steps:
       - checkout
@@ -98,7 +98,7 @@ jobs:
 
   build-and-release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2021-10
+      - image: quay.io/astronomer/ci-helm-release:2021-11
     steps:
       - checkout
       - run:
@@ -138,7 +138,7 @@ jobs:
 
   release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2021-10
+      - image: quay.io/astronomer/ci-helm-release:2021-11
     steps:
       - checkout
       - run:
@@ -147,7 +147,7 @@ jobs:
 
   release-public:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2021-10
+      - image: quay.io/astronomer/ci-helm-release:2021-11
     steps:
       - checkout
       - publish-github-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,4 @@
+---
 version: 2.1
 
 workflows:
@@ -12,9 +13,9 @@ workflows:
           context:
             - gcp-astronomer-prod
           requires:
-          - lint
-          - run_pre_commit
-          - unittest-charts
+            - lint
+            - run_pre_commit
+            - unittest-charts
 
       - airflow-test:
           matrix:
@@ -23,12 +24,12 @@ workflows:
               kube_version: ["1.16.15", "1.17.17", "1.18.19", "1.19.11", "1.20.7"]
               executor: ["CeleryExecutor", "LocalExecutor", "KubernetesExecutor"]
           requires:
-          - build-and-release-internal
+            - build-and-release-internal
 
       - approve-release-prod:
           type: approval
           requires:
-            - 'airflow-test'
+            - "airflow-test"
           filters:
             branches:
               only:
@@ -106,7 +107,7 @@ jobs:
       - persist_to_workspace:
           root: /tmp/airflow-chart-package
           paths:
-            - './*.tgz'
+            - "./*.tgz"
 
   airflow-test:
     machine:
@@ -160,7 +161,7 @@ commands:
     parameters:
       tag:
         type: string
-        default:  "$NEXT_TAG"
+        default: "$NEXT_TAG"
     steps:
       - run:
           name: Create a release on GitHub

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,3 @@
-
 ## Description
 
 > Describe the purpose of this pull request.
@@ -11,7 +10,7 @@
 
 Resolves astronomer/issues#XXXX
 
-## 🧪  Testing
+## 🧪 Testing
 
 > What are the main risks associated with this change, and how are they addressed by tests added in this PR?
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,26 @@
 ---
 exclude: '^(venv|\.vscode)' # regex
 repos:
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.1.10
+    hooks:
+      - id: remove-tabs
+        exclude_types: [makefile, binary]
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v2.4.1"
+    hooks:
+      - id: prettier
+        args: ["--print-width=135"]
+        exclude: "(charts|templates|files)"
   - repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 21.10b0
     hooks:
       - id: black
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.29.0
+    hooks:
+      - id: pyupgrade
+        args: ["--py38-plus"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:
@@ -18,6 +34,7 @@ repos:
       - id: check-yaml
         args: ["--allow-multiple-documents"]
         exclude: "(charts|templates|files)"
+      - id: debug-statements
       - id: detect-private-key
       - id: end-of-file-fixer
       - id: file-contents-sorter
@@ -27,6 +44,8 @@ repos:
         args: ["-b", "master"]
       - id: mixed-line-ending
         args: ["--fix=lf"]
+      - id: requirements-txt-fixer
+        args: ["tests/functional-tests/requirements.txt"]
       - id: sort-simple-yaml
       - id: trailing-whitespace
   - repo: https://gitlab.com/pycqa/flake8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ You can run Kubernetes in Docker (kind) in order to develop this chart on your w
 - Docker
 
 Make sure your user has access to Docker:
+
 ```
 docker run --rm hello-world:latest
 ```
@@ -25,6 +26,7 @@ bin/reset-local-dev
 ```
 
 The above script takes the following steps:
+
 - Install dependencies: kind, kubectl, helm
 - Delete existing kind cluster named 'kind', if it exists
 - Start a new kind cluster

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ helm install airflow \
     astronomer/airflow
 
 ```
+
 To install this repository from source
+
 ```bash
 kubectl create namespace airflow
 helm install --namespace airflow .
@@ -49,6 +51,7 @@ helm install --namespace airflow .
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart
+
 To install the chart with the release name `my-release`:
 
 ```bash
@@ -170,37 +173,36 @@ workers:
 
 ## Docker Images
 
-* The Airflow image that are referenced as the default values in this chart are generated from this repository: https://github.com/astronomer/ap-airflow.
-* Other non-airflow images used in this chart are generated from this repository: https://github.com/astronomer/ap-vendor.
+- The Airflow image that are referenced as the default values in this chart are generated from this repository: https://github.com/astronomer/ap-airflow.
+- Other non-airflow images used in this chart are generated from this repository: https://github.com/astronomer/ap-vendor.
 
 ## Parameters
 
 The complete list of parameters supported by the community chart can be found on the [Parameteres Reference](https://airflow.apache.org/docs/helm-chart/stable/parameters-ref.html) page, and can be set under the `airflow` key in this chart.
 
-
 The following tables lists the configurable parameters of the Astronomer chart and their default values.
 
-| Parameter                                             | Description                                                                                               | Default                                                           |    |
-|:------------------------------------------------------|:----------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------|:---|
-| `ingress.enabled`                                     | Enable Kubernetes Ingress support                                                                         | `false`                                                           |    |
-| `ingress.acme`                                        | Add acme annotations to Ingress object                                                                    | `false`                                                           |    |
-| `ingress.tlsSecretName`                               | Name of secret that contains a TLS secret                                                                 | `~`                                                               |    |
-| `ingress.webserverAnnotations`                        | Annotations added to Webserver Ingress object                                                             | `{}`                                                              |    |
-| `ingress.flowerAnnotations`                           | Annotations added to Flower Ingress object                                                                | `{}`                                                              |    |
-| `ingress.baseDomain`                                  | Base domain for VHOSTs                                                                                    | `~`                                                               |    |
-| `ingress.auth.enabled`                                | Enable auth with Astronomer Platform                                                                      | `true`                                                            |    |
-| `workers.autoscaling.enabled`                         | Traditional HorizontalPodAutoscaler                                                                       | `false`                                                           |    |
-| `workers.autoscaling.minReplicas`                     | Minimum amount of workers                                                                                 | `1`                                                               |    |
-| `workers.autoscaling.maxReplicas`                     | Maximum amount of workers                                                                                 | `10`                                                              |    |
-| `workers.autoscaling.targetCPUUtilization`            | Target CPU Utilization of workers                                                                         | `80`                                                              |    |
-| `workers.autoscaling.targetMemoryUtilization`         | Target Memory Utilization of workers                                                                      | `80`                                                              |    |
-| `extraObjects`                                        | Extra K8s Objects to deploy (these are passed through `tpl`). More about [Extra Objects](#extra-objects). | `[]`                                                              |    |
-| `sccEnabled`                                          | Enable security context constraints required for OpenShift                                                | `false`                                                           |    |
-| `authSidecar.enabled`                                 | Enable authSidecar                                                                                        | `false`                                                           |    |
-| `authSidecar.repository`                              | The image for the auth sidecar proxy                                                                      | `nginxinc/nginx-unprivileged`                                     |    |
-| `authSidecar.tag`                                     | The image tag for the auth sidecar proxy                                                                  | `stable`                                                          |    |
-| `authSidecar.pullPolicy`                              | The K8s pullPolicy for the the auth sidecar proxy image                                                   | `IfNotPresent`                                                    |    |
-| `authSidecar.port`                                    | The port the auth sidecar exposes                                                                         | `8084`                                                            |    |
+| Parameter                                     | Description                                                                                               | Default                       |     |
+| :-------------------------------------------- | :-------------------------------------------------------------------------------------------------------- | :---------------------------- | :-- |
+| `ingress.enabled`                             | Enable Kubernetes Ingress support                                                                         | `false`                       |     |
+| `ingress.acme`                                | Add acme annotations to Ingress object                                                                    | `false`                       |     |
+| `ingress.tlsSecretName`                       | Name of secret that contains a TLS secret                                                                 | `~`                           |     |
+| `ingress.webserverAnnotations`                | Annotations added to Webserver Ingress object                                                             | `{}`                          |     |
+| `ingress.flowerAnnotations`                   | Annotations added to Flower Ingress object                                                                | `{}`                          |     |
+| `ingress.baseDomain`                          | Base domain for VHOSTs                                                                                    | `~`                           |     |
+| `ingress.auth.enabled`                        | Enable auth with Astronomer Platform                                                                      | `true`                        |     |
+| `workers.autoscaling.enabled`                 | Traditional HorizontalPodAutoscaler                                                                       | `false`                       |     |
+| `workers.autoscaling.minReplicas`             | Minimum amount of workers                                                                                 | `1`                           |     |
+| `workers.autoscaling.maxReplicas`             | Maximum amount of workers                                                                                 | `10`                          |     |
+| `workers.autoscaling.targetCPUUtilization`    | Target CPU Utilization of workers                                                                         | `80`                          |     |
+| `workers.autoscaling.targetMemoryUtilization` | Target Memory Utilization of workers                                                                      | `80`                          |     |
+| `extraObjects`                                | Extra K8s Objects to deploy (these are passed through `tpl`). More about [Extra Objects](#extra-objects). | `[]`                          |     |
+| `sccEnabled`                                  | Enable security context constraints required for OpenShift                                                | `false`                       |     |
+| `authSidecar.enabled`                         | Enable authSidecar                                                                                        | `false`                       |     |
+| `authSidecar.repository`                      | The image for the auth sidecar proxy                                                                      | `nginxinc/nginx-unprivileged` |     |
+| `authSidecar.tag`                             | The image tag for the auth sidecar proxy                                                                  | `stable`                      |     |
+| `authSidecar.pullPolicy`                      | The K8s pullPolicy for the the auth sidecar proxy image                                                   | `IfNotPresent`                |     |
+| `authSidecar.port`                            | The port the auth sidecar exposes                                                                         | `8084`                        |     |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -210,7 +212,7 @@ helm install --name my-release \
   --set enablePodLaunching=false .
 ```
 
-##  Autoscaling with KEDA
+## Autoscaling with KEDA
 
 KEDA stands for Kubernetes Event Driven Autoscaling. [KEDA](https://github.com/kedacore/keda) is a custom controller that allows users to create custom bindings
 to the Kubernetes [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/).
@@ -289,20 +291,20 @@ to port-forward the Airflow UI to http://localhost:8080/ to confirm Airflow is w
 
 **Build a Docker image from your DAGs:**
 
-1. Start a project using [astro-cli](https://github.com/astronomer/astro-cli), which will generate a Dockerfile, and load your DAGs in. You can test locally before pushing to kind with `astro airflow start`.
+1.  Start a project using [astro-cli](https://github.com/astronomer/astro-cli), which will generate a Dockerfile, and load your DAGs in. You can test locally before pushing to kind with `astro airflow start`.
 
         mkdir my-airflow-project && cd my-airflow-project
         astro dev init
 
-2. Then build the image:
+2.  Then build the image:
 
         docker build -t my-dags:0.0.1 .
 
-3. Load the image into kind:
+3.  Load the image into kind:
 
         kind load docker-image my-dags:0.0.1
 
-4. Upgrade Helm deployment:
+4.  Upgrade Helm deployment:
 
         helm upgrade airflow -n airflow \
             --set images.airflow.repository=my-dags \
@@ -327,12 +329,12 @@ extraObjects:
           template:
             spec:
               containers:
-              - name: myjob
-                image: ubuntu
-                command:
-                - echo
-                args:
-                - hello
+                - name: myjob
+                  image: ubuntu
+                  command:
+                    - echo
+                  args:
+                    - hello
               restartPolicy: OnFailure
 ```
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -13,25 +13,25 @@ As we now build on top of the official community Helm chart, most of the paramet
 For example, to set `airflowVersion`, `defaultAirflowTag`, and `executor`:
 
 ```yaml
- airflow:
-   airflowVersion: 2.1.0
-   defaultAirflowTag: 2.1.0-1-buster
-   executor: CeleryExecutor
+airflow:
+  airflowVersion: 2.1.0
+  defaultAirflowTag: 2.1.0-1-buster
+  executor: CeleryExecutor
 ```
 
 The complete list of parameters supported by the community chart can be found on the [Parameteres Reference](https://airflow.apache.org/docs/helm-chart/stable/parameters-ref.html) page.
 
 ### Renamed Parameters
 
-| From                                      | To                                                |
-| ----------------------------------------- | ------------------------------------------------- |
-| `createUserJobAnnotations`                | `airflow.createUserJob.annotations`               |
-| `runMigrationsJobAnnotations`             | `airflow.migrateDatabaseJob.annotations`          |
-| `rbacEnabled`                             | `airflow.rbac.create`                             |
-| `scheduler.airflowLocalSettings`          | `airflow.airflowLocalSettings`                    |
-| `pgbouncer.extraIniDatabaseMetatdata` (yes, typo is correct) | `airflow.pgbouncer.extaIniMetadata` |
-| `pgbouncer.extraIniDatabaseResultBackend` | `airflow.pgbouncer.extaIniResultBackend`          |
-| `pgbouncer.extraIniPgbouncerConfig`       | `airflow.pgbouncer.extaIni`                       |
+| From                                                         | To                                       |
+| ------------------------------------------------------------ | ---------------------------------------- |
+| `createUserJobAnnotations`                                   | `airflow.createUserJob.annotations`      |
+| `runMigrationsJobAnnotations`                                | `airflow.migrateDatabaseJob.annotations` |
+| `rbacEnabled`                                                | `airflow.rbac.create`                    |
+| `scheduler.airflowLocalSettings`                             | `airflow.airflowLocalSettings`           |
+| `pgbouncer.extraIniDatabaseMetatdata` (yes, typo is correct) | `airflow.pgbouncer.extaIniMetadata`      |
+| `pgbouncer.extraIniDatabaseResultBackend`                    | `airflow.pgbouncer.extaIniResultBackend` |
+| `pgbouncer.extraIniPgbouncerConfig`                          | `airflow.pgbouncer.extaIni`              |
 
 ### ServiceAccount Annotations
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -39,16 +39,16 @@ spec:
       component: pgbouncer
       release: RELEASE-NAME
   policyTypes:
-  - Ingress
+    - Ingress
   ingress:
-  - from:
-    - podSelector:
-        matchLabels:
-          tier: airflow
-          release: RELEASE-NAME
-    ports:
-    - protocol: TCP
-      port: 6543
+    - from:
+        - podSelector:
+            matchLabels:
+              tier: airflow
+              release: RELEASE-NAME
+      ports:
+        - protocol: TCP
+          port: 6543
 ```
 
 From this output, we can make the following assertions:
@@ -94,14 +94,14 @@ Which produces:
 With that empty content, there's pretty much only one thing we can do, which is to essentially assert that it is empty:
 
 ```yaml
-  - it: "should work with pgbouncer.enabled: True, networkPolicies.enabled: True, pgbouncer.networkPolicies.enabled: False"
-    set:
-      pgbouncer.enabled: True
-      networkPolicies.enabled: True
-      pgbouncer.networkPolicies.enabled: False
-    asserts:
-      - hasDocuments:
-          count: 0
+- it: "should work with pgbouncer.enabled: True, networkPolicies.enabled: True, pgbouncer.networkPolicies.enabled: False"
+  set:
+    pgbouncer.enabled: True
+    networkPolicies.enabled: True
+    pgbouncer.networkPolicies.enabled: False
+  asserts:
+    - hasDocuments:
+        count: 0
 ```
 
 This is a little counterintuitive because the output has one yaml document, but there is no parseable content inside of it, so this is seen as 0 documents that would be relevant to kubernetes. If we try to assert that there is 1 document, we see the following helpful error:

--- a/tests/functional-tests/requirements.txt
+++ b/tests/functional-tests/requirements.txt
@@ -1,5 +1,5 @@
+docker==4.1.0
+kubernetes==11.0.0
 pre-commit==2.4.0
 pytest==6.0.1
-kubernetes==11.0.0
 testinfra==3.2.1
-docker==4.1.0


### PR DESCRIPTION
Add pre-commit hooks that are more in line with what we have in astronomer/astronomer. Also add prettier. Run `pre-commit run --all-files` to correct the contents of the repo.

Also bump some dev component versions in CircleCI.

There are no functional changes in this change set. Closest thing is sorting a requirements.txt file. Other than that and pre-commit config, everything else is just markdown changes, and mostly whitespace.