### PR TITLE
bump redis image to 6.2.6

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -32,7 +32,7 @@ airflow:
       tag: 0.18.0
     redis:
       repository: quay.io/astronomer/ap-redis
-      tag: 6.2.5-1
+      tag: 6.2.6
     pgbouncer:
       repository: quay.io/astronomer/ap-pgbouncer
       tag: 1.16.0


### PR DESCRIPTION
## Description

bump redis image to 6.2.6

## PR Title

bump redis image to 6.2.6

## 🎟 Issue(s)

Resolves astronomer/issues#3947

## 🧪 Testing

NA

## 📸 Screenshots

> Add screenshots to illustrate the changes, if applicable.

## 📋 Checklist

- [ ] The PR title is informative to the user experience
- [ ] Functional test(s) added
- [ ] Helm chart unit test(s)
