### PR TITLE
pgbouncer sslmode support

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -8,5 +8,6 @@ set -e
 # before we do 'helm lint'
 rm -rf /tmp/airflow-chart-lint/ || true
 mkdir -p /tmp/airflow-chart-lint
+helm dependency update
 cp -R . /tmp/airflow-chart-lint/airflow
 helm lint /tmp/airflow-chart-lint/airflow

--- a/templates/generate-ssl.yaml
+++ b/templates/generate-ssl.yaml
@@ -1,0 +1,83 @@
+###########################################
+## Pgbouncer SSL Pre install/update Hook ##
+###########################################
+{{- if (and .Values.airflow.pgbouncer.enabled (eq .Values.airflow.pgbouncer.sslmode "require")) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-2"
+  name: {{ .Release.Name }}-create-secret-role
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "watch", "list", "create", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-2"
+  name: {{ .Release.Name }}-create-secret-role-binding
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-pgbouncer-ssl
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}-create-secret-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "3"
+  labels:
+    tier: airflow
+    component: pgbouncer
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name:  {{ .Release.Name }}-pgbouncer-ssl
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-pgbouncerssl-job
+  labels:
+    tier: airflow
+    component: pgbouncer
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-weight": "5"
+spec:
+  template:
+    metadata:
+      labels:
+        tier: airflow
+        component: pgbouncer
+        release: {{ .Release.Name }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ .Release.Name }}-pgbouncer-ssl
+      containers:
+        - name: pgbouncercert-genertor
+          image: "{{ .Values.astronomer.images.certgenerator.repository }}:{{ .Values.astronomer.images.certgenerator.tag}}"
+          imagePullPolicy: Always
+          args: [
+            "--hostname={{ .Release.Name }}-pgbouncer.{{ .Release.Name }}.svc.cluster.local",
+            "--secret-name={{ .Release.Name }}-pgbouncer-client-certificates",
+            "--namespace={{ .Release.Namespace }}",
+            "--in-cluster=True"
+          ]
+
+{{ end }}

--- a/templates/generate-ssl.yaml
+++ b/templates/generate-ssl.yaml
@@ -70,7 +70,7 @@ spec:
       restartPolicy: Never
       serviceAccountName: {{ .Release.Name }}-pgbouncer-ssl
       containers:
-        - name: pgbouncercert-genertor
+        - name: pgbouncer-certgenerator
           image: "{{ .Values.astronomer.images.certgenerator.repository }}:{{ .Values.astronomer.images.certgenerator.tag}}"
           imagePullPolicy: Always
           args: [

--- a/templates/generate-ssl.yaml
+++ b/templates/generate-ssl.yaml
@@ -72,7 +72,7 @@ spec:
       containers:
         - name: pgbouncer-certgenerator
           image: "{{ .Values.astronomer.images.certgenerator.repository }}:{{ .Values.astronomer.images.certgenerator.tag}}"
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           args: [
             "--hostname={{ .Release.Name }}-pgbouncer.{{ .Release.Name }}.svc.cluster.local",
             "--secret-name={{ .Release.Name }}-pgbouncer-client-certificates",

--- a/tests/chart_tests/helm_template_generator.py
+++ b/tests/chart_tests/helm_template_generator.py
@@ -91,6 +91,9 @@ def render_chart(
             tmp_file.name,
         ]
         if show_only:
+            if isinstance(show_only, str):
+                show_only = [show_only]
+
             for i in show_only:
                 if not Path(i).exists():
                     raise FileNotFoundError(f"ERROR: {i} not found")

--- a/tests/chart_tests/test_pgbouncer_certgenerator.py
+++ b/tests/chart_tests/test_pgbouncer_certgenerator.py
@@ -1,0 +1,37 @@
+import jmespath
+import pytest
+
+from tests.chart_tests.helm_template_generator import render_chart
+
+from .. import supported_k8s_versions
+
+expected_rbac = {
+    "apiGroups": [""],
+    "resources": ["secrets"],
+    "verbs": ["get", "watch", "list", "create", "patch", "delete"],
+}
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+class TestPgbouncersslFeature:
+    def test_pgbouncer_certgenerator_defaults(self, kube_version):
+        """Test pgbouncer cert generator defaults."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={},
+            show_only="templates/generate-ssl.yaml",
+        )
+        assert len(docs) == 0
+
+    def test_pgbouncer_certgenerator_with_sslmode_enabled(self, kube_version):
+        """Test pgbouncer certgenerator sslmode opts result."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"airflow": {"pgbouncer": {"enabled": True, "sslmode": "require"}}},
+            show_only="templates/generate-ssl.yaml",
+        )
+        assert len(docs) == 4
+        assert "ServiceAccount" == jmespath.search("kind", docs[0])
+        assert "Role" == jmespath.search("kind", docs[1])
+        assert expected_rbac in docs[1]["rules"]
+        assert "RoleBinding" == jmespath.search("kind", docs[2])

--- a/values.yaml
+++ b/values.yaml
@@ -408,3 +408,9 @@ ingress:
 
 platform:
   release: ~
+
+astronomer:
+  images:
+    certgenerator:
+      repository: quay.io/astronomer/ap-certgenerator
+      tag: 0.1.0


### PR DESCRIPTION
## Description

Adds support for sslmode "require" when posgtres server is enabled with force tls

## PR Title

pbouncer sslmode support

## 🎟 Issue(s)

Resolves https://github.com/astronomer/issues/issues/3482

## 🧪 Testing

> What are the main risks associated with this change, and how are they addressed by tests added in this PR?

> Please add helm unit testing, if applicable. The docs are regretfully sparse for helm unit testing, [here](https://github.com/astronomer/helm-unittest/blob/main/DOCUMENT.md) is what we have to work with. In general, these kind of tests can be used for specific assertions like 'when these values are set, the resource ends up looking like XYZ' but not for generalized assertions like 'for all resources, make sure the namespace is not set to the release name'.

> Please also add to the system testing [here](../tests/functional-tests). This kind of testing allows you to connect into any live, running pod to make assertions about how they are operating.

## 📸 Screenshots

> Add screenshots to illustrate the changes, if applicable.

## 📋 Checklist

- [ ] The PR title is informative to the user experience
- [ ] Functional test(s) added
- [ ] Helm chart unit test(s)
