### PR TITLE
Documentation | Add default creds to login local KinD airflow deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ helm list -n airflow
 
 Run `kubectl port-forward svc/airflow-webserver 8080:8080 -n airflow`
 to port-forward the Airflow UI to http://localhost:8080/ to confirm Airflow is working.
+Login as _admin_ and password _admin_.
 
 **Build a Docker image from your DAGs:**
 


### PR DESCRIPTION
## Description

As a first time user for the local deployment of Airflow in KinD cluster, the Airflow login creds were not mentioned in the README

## Related Issues

NA

## Testing

README change

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
