### PR TITLE
Drop k8s 1.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ workflows:
           matrix:
             parameters:
               # https://hub.docker.com/r/kindest/node/tags
-              kube_version: ["1.18.19", "1.19.11", "1.20.7", "1.21.2"]
+              kube_version: ["1.19.11", "1.20.7", "1.21.2"]
               executor: ["CeleryExecutor", "LocalExecutor", "KubernetesExecutor"]
           requires:
             - build-and-release-internal
@@ -49,7 +49,7 @@ workflows:
 jobs:
   run_pre_commit:
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2021-12
+      - image: quay.io/astronomer/ci-pre-commit:2022-01
     steps:
       - checkout
       - run:
@@ -84,7 +84,7 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2021-12
+      - image: quay.io/astronomer/ci-helm-release:2022-01
     steps:
       - checkout
       - run:
@@ -93,7 +93,7 @@ jobs:
 
   build-and-release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2021-12
+      - image: quay.io/astronomer/ci-helm-release:2022-01
     steps:
       - checkout
       - run:
@@ -115,7 +115,7 @@ jobs:
         default: "LocalExecutor"
       kube_version:
         type: string
-        default: "1.18.19"
+        default: "1.21.2"
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -133,7 +133,7 @@ jobs:
 
   release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2021-12
+      - image: quay.io/astronomer/ci-helm-release:2022-01
     steps:
       - checkout
       - run:
@@ -142,7 +142,7 @@ jobs:
 
   release-public:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2021-12
+      - image: quay.io/astronomer/ci-helm-release:2022-01
     steps:
       - checkout
       - publish-github-release

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,12 +23,12 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.1
+    rev: v2.31.0
     hooks:
       - id: pyupgrade
         args: ["--py38-plus"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.1.0
     hooks:
       - id: check-case-conflict
       - id: check-executables-have-shebangs
@@ -67,7 +67,7 @@ repos:
         args:
           - --ignore=E501,W503
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.8.0.1
+    rev: v0.8.0.3
     hooks:
       - id: shellcheck
   - repo: https://github.com/Lucas-C/pre-commit-hooks

--- a/bin/start-kind-cluster
+++ b/bin/start-kind-cluster
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2181
 
-KUBE_VERSION="${KUBE_VERSION:-1.18.2}"
+KUBE_VERSION="${KUBE_VERSION:-1.21.2}"
 
 # Create a kind cluster
 kind create cluster --image "kindest/node:v${KUBE_VERSION}"

--- a/tests/chart_tests/helm_template_generator.py
+++ b/tests/chart_tests/helm_template_generator.py
@@ -32,7 +32,7 @@ api_client = ApiClient()
 BASE_URL_SPEC = "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master"
 
 
-def get_schema_k8s(api_version, kind, kube_version="1.18.0"):
+def get_schema_k8s(api_version, kind, kube_version="1.21.0"):
     """Return a k8s schema for use in validation."""
     api_version = api_version.lower()
     kind = kind.lower()
@@ -49,14 +49,14 @@ def get_schema_k8s(api_version, kind, kube_version="1.18.0"):
 
 
 @lru_cache(maxsize=None)
-def create_validator(api_version, kind, kube_version="1.18.0"):
+def create_validator(api_version, kind, kube_version="1.21.0"):
     """Create a k8s validator for the given inputs."""
     schema = get_schema_k8s(api_version, kind, kube_version=kube_version)
     jsonschema.Draft7Validator.check_schema(schema)
     return jsonschema.Draft7Validator(schema)
 
 
-def validate_k8s_object(instance, kube_version="1.18.0"):
+def validate_k8s_object(instance, kube_version="1.21.0"):
     """Validate the k8s object."""
     validate = create_validator(
         instance.get("apiVersion"), instance.get("kind"), kube_version=kube_version
@@ -69,7 +69,7 @@ def render_chart(
     values=None,
     show_only=None,
     chart_dir=None,
-    kube_version="1.18.0",
+    kube_version="1.21.0",
 ):
     """
     Render a helm chart into dictionaries. For helm chart testing only


### PR DESCRIPTION
## Description

Drop k8s 1.18 from this repo. It is being deprecated in all cloud environments within the next month and we are not supporting it in new versions of astronomer.

## Related Issues

https://github.com/astronomer/issues/issues/3890

## Testing

These are all CI related changes so as long as CI is passing we should be good.