### PR TITLE
Add securityContext for redis sts to run as non-root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /test-results
 backup
 certs
+charts
 dev-account.json
 kubeconfig
 letsencrypt*

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v2 is Helm 3
 apiVersion: v2
 name: airflow
-version: 1.4.1
+version: 1.6.0-rc1
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:
@@ -9,5 +9,5 @@ keywords:
   - airflow
 dependencies:
   - name: airflow
-    version: 1.4.0
+    version: 1.6.0
     repository: https://airflow.apache.org

--- a/tests/chart_tests/test_default_chart.py
+++ b/tests/chart_tests/test_default_chart.py
@@ -6,7 +6,7 @@ from tests.chart_tests.helm_template_generator import render_chart
 def test_default_chart_with_basedomain():
     """Test that each template used with just baseDomain set renders."""
     docs = render_chart()
-    assert len(docs) == 26
+    assert len(docs) == 28
 
 
 @pytest.mark.parametrize("namespace", ["abc", "123", "123abc", "123-abc"])

--- a/tests/chart_tests/test_redis.py
+++ b/tests/chart_tests/test_redis.py
@@ -1,0 +1,52 @@
+import pytest
+
+from tests.chart_tests.helm_template_generator import render_chart
+
+from .. import supported_k8s_versions
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+class TestRedis:
+    def test_redis_sts_defaults(self, kube_version):
+        """Test Redis statefulSet defaults"""
+        # TODO: find a way to use show-only with subchart
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "airflow": {
+                    "executor": "CeleryExecutor",
+                },
+            },
+        )
+
+        # workaround to find the redis sts from the subchart since we can't use --show-only
+        redis_sts = [
+            x
+            for x in docs
+            if x["kind"] == "StatefulSet"
+            and x["metadata"]["name"] == "release-name-redis"
+        ][0]
+        assert redis_sts["spec"]["template"]["spec"]["securityContext"] == {
+            "runAsUser": 0
+        }
+
+    def test_redis_sts_securityContext(self, kube_version):
+        """Test Redis statefulSet with securityContext defined"""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "airflow": {
+                    "executor": "CeleryExecutor",
+                    "redis": {"securityContext": {"fsGroup": 5000}},
+                },
+            },
+        )
+        redis_sts = [
+            x
+            for x in docs
+            if x["kind"] == "StatefulSet"
+            and x["metadata"]["name"] == "release-name-redis"
+        ][0]
+        assert (
+            redis_sts["spec"]["template"]["spec"]["securityContext"]["fsGroup"] == 5000
+        )


### PR DESCRIPTION
## Description

Add securityContext for redis sts to run as non-root

## Related Issues

https://github.com/astronomer/issues/issues/3348

## Testing

This includes tests, which should be enough, as long as CI passes.

## Merging

This is just for release 1.6.