### PR TITLE
backport ap-vendor security updates to release-1.0 airflow chart

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ workflows:
 jobs:
   run_pre_commit:
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2021-11
+      - image: quay.io/astronomer/ci-pre-commit:2022-01
     steps:
       - checkout
       - run:
@@ -84,7 +84,7 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2021-11
+      - image: quay.io/astronomer/ci-helm-release:2022-01
     steps:
       - checkout
       - run:
@@ -93,7 +93,7 @@ jobs:
 
   build-and-release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2021-11
+      - image: quay.io/astronomer/ci-helm-release:2022-01
     steps:
       - checkout
       - run:
@@ -107,7 +107,7 @@ jobs:
   airflow-test:
     machine:
       # https://circleci.com/docs/2.0/configuration-reference/#available-machine-images
-      image: ubuntu-2004:202107-02
+      image: ubuntu-2004:202111-01
       resource_class: large
     parameters:
       executor:
@@ -123,7 +123,7 @@ jobs:
       - run:
           name: Install Airflow chart
           command: |
-            pyenv global 3.9.4
+            pyenv global 3.9.7
             export KUBE_VERSION=<< parameters.kube_version >>
             export EXECUTOR=<< parameters.executor >>
             HELM_CHART_PATH=$(find /tmp/workspace/ -name 'airflow-*.tgz')

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v2 is Helm 3
 apiVersion: v2
 name: airflow
-version: 1.0.9
+version: 1.0.10
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:

--- a/bin/install-ci-tools
+++ b/bin/install-ci-tools
@@ -2,7 +2,7 @@
 set -e
 
 if [[ -z "${KIND_VERSION}" ]]; then
-  export KIND_VERSION="0.7.0"
+  export KIND_VERSION="0.11.1"
 fi
 
 if [[ -z "${HELM_VERSION}" ]]; then

--- a/values.yaml
+++ b/values.yaml
@@ -32,13 +32,13 @@ airflow:
       tag: 0.18.0
     redis:
       repository: quay.io/astronomer/ap-redis
-      tag: 6.2.5-1
+      tag: 6.2.6
     pgbouncer:
       repository: quay.io/astronomer/ap-pgbouncer
-      tag: 1.16.0
+      tag: 1.16.1
     pgbouncerExporter:
       repository: quay.io/astronomer/ap-pgbouncer-exporter
-      tag: 0.11.0-2
+      tag: 0.13.0
     gitSync:
       repository: k8s.gcr.io/git-sync/git-sync
       tag: v3.3.4

--- a/values.yaml
+++ b/values.yaml
@@ -40,8 +40,8 @@ airflow:
       repository: quay.io/astronomer/ap-pgbouncer-exporter
       tag: 0.13.0
     gitSync:
-      repository: k8s.gcr.io/git-sync/git-sync
-      tag: v3.3.4
+      repository: quay.io/astronomer/ap-git-sync
+      tag: 3.3.5
   # Airflow scheduler settings
   scheduler:
     livenessProbe:


### PR DESCRIPTION

## Description
**backport vendor packages to release_1_0**
* ap-redis 6.2.5-1 -> 6.2.6
* ap-pgbouncer 1.16.0 -> 1.16.1
* ap-pgbouncer-exporter 0.11.0-2 -> 0.13.0

**additional changes**

migrate k8s.gcr.io/git-sync/git-sync to astronomer quay.io/astronomer/ap-git-sync
update git-sync image version 3.3.4 -> 3.3.5

**circle ci config updates**
* updates to kind package version
* ci image version update
* helm release image version update
* circleci ubuntu image version update
* set python to 3.9.7

## Related Issues

Issue Link : https://github.com/astronomer/issues/issues/4210

## Testing

QA should able to deploy airflow deployment without any issues
