### PR TITLE
Add COMPONENT env. var. to standard Airflow environment

### DIFF
--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -3,6 +3,10 @@
   # Hard Coded Airflow Envs
   - name: ASTRONOMER__AIRFLOW__WORKER_LOG_RETENTION_DAYS
     value: "3"
+  - name: COMPONENT # Checked by entrypoint when sidecar logging is enabled
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.labels['component']
   {{- /*
     Everything below here needs to be kept in sync with the airflow oss chart
   */}}


### PR DESCRIPTION
## Description

Add COMPONENT env. var. to standard Airflow environment. This is consumed by the ap-airflow entrypoint when sidecar logging is enabled.

## Related Issues

astronomer/issues#3563