### PR TITLE
update vendor images in airflow chart

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: remove-tabs
         exclude_types: [makefile, binary]
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v2.6.0"
+    rev: "v2.6.1"
     hooks:
       - id: prettier
         args: ["--print-width=135"]
@@ -19,7 +19,7 @@ repos:
         name: isort (python)
         args: ["--profile", "black"]
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/asottile/pyupgrade

--- a/values.yaml
+++ b/values.yaml
@@ -35,10 +35,10 @@ airflow:
       tag: 6.2.6
     pgbouncer:
       repository: quay.io/astronomer/ap-pgbouncer
-      tag: 1.16.1
+      tag: 1.17.0
     pgbouncerExporter:
       repository: quay.io/astronomer/ap-pgbouncer-exporter
-      tag: 0.13.0
+      tag: 0.13.0-1
     gitSync:
       repository: quay.io/astronomer/ap-git-sync
       tag: 3.3.5


### PR DESCRIPTION


## Description

Enhancement to pgbouncer service and various security fixes

* update ap-pgbouncer 1.16.1 -> 1.17.0
* ap-pgbouncer-exporter 0.13.0 -> 0.13.0-1

## Related Issues

NA

## Testing

QA should able to perform deploy and upgrade without any issues 
