### PR TITLE
Use OSS Airflow Chart 1.4.0

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: airflow
-  repository: https://github.com/astronomer/airflow/releases/download/oss-helm-chart/1.3.1
-  version: 1.3.1
-digest: sha256:581220abca41ebea7a86ef522189990a8f23bea4a781be86f487968a18b336a5
-generated: "2021-12-16T20:14:26.521076-07:00"
+  repository: https://airflow.apache.org
+  version: 1.4.0
+digest: sha256:75f857a231746d64ab3dccdcf88959a7c5155715e21620535eb19ad9dd17b7c1
+generated: "2022-01-11T11:41:40.735569-07:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -9,5 +9,5 @@ keywords:
   - airflow
 dependencies:
   - name: airflow
-    version: 1.3.1
-    repository: https://github.com/astronomer/airflow/releases/download/oss-helm-chart/1.3.1
+    version: 1.4.0
+    repository: https://airflow.apache.org


### PR DESCRIPTION
## Description

Now that OSS chart 1.4.0 has been released, use it.

## Related Issues

Not sure, maybe @aliotta or @pgvishnuram can chime in?

## Testing

Did a local chart install.
