### PR TITLE
1244 fix additional volume template

### DIFF
--- a/templates/workers/worker-persistentvolume.yaml
+++ b/templates/workers/worker-persistentvolume.yaml
@@ -21,5 +21,5 @@ spec:
     - {{ default "ReadWriteMany" $additionalVolume.accessMode }}
   persistentVolumeReclaimPolicy: Delete
   storageClassName: {{ $additionalVolume.storageClassName }}
-{{- toYaml $additionalVolume.volumePlugin | nindent 2 }}
+  volumePlugin: {{- toYaml $additionalVolume.volumePlugin | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
## Description

This fixes the report of a volume template bug made in https://github.com/astronomer/astronomer/issues/1244

## Testing

I manually tested this. You can see my comment about digging into the bug and what the fix is here: https://github.com/astronomer/astronomer/issues/1244#issuecomment-1076944297

This would have been caught by pytest chart tests that exist in newer versions of the chart. astronomer/airflow-chart version 0.20 is used by astronomer/astronomer version 0.25, which is an LTS. We may want to back-port pytest tests to that version since [we plan to support astronomer/astronomer version 0.25 until December 2022](https://docs.astronomer.io/software/release-lifecycle-policy/#software-lifecycle-schedule). This could be a good learning exercise for new folks on the team, and likely wouldn't take much difficulty, but could take 1-3 days for new folks.

## Merging

This change should only be merged into release-0.20 branch. It is irrelevant for anything newer. AFAIK we are not supporting anything older, but it would be safe to merge into older branches if needed.