### PR TITLE
Add properly quote namespace names

### DIFF
--- a/templates/generate-ssl.yaml
+++ b/templates/generate-ssl.yaml
@@ -25,7 +25,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ .Release.Name }}-pgbouncer-ssl
-  namespace: {{ .Release.Namespace }}
+  namespace: "{{ .Release.Namespace }}"
 roleRef:
   kind: Role
   name: {{ .Release.Name }}-create-secret-role

--- a/tests/chart_tests/helm_template_generator.py
+++ b/tests/chart_tests/helm_template_generator.py
@@ -59,7 +59,7 @@ def create_validator(api_version, kind, kube_version="1.21.0"):
 
 def validate_k8s_object(instance, kube_version="1.21.0"):
     """Validate the k8s object."""
-    # Skip PostgreSQL chart
+    # Skip PostgreSQL chart because it doesn't pass kubernetes json schema validation
     labels = jmespath.search("metadata.labels", instance) or {}
     if "helm.sh/chart" in labels:
         chart = labels["helm.sh/chart"]

--- a/tests/chart_tests/helm_template_generator.py
+++ b/tests/chart_tests/helm_template_generator.py
@@ -60,7 +60,7 @@ def create_validator(api_version, kind, kube_version="1.21.0"):
 def validate_k8s_object(instance, kube_version="1.21.0"):
     """Validate the k8s object."""
     # Skip PostgreSQL chart
-    labels = jmespath.search("metadata.labels", instance)
+    labels = jmespath.search("metadata.labels", instance) or {}
     if "helm.sh/chart" in labels:
         chart = labels["helm.sh/chart"]
     else:

--- a/tests/chart_tests/helm_template_generator.py
+++ b/tests/chart_tests/helm_template_generator.py
@@ -59,7 +59,7 @@ def create_validator(api_version, kind, kube_version="1.21.0"):
 
 def validate_k8s_object(instance, kube_version="1.21.0"):
     """Validate the k8s object."""
-    # Skip PostgreSQL chart because it doesn't pass kubernetes json schema validation
+    # Skip PostgreSQL chart because it doesn't pass kubernetes json schema validation with all-numeric namespace
     labels = jmespath.search("metadata.labels", instance) or {}
     if "helm.sh/chart" in labels:
         chart = labels["helm.sh/chart"]

--- a/tests/chart_tests/helm_template_generator.py
+++ b/tests/chart_tests/helm_template_generator.py
@@ -70,12 +70,14 @@ def render_chart(
     show_only=None,
     chart_dir=None,
     kube_version="1.21.0",
+    namespace=None,
 ):
     """
     Render a helm chart into dictionaries. For helm chart testing only
     """
     values = values or {}
     chart_dir = chart_dir or sys.path[0]
+    namespace = namespace or "default"
     with NamedTemporaryFile() as tmp_file:
         content = yaml.dump(values)
         tmp_file.write(content.encode())
@@ -89,6 +91,9 @@ def render_chart(
             chart_dir,
             "--values",
             tmp_file.name,
+            "--namespace",
+            namespace,
+
         ]
         if show_only:
             if isinstance(show_only, str):

--- a/tests/chart_tests/test_default_chart.py
+++ b/tests/chart_tests/test_default_chart.py
@@ -1,5 +1,6 @@
-from tests.chart_tests.helm_template_generator import render_chart
 import pytest
+
+from tests.chart_tests.helm_template_generator import render_chart
 
 
 def test_default_chart_with_basedomain():

--- a/tests/chart_tests/test_default_chart.py
+++ b/tests/chart_tests/test_default_chart.py
@@ -9,6 +9,6 @@ def test_default_chart_with_basedomain():
 
 
 @pytest.mark.parametrize("namespace", ["abc", "123", "123abc", "123-abc"])
-def test_namespace_names(self, namespace):
+def test_namespace_names(namespace):
     """Test various namespace names to make sure they render correctly in templates"""
     render_chart(namespace=namespace)

--- a/tests/chart_tests/test_default_chart.py
+++ b/tests/chart_tests/test_default_chart.py
@@ -1,7 +1,14 @@
 from tests.chart_tests.helm_template_generator import render_chart
+import pytest
 
 
 def test_default_chart_with_basedomain():
     """Test that each template used with just baseDomain set renders."""
     docs = render_chart()
     assert len(docs) == 26
+
+
+@pytest.mark.parametrize("namespace", ["abc", "123", "123abc", "123-abc"])
+def test_namespace_names(self, namespace):
+    """Test various namespace names to make sure they render correctly in templates"""
+    render_chart(namespace=namespace)


### PR DESCRIPTION
resolves https://github.com/astronomer/issues/issues/3885


```
astronomer-houston-worker-776c89bfc5-6ztvm houston 2022-02-09T18:37:08 INFO Response from #createDeployment: {"result":{"message":"failed pre-install: warning: Hook pre-install airflow/templates/generate-ssl.yaml failed: RoleBinding in version \"v1beta1\" cannot be handled as a RoleBinding: v1beta1.RoleBinding.Subjects: []v1beta1.Subject: v1beta1.Subject.Namespace: ReadString: expects \" or n, but found 1, error found in #10 byte of ...|mespace\":12345}]}\n|..., bigger context ...|name\":\"test-number-ns-pgbouncer-ssl\",\"namespace\":12345}]}\n|..."},"deployment":{}}
```