### PR TITLE
Lowercase RELEASE-NAME for helm 3.8 compatibility

### DIFF
--- a/tests/chart_tests/helm_template_generator.py
+++ b/tests/chart_tests/helm_template_generator.py
@@ -74,7 +74,7 @@ def validate_k8s_object(instance, kube_version="1.21.0"):
 
 
 def render_chart(
-    name="RELEASE-NAME",
+    name="release-name",
     values=None,
     show_only=None,
     chart_dir=None,


### PR DESCRIPTION
## Description

Helm 3.8 enforces a regex that has been around for a while where release names have to be lower case.

## Related Issues

<https://github.com/astronomer/issues/issues/4124>

## Testing

This same change has already been merged in astronomer/astronomer.