### PR TITLE
override timestamp key type from string to timestamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /config.yaml
 /config.yml
 /secrets
+/test-results
 backup
 certs
 dev-account.json

--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -14,6 +14,8 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   vector-config.yaml: |
+    log_schema:
+      timestamp_key : "@timestamp"
     data_dir: "${SIDECAR_LOGS}"
     sources:
       generate_syslog:
@@ -45,7 +47,7 @@ data:
           password : {{ .Values.airflow.elasticsearch.connection.pass }}
       {{- end }}
         bulk:
-          index: "vector.${RELEASE:--}.%Y-%m-%d-%s"
+          index: "vector.${RELEASE:--}.%Y-%m-%d"
           action: create
 
 {{- end }}

--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -44,5 +44,8 @@ data:
           user: {{ .Values.airflow.elasticsearch.connection.user }}
           password : {{ .Values.airflow.elasticsearch.connection.pass }}
       {{- end }}
+        bulk:
+          index: "vector.${RELEASE:--}.%Y-%m-%d-%s"
+          action: create
 
 {{- end }}

--- a/tests/chart_tests/conftest.py
+++ b/tests/chart_tests/conftest.py
@@ -69,7 +69,7 @@ def docker_daemon_present():
         return False
 
 
-@pytest.fixture(autouse=True, scope="session")
+@pytest.fixture(scope="session")
 def docker_client():
     """This is a text fixture for the docker client,
     should it be needed in a test

--- a/tests/chart_tests/test_logging_sidecar.py
+++ b/tests/chart_tests/test_logging_sidecar.py
@@ -1,4 +1,5 @@
 import pytest
+import yaml
 
 from tests.chart_tests.helm_template_generator import render_chart
 
@@ -26,8 +27,12 @@ class TestLoggingSidecar:
         doc = docs[0]
         assert "ConfigMap" == doc["kind"]
         assert "v1" == doc["apiVersion"]
-        assert "testuser" in doc["data"]["vector-config.yaml"]
-        assert "testpass" in doc["data"]["vector-config.yaml"]
+        assert (vc := yaml.safe_load(doc["data"]["vector-config.yaml"]))
+        assert vc["sinks"]["out"]["auth"] == {
+            "strategy": "basic",
+            "user": "testuser",
+            "password": "testpass",
+        }
 
     def test_logging_sidecar_config_disabled(self, kube_version):
         """Test logging sidecar config with flag disabled"""


### PR DESCRIPTION
## Description

- This PR overrides vector's global timestamp field type from string to type timestamp. Due to this the ES query that renders Airflow UI and Astronomer UI logs were failing to be fetched.
- This also creates a unique index per sidecar-container. Currently all container logs were written to a default index 

## Related Issues

Related https://github.com/astronomer/issues/issues/4575

## Testing

Tested on remote cluster

## Merging

0.29.0
