### PR TITLE
Update deprecated api groups for Kubernetes 1.22 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ workflows:
           matrix:
             parameters:
               # https://hub.docker.com/r/kindest/node/tags
-              kube_version: ["1.19.11", "1.20.7", "1.21.2"]
+              kube_version: ["1.19.11", "1.20.7", "1.21.2", "1.22.5"]
               executor: ["CeleryExecutor", "LocalExecutor", "KubernetesExecutor"]
           requires:
             - build-and-release-internal

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ workflows:
           matrix:
             parameters:
               # https://hub.docker.com/r/kindest/node/tags
-              kube_version: ["1.19.11", "1.20.7", "1.21.2", "1.22.5"]
+              kube_version: ["1.19.11", "1.20.7", "1.21.2", "1.22.7", "1.23.4"]
               executor: ["CeleryExecutor", "LocalExecutor", "KubernetesExecutor"]
           requires:
             - build-and-release-internal

--- a/templates/generate-ssl.yaml
+++ b/templates/generate-ssl.yaml
@@ -15,7 +15,7 @@ rules:
   resources: ["secrets"]
   verbs: ["get", "watch", "list", "create", "patch", "delete"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   annotations:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -46,24 +46,30 @@ spec:
       http:
         paths:
           - path: /{{ .Release.Name }}/airflow
+            pathType: Prefix
             backend:
-              serviceName: {{ .Release.Name }}-webserver
-              {{- if .Values.authSidecar.enabled  }}
-              servicePort: auth-proxy
-              {{- else }}
-              servicePort: airflow-ui
-              {{- end }}
+              service:
+                name: {{ .Release.Name }}-webserver
+                port:
+                  {{- if .Values.authSidecar.enabled  }}
+                  name: auth-proxy
+                  {{- else }}
+                  name: airflow-ui
+                  {{- end }}
     - host: {{- include "airflow_subdomain" . | indent 1 }}
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: {{ .Release.Name }}-webserver
-              {{- if .Values.authSidecar.enabled  }}
-              servicePort: auth-proxy
-              {{- else }}
-              servicePort: airflow-ui
-              {{- end }}
+              service:
+                name: {{ .Release.Name }}-webserver
+                port:
+                  {{- if .Values.authSidecar.enabled  }}
+                  name: auth-proxy
+                  {{- else }}
+                  name: airflow-ui
+                  {{- end }}
 {{- end }}
 {{- if and .Values.ingress.enabled (eq .Values.airflow.executor "CeleryExecutor") }}
 ---
@@ -111,24 +117,33 @@ spec:
         paths:
           {{- if .Values.authSidecar.enabled  }}
           - path: /{{ .Release.Name }}/flower
+            pathType: Prefix
             backend:
-              serviceName: {{ .Release.Name }}-flower
-              servicePort: auth-proxy
+              service:
+                name: {{ .Release.Name }}-flower
+                port:
+                  name: auth-proxy
           {{- else }}
           - path: /{{ .Release.Name }}/flower(/|$)(.*)
+            pathType: Prefix
             backend:
-              serviceName: {{ .Release.Name }}-flower
-              servicePort: flower-ui
-          {{- end }}
+              service:
+                name: {{ .Release.Name }}-flower
+                port:
+                  name: flower-ui
+          {{ end }}
     - host: {{- include "flower_subdomain" . | indent 1 }}
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: {{ .Release.Name }}-flower
-              {{- if .Values.authSidecar.enabled  }}
-              servicePort: auth-proxy
-              {{- else }}
-              servicePort: flower-ui
-              {{- end }}
+              service:
+                name: {{ .Release.Name }}-flower
+                port:
+                  {{- if .Values.authSidecar.enabled  }}
+                  name: auth-proxy
+                  {{- else }}
+                  name: flower-ui
+                  {{- end }}
 {{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -4,7 +4,7 @@
 {{- if .Values.ingress.enabled }}
   {{ $ctx := . }}
 kind: Ingress
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-airflow-ingress
   labels:
@@ -68,7 +68,7 @@ spec:
 {{- if and .Values.ingress.enabled (eq .Values.airflow.executor "CeleryExecutor") }}
 ---
 kind: Ingress
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-flower-ingress
   labels:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -4,7 +4,11 @@
 {{- if .Values.ingress.enabled }}
   {{ $ctx := . }}
 kind: Ingress
+{{- if semverCompare "< 1.19-0" .Capabilities.KubeVersion.Version -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
 apiVersion: networking.k8s.io/v1
+{{- end }}
 metadata:
   name: {{ .Release.Name }}-airflow-ingress
   labels:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -4,11 +4,7 @@
 {{- if .Values.ingress.enabled }}
   {{ $ctx := . }}
 kind: Ingress
-{{- if semverCompare "< 1.19-0" .Capabilities.KubeVersion.Version -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else }}
 apiVersion: networking.k8s.io/v1
-{{- end }}
 metadata:
   name: {{ .Release.Name }}-airflow-ingress
   labels:


### PR DESCRIPTION
## Description

Update api versions to be compatible with k8s >= 1.22

## Related Issues

[Part of work to support Kubernetes 1.22](https://github.com/astronomer/issues/issues/3889)

[Astronomer Airflow Chart Issue Link to support 1.22](https://github.com/astronomer/issues/issues/4363)

## Testing

- Initial Validation: Added 1.22 k8s kind cluster to run Airflow deployments 
- CI passes on 1.22 and 1.23