### PR TITLE
Fix KubernetesExecutor on Airflow < 1.10.12

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -327,8 +327,19 @@ airflow:
       elasticsearch_write_stdout: True
       elasticsearch_json_format: True
       elasticsearch_log_id_template: "{dag_id}_{task_id}_{execution_date}_{try_number}"
+    # The following kubernetes config is required to support Airflow 1.10.10
     kubernetes:
       dags_in_image: True
+      worker_service_account_name: '{{ include "worker.serviceAccountName" . }}'
+      image_pull_secrets: '{{ template "registry_secret" . }}'
+    kubernetes_labels:
+      tier: airflow
+      component: worker
+      release: "{{ .Release.Name }}"
+    kubernetes_secrets:
+      AIRFLOW__CORE__SQL_ALCHEMY_CONN: '{{ printf "%s=connection" (include "airflow_metadata_secret" .) }}'
+      AIRFLOW_CONN_AIRFLOW_DB: '{{ printf "%s=connection" (include "airflow_metadata_secret" .) }}'
+      AIRFLOW__CORE__FERNET_KEY: '{{ printf "%s=fernet-key" (include "fernet_key_secret" .) }}'
     # Only required when running on the platform, but works elsewhere too
     astronomer:
       jwt_signing_cert: /etc/airflow/tls/tls.crt


### PR DESCRIPTION
Airflow pre 1.10.12 doesn't use the pod_template_file and we were missing some of the old-style configuration needed to allow KubernetesExecutor to function.

## 🎟 Issue(s)

Resolves https://github.com/astronomer/issues/issues/3799

## 🧪 Testing

> What are the main risks associated with this change, and how are they addressed by tests added in this PR?

> Please add helm unit testing, if applicable. The docs are regretfully sparse for helm unit testing, [here](https://github.com/astronomer/helm-unittest/blob/main/DOCUMENT.md) is what we have to work with. In general, these kind of tests can be used for specific assertions like 'when these values are set, the resource ends up looking like XYZ' but not for generalized assertions like 'for all resources, make sure the namespace is not set to the release name'.

> Please also add to the system testing [here](../tests/functional-tests). This kind of testing allows you to connect into any live, running pod to make assertions about how they are operating.

## 📸 Screenshots

> Add screenshots to illustrate the changes, if applicable.

## 📋 Checklist

- [ ] The PR title is informative to the user experience
- [ ] Functional test(s) added
- [ ] Helm chart unit test(s)
