### PR TITLE
update sidecar logging template - replace fluentd with vector elasticsearch configmap

### DIFF
--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -5,7 +5,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: {{ .Release.Name }}-logging-sidecar
+  name: sidecar-logging
   labels:
     tier: airflow
     component: logging-sidecar
@@ -13,86 +13,25 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
 data:
-  main.conf: |-
-    <source>
-      @id unstructured-logging
-      @type tcp
-      tag tcp.events
-      bind 127.0.0.1
-      port 5170
-      <parse>
-        @type regexp
-        expression /(?<version>[^ ]+) (?<logtime>[^ ]+) (?<stream>[^ ]+) (?<component>[^ ]+) (?<message>.*)/
-      </parse>
-    </source>
+  vector-config.yaml: |
+    data_dir = "#{ENV['SIDECAR_LOGS_DIR']}"
+    sources:
+      generate_syslog:
+        type: file
+        include: 
+          - #{ENV['SIDECAR_LOGS_DIR']}/*.log
+        read_from: beginning
+    sinks:
+      out:
+        type: elasticsearch
+        inputs:
+          - generate_syslog
+        mode: bulk
+        compression: none
+        endpoint: "http://{{.Values.loggingSidecar.enabled}}:9200"
+        auth:
+          strategy: "basic"
+          user: {{ .Values.loggingSidecar.user }}
+          password : {{ .Values.loggingSidecar.password }}
 
-    <filter tcp.events>
-      @type record_transformer
-      enable_ruby
-      renew_record
-      <record>
-        workspace "#{ENV['WORKSPACE']}"
-        release "#{ENV['RELEASE']}"
-        logtime ${record["logtime"]}
-        component ${record["component"]}
-        stream ${record["stream"]}
-        message ${record["message"]}
-      </record>
-      <inject>
-        time_key @logtime
-        time_type unixtime_nanos
-      </inject>
-    </filter>
-
-    <match tcp.events>
-      @type rewrite_tag_filter
-      <rule>
-        key release
-        pattern /^(.+)/
-        tag airflow.$1
-      </rule>
-    </match>
-
-    <match airflow.*>
-      @type rewrite_tag_filter
-      <rule>
-        key component
-        pattern /^(.+)/
-        tag ${tag}.$1
-      </rule>
-    </match>
-
-    <match airflow.**>
-      @type copy
-      <store>
-        @id elasticsearch
-        @type elasticsearch_dynamic
-        @log_level info
-        include_timestamp true
-        reconnect_on_error true
-        reload_on_failure true
-        reload_connections false
-        request_timeout 120s
-        suppress_type_name true
-        host "#{ENV['OUTPUT_HOST']}"
-        port "#{ENV['OUTPUT_PORT']}"
-        index_name fluentd.${record["release"]}.${Time.at(time).getutc.strftime(@logstash_dateformat)}
-        <buffer>
-          @type file
-          path "/tmp/buffer"
-          flush_mode interval
-          retry_type exponential_backoff
-          flush_thread_count 2
-          flush_interval 5s
-          retry_forever
-          retry_max_interval 30
-          chunk_limit_size "#{ENV['OUTPUT_BUFFER_CHUNK_LIMIT']}"
-          queue_limit_length "#{ENV['OUTPUT_BUFFER_QUEUE_LIMIT']}"
-          overflow_action block
-        </buffer>
-        #<buffer>
-        #  @type memory
-        #</buffer>
-      </store>
-    </match>
 {{- end }}

--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -28,7 +28,7 @@ data:
           - generate_syslog
         mode: bulk
         compression: none
-        endpoint: "http://{{.Values.loggingSidecar.host}}:{{ .Values.loggingSidecar.port }}"
+        endpoint: "http://{{ .Values.loggingSidecar.host }}:{{ .Values.loggingSidecar.port }}"
         auth:
           strategy: "basic"
           user: {{ .Values.loggingSidecar.user }}

--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -5,7 +5,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: sidecar-logging
+  name: sidecar-config
   labels:
     tier: airflow
     component: logging-sidecar
@@ -28,10 +28,14 @@ data:
           - generate_syslog
         mode: bulk
         compression: none
-        endpoint: "http://{{ .Values.loggingSidecar.host }}:{{ .Values.loggingSidecar.port }}"
+      {{- if .Values.airflow.elasticsearch.enabled  }}
+        endpoint: "http://{{ .Values.airflow.elasticsearch.connection.host }}:{{ .Values.airflow.elasticsearch.connection.port }}"
         auth:
           strategy: "basic"
-          user: {{ .Values.loggingSidecar.user }}
-          password : {{ .Values.loggingSidecar.password }}
+          user: {{ .Values.airflow.elasticsearch.connection.user }}
+          password : {{ .Values.airflow.elasticsearch.connection.password }}
+      {{ else }}
+      # TODO - confirm what needs to be done incase ES config disabled and not provided
+      {{- end }}
 
 {{- end }}

--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   vector-config.yaml: |
-    data_dir = "#{ENV['SIDECAR_LOGS_DIR']}"
+    data_dir : #{ENV['SIDECAR_LOGS_DIR']}
     sources:
       generate_syslog:
         type: file

--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -18,7 +18,7 @@ data:
     sources:
       generate_syslog:
         type: file
-        include: 
+        include:
           - #{ENV['SIDECAR_LOGS_DIR']}/*.log
         read_from: beginning
     sinks:
@@ -28,7 +28,7 @@ data:
           - generate_syslog
         mode: bulk
         compression: none
-        endpoint: "http://{{.Values.loggingSidecar.enabled}}:9200"
+        endpoint: "http://{{.Values.loggingSidecar.host}}:{{ .Values.loggingSidecar.port }}"
         auth:
           strategy: "basic"
           user: {{ .Values.loggingSidecar.user }}

--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -43,8 +43,6 @@ data:
           strategy: "basic"
           user: {{ .Values.airflow.elasticsearch.connection.user }}
           password : {{ .Values.airflow.elasticsearch.connection.pass }}
-      {{ else }}
-      # TODO - confirm what needs to be done incase ES config disabled and not provided
       {{- end }}
 
 {{- end }}

--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -14,18 +14,27 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   vector-config.yaml: |
-    data_dir : #{ENV['SIDECAR_LOGS_DIR']}
+    data_dir: "${SIDECAR_LOGS}"
     sources:
       generate_syslog:
         type: file
         include:
-          - #{ENV['SIDECAR_LOGS_DIR']}/*.log
+          - "${SIDECAR_LOGS}/*.log"
         read_from: beginning
+    transforms:
+      transform_syslog:
+        type: add_fields
+        inputs: 
+          - generate_syslog
+        fields:
+          component: "${COMPONENT:--}"
+          workspace: "${WORKSPACE:--}"
+          release: "${RELEASE:--}"
     sinks:
       out:
         type: elasticsearch
         inputs:
-          - generate_syslog
+          - transform_syslog
         mode: bulk
         compression: none
       {{- if .Values.airflow.elasticsearch.enabled  }}

--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -24,7 +24,7 @@ data:
     transforms:
       transform_syslog:
         type: add_fields
-        inputs: 
+        inputs:
           - generate_syslog
         fields:
           component: "${COMPONENT:--}"

--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -5,7 +5,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: sidecar-config
+  name: {{ .Release.Name }}-sidecar-config
   labels:
     tier: airflow
     component: logging-sidecar
@@ -42,7 +42,7 @@ data:
         auth:
           strategy: "basic"
           user: {{ .Values.airflow.elasticsearch.connection.user }}
-          password : {{ .Values.airflow.elasticsearch.connection.password }}
+          password : {{ .Values.airflow.elasticsearch.connection.pass }}
       {{ else }}
       # TODO - confirm what needs to be done incase ES config disabled and not provided
       {{- end }}

--- a/tests/chart_tests/test_logging_sidecar.py
+++ b/tests/chart_tests/test_logging_sidecar.py
@@ -1,0 +1,39 @@
+import pytest
+
+from tests.chart_tests.helm_template_generator import render_chart
+
+from .. import supported_k8s_versions
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+class TestLoggingSidecar:
+    def test_logging_sidecar_config_defaults(self, kube_version):
+        """Test logging sidecar config with defaults"""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "loggingSidecar": {"enabled": True},
+                "airflow": {
+                    "elasticsearch": {
+                        "enabled": True,
+                        "connection": {"user": "testuser", "pass": "testpass"},
+                    }
+                },
+            },
+            show_only="templates/logging-sidecar-configmap.yaml",
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+        assert "ConfigMap" == doc["kind"]
+        assert "v1" == doc["apiVersion"]
+        assert "testuser" in doc["data"]["vector-config.yaml"]
+        assert "testpass" in doc["data"]["vector-config.yaml"]
+
+    def test_logging_sidecar_config_disabled(self, kube_version):
+        """Test logging sidecar config with flag disabled"""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"loggingSidecar": {"enabled": False}},
+            show_only="templates/logging-sidecar-configmap.yaml",
+        )
+        assert len(docs) == 0

--- a/values.yaml
+++ b/values.yaml
@@ -223,6 +223,12 @@ airflow:
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           name: base
           ports: []
+    {{- if .Values.loggingSidecar.enabled }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh","-c","curl http://127.0.0.1:8000/quitquitquit]
+    {{- end }}
           volumeMounts:
             - mountPath: {{ template "airflow_logs" . }}
               name: logs
@@ -374,7 +380,8 @@ authSidecar:
   port: 8084
 
 loggingSidecar:
-  enabled: false
+  enabled: true
+  name: sidecar-logging-consumer
 
 # Ingress configuration
 ingress:

--- a/values.yaml
+++ b/values.yaml
@@ -374,7 +374,7 @@ authSidecar:
   port: 8084
 
 loggingSidecar:
-  enabled: true
+  enabled: false
   name: sidecar-logging-consumer
 
 # Ingress configuration

--- a/values.yaml
+++ b/values.yaml
@@ -226,7 +226,7 @@ airflow:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh","-c","curl http://127.0.0.1:8000/quitquitquit]
+                command: ["/bin/sh","-c","curl -XPOST http://127.0.0.1:8000/quitquitquit"]
           volumeMounts:
             - mountPath: {{ template "airflow_logs" . }}
               name: logs

--- a/values.yaml
+++ b/values.yaml
@@ -223,10 +223,6 @@ airflow:
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           name: base
           ports: []
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh","-c","curl -XPOST http://127.0.0.1:8000/quitquitquit"]
           volumeMounts:
             - mountPath: {{ template "airflow_logs" . }}
               name: logs

--- a/values.yaml
+++ b/values.yaml
@@ -223,12 +223,10 @@ airflow:
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           name: base
           ports: []
-    {{- if .Values.loggingSidecar.enabled }}
           lifecycle:
             preStop:
               exec:
                 command: ["/bin/sh","-c","curl http://127.0.0.1:8000/quitquitquit]
-    {{- end }}
           volumeMounts:
             - mountPath: {{ template "airflow_logs" . }}
               name: logs


### PR DESCRIPTION
## Description

This PR updates the current sidecar logging template by replacing fluentd configmap with a vector configmap for elastic search consumer

## Related Issues
Related astronomer/issues#4419

## Testing
Tested on a kind cluster
