### PR TITLE
bump release 0.20 images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
   airflow-test:
     machine:
       # https://circleci.com/docs/2.0/configuration-reference/#available-machine-images
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:202111-01
       resource_class: large
     parameters:
       executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs:
       - run:
           name: Install Airflow chart
           command: |
-            pyenv global 3.9.1
+            pyenv global 3.9.7
             export KUBE_VERSION=<< parameters.kube_version >>
             export EXECUTOR=<< parameters.executor >>
             HELM_CHART_PATH=$(find /tmp/workspace/ -name 'airflow-*.tgz')

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
 
   build-and-release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2021-04
+      - image: quay.io/astronomer/ci-helm-release:2022-01
     steps:
       - checkout
       - run:
@@ -139,7 +139,7 @@ jobs:
 
   release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2021-04
+      - image: quay.io/astronomer/ci-helm-release:2022-01
     steps:
       - checkout
       - run:
@@ -148,7 +148,7 @@ jobs:
 
   release-public:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2021-04
+      - image: quay.io/astronomer/ci-helm-release:2022-01
     steps:
       - checkout
       - publish-github-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ workflows:
 jobs:
   run_pre_commit:
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2021-05
+      - image: quay.io/astronomer/ci-pre-commit:2022-01
     steps:
       - checkout
       - run:

--- a/bin/install-ci-tools
+++ b/bin/install-ci-tools
@@ -2,7 +2,7 @@
 set -e
 
 if [[ -z "${KIND_VERSION}" ]]; then
-  export KIND_VERSION="0.7.0"
+  export KIND_VERSION="0.11.1"
 fi
 
 if [[ -z "${HELM_VERSION}" ]]; then

--- a/values.yaml
+++ b/values.yaml
@@ -94,15 +94,15 @@ images:
     pullPolicy: IfNotPresent
   redis:
     repository: quay.io/astronomer/ap-redis
-    tag: 6.2.5-1
+    tag: 6.2.6
     pullPolicy: IfNotPresent
   pgbouncer:
     repository: quay.io/astronomer/ap-pgbouncer
-    tag: 1.8.1
+    tag: 1.16.1
     pullPolicy: IfNotPresent
   pgbouncerExporter:
     repository: quay.io/astronomer/ap-pgbouncer-exporter
-    tag: 0.11.0-1
+    tag: 0.13.0
     pullPolicy: IfNotPresent
 
 # Environment variables for all airflow containers


### PR DESCRIPTION
* ap-pgbouncer 1.8.1 -> 1.16.1
* ap-pgbouncer-exporter 0.11.0-1 -> 0.13.0
* ap-redis 6.2.5-1 -> 6.2.6

## Description

Do not merge this PR until this description is replaced with relevant info.

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.
