### PR TITLE
fix for pgbouncer client certs generation issue with openshift

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -416,4 +416,4 @@ astronomer:
   images:
     certgenerator:
       repository: quay.io/astronomer/ap-certgenerator
-      tag: 0.1.0
+      tag: 0.1.2


### PR DESCRIPTION
## Description

Certificates are not generated due to permission issues - introduced by uid ranges that was not considered initially for openshift

## Related Issues

https://github.com/astronomer/issues/issues/4223

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.
