### PR TITLE
Fix git sync rev param hash cloning issue

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -39,8 +39,10 @@ airflow:
     pgbouncerExporter:
       repository: quay.io/astronomer/ap-pgbouncer-exporter
       tag: 0.11.0-2
-
-  # Airflow scheduler settings
+    gitSync:
+      repository: k8s.gcr.io/git-sync/git-sync
+      tag: v3.3.4
+    # Airflow scheduler settings
   scheduler:
     livenessProbe:
       timeoutSeconds: 30

--- a/values.yaml
+++ b/values.yaml
@@ -42,7 +42,7 @@ airflow:
     gitSync:
       repository: k8s.gcr.io/git-sync/git-sync
       tag: v3.3.4
-    # Airflow scheduler settings
+  # Airflow scheduler settings
   scheduler:
     livenessProbe:
       timeoutSeconds: 30


### PR DESCRIPTION
## Description

> update git sync version to 3.3.4 from 3.3.0 to fix rev git sync param accepting git hash

looked at the following for reference: https://github.com/apache/airflow/blob/1ee65bb8ae9f98233208ebb7918cf9aa1e01823e/chart/values.yaml#L85 

## 🎟 Issue(s)

Resolves astronomer/issues#3779

## 🧪 Testing

> What are the main risks associated with this change, and how are they addressed by tests added in this PR?

> Please add helm unit testing, if applicable. The docs are regretfully sparse for helm unit testing, [here](https://github.com/astronomer/helm-unittest/blob/main/DOCUMENT.md) is what we have to work with. In general, these kind of tests can be used for specific assertions like 'when these values are set, the resource ends up looking like XYZ' but not for generalized assertions like 'for all resources, make sure the namespace is not set to the release name'.

> Please also add to the system testing [here](../tests/functional-tests). This kind of testing allows you to connect into any live, running pod to make assertions about how they are operating.

## 📸 Screenshots

> Add screenshots to illustrate the changes, if applicable.

## 📋 Checklist

- [ ] The PR title is informative to the user experience
- [ ] Functional test(s) added
- [ ] Helm chart unit test(s)
