### PR TITLE
fix release to prod command for multi version charts

### DIFF
--- a/bin/release-internal-to-prod
+++ b/bin/release-internal-to-prod
@@ -15,7 +15,7 @@ fi
 dev_repo=internal-helm.astronomer.io
 prod_repo=helm.astronomer.io
 git_root="$(git rev-parse --show-toplevel)"
-version=$(awk '$1 ~ /^version/ {printf $2}' "${git_root}/Chart.yaml")
+version=$(awk '$1 ~ /^version/ {printf $2;exit;}' "${git_root}/Chart.yaml")
 filename="airflow-${version}.tgz"
 max_age=300
 

--- a/bin/release-internal-to-prod
+++ b/bin/release-internal-to-prod
@@ -15,7 +15,7 @@ fi
 dev_repo=internal-helm.astronomer.io
 prod_repo=helm.astronomer.io
 git_root="$(git rev-parse --show-toplevel)"
-version=$(awk '$1 ~ /^version/ {printf $2;exit;}' "${git_root}/Chart.yaml")
+version=$(awk '$0 ~ /^version/ {printf $2}' "${git_root}/Chart.yaml")
 filename="airflow-${version}.tgz"
 max_age=300
 


### PR DESCRIPTION
Issue: https://github.com/astronomer/issues/issues/3816

Description: when the chart file has a field called version twice the awk command concats them together. for instance the below chart outputs 1.0.91.3.0 when it should output 1.0.9.

`# apiVersion v2 is Helm 3
apiVersion: v2
name: airflow
version: 1.1.0-rc1
description: Helm chart to deploy the Astronomer Platform Airflow module
icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
keywords:
  \- astronomer
  \- airflow
dependencies:
  \- name: airflow
    version: 1.3.0
    repository: https://airflow.apache.org`
