### PR TITLE
Add NFS as an allowed volume type to airflow-scc-anyuid

### DIFF
--- a/templates/airflow-scc-anyuid.yaml
+++ b/templates/airflow-scc-anyuid.yaml
@@ -33,6 +33,7 @@ volumes:
 - configMap
 - downwardAPI
 - emptyDir
+- nfs
 - persistentVolumeClaim
 - projected
 - secret


### PR DESCRIPTION
Allows nfs volumes to be mounted directly in airflow pods on OpenShift

## Description

This allows users to mount nfs volumes using the `extraVolumes` feature on Openshift (in the current configuration this is blocked by security context contraints).

## 🧪 Testing

> What are the main risks associated with this change, and how are they addressed by tests added in this PR?

There are security implications to allowing extra volume types although in this case since this doesn't allow extra access to the host it appears to me to be minimal.