### PR TITLE
Sync supported k8s versions with what is in astronomer/astronomer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ workflows:
           matrix:
             parameters:
               # https://hub.docker.com/r/kindest/node/tags
-              kube_version: ["1.16.15", "1.17.17", "1.18.19", "1.19.11", "1.20.7"]
+              kube_version: ["1.17.17", "1.18.19", "1.19.11", "1.20.7", "1.21.2"]
               executor: ["CeleryExecutor", "LocalExecutor", "KubernetesExecutor"]
           requires:
             - build-and-release-internal

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
   airflow-test:
     machine:
       # https://circleci.com/docs/2.0/configuration-reference/#available-machine-images
-      image: ubuntu-2004:202107-02
+      image: ubuntu-2004:202111-01
       resource_class: large
     parameters:
       executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run:
           name: Install Airflow chart
           command: |
-            pyenv global 3.9.4
+            pyenv global 3.9.7
             export KUBE_VERSION=<< parameters.kube_version >>
             export EXECUTOR=<< parameters.executor >>
             HELM_CHART_PATH=$(find /tmp/workspace/ -name 'airflow-*.tgz')

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ workflows:
           matrix:
             parameters:
               # https://hub.docker.com/r/kindest/node/tags
-              kube_version: ["1.17.17", "1.18.19", "1.19.11", "1.20.7", "1.21.2"]
+              kube_version: ["1.17.17", "1.18.19", "1.19.11", "1.20.7", "1.21.1"]
               executor: ["CeleryExecutor", "LocalExecutor", "KubernetesExecutor"]
           requires:
             - build-and-release-internal

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ workflows:
           matrix:
             parameters:
               # https://hub.docker.com/r/kindest/node/tags
-              kube_version: ["1.17.17", "1.18.19", "1.19.11", "1.20.7", "1.21.1"]
+              kube_version: ["1.17.17", "1.18.19", "1.19.11", "1.20.7", "1.21.2"]
               executor: ["CeleryExecutor", "LocalExecutor", "KubernetesExecutor"]
           requires:
             - build-and-release-internal

--- a/bin/install-ci-tools
+++ b/bin/install-ci-tools
@@ -2,11 +2,11 @@
 set -e
 
 if [[ -z "${KIND_VERSION}" ]]; then
-  export KIND_VERSION="0.7.0"
+  export KIND_VERSION="0.11.1"
 fi
 
 if [[ -z "${HELM_VERSION}" ]]; then
-  export HELM_VERSION="3.6.0"
+  export HELM_VERSION="3.7.1"
 fi
 
 # Determine the platform we are running on


### PR DESCRIPTION
## Description

Synchronize the tested k8s versions with what we have in astronomer/astronomer

## Extras

These changes were all made while troubleshooting problems with kind cluster creation with 1.21, but kind itself ended up being the problem as it was too old for 1.21.

- Bump kind version
- Bump helm version
- Bump machine version and pyenv version to match the new machine