### PR TITLE
Deprecate k8s 1.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ workflows:
           matrix:
             parameters:
               # https://hub.docker.com/r/kindest/node/tags
-              kube_version: ["1.17.17", "1.18.19", "1.19.11", "1.20.7", "1.21.2"]
+              kube_version: ["1.18.19", "1.19.11", "1.20.7", "1.21.2"]
               executor: ["CeleryExecutor", "LocalExecutor", "KubernetesExecutor"]
           requires:
             - build-and-release-internal


### PR DESCRIPTION
## Description

Deprecate k8s 1.17 because in January it will [no longer be supported in any supported cloud provider](https://github.com/astronomer/ops-stuff/blob/main/docs/k8s-version-table.md)

Please squash and merge when approved.