### PR TITLE
Bump airflow chart dependency

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: airflow
   repository: https://airflow.apache.org
-  version: 1.2.0
-digest: sha256:c72414525597a3344b14909c7b8fc6b11a51470c1206a6ac71434f5c51d5f884
-generated: "2021-09-29T10:32:20.656664-06:00"
+  version: 1.3.0
+digest: sha256:4a6c9b4e88ffc5610e5286ccfb706b854125efa766d28f52d1253e365945c347
+generated: "2021-11-15T18:08:24.410099-08:00"


### PR DESCRIPTION
Bump airflow chart dependency from 1.2.0 to 1.3.0.