### PR TITLE
Exclude a bunch of unrelated repo data from the chart.

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -28,8 +28,6 @@ bin
 CODEOWNERS
 CONTRIBUTING.md
 Makefile
-README.md
-UPDATING.md
 configs
 dev
 tests

--- a/.helmignore
+++ b/.helmignore
@@ -21,4 +21,15 @@
 *.tmproj
 bin
 # Astronomer helm repository directory
+.circleci
+.github
+.gitignore
+.pre-commit-config.yaml
+CODEOWNERS
+CONTRIBUTING.md
+Makefile
+README.md
+UPDATING.md
 configs
+dev
+tests


### PR DESCRIPTION
## Description

A lot of extra files are being included in our helm chart. These additions keep the helm chart more tidy and a bit smaller file size.

```
$ k -n astronomer-redacted-redactination-123 get secret "sh.helm.release.v1.redacted-redactination-123.v42" -o jsonpath='{.data.release}' | base64 -d | base64 -d | gzip -d | jq '.chart.files[].name'
2022-06-17T14:48:07-0700
".circleci/config.yml"
".github/pull_request_template.md"
".helmignore"
".pre-commit-config.yaml"
"CODEOWNERS"
"CONTRIBUTING.md"
"LICENSE"
"Makefile"
"README.md"
"UPDATING.md"
"dev/custom_upstream_airflow_chart_release.md"
"tests/README.md"
"tests/__init__.py"
"tests/chart_tests/__init__.py"
"tests/chart_tests/conftest.py"
"tests/chart_tests/helm_template_generator.py"
"tests/chart_tests/requirements.in"
"tests/chart_tests/requirements.txt"
"tests/chart_tests/test_default_chart.py"
"tests/chart_tests/test_docker_images.py"
"tests/chart_tests/test_extra_objects.py"
"tests/chart_tests/test_ingress.py"
"tests/chart_tests/test_logging_sidecar.py"
"tests/chart_tests/test_pgbouncer_certgenerator.py"
"tests/chart_tests/test_scc.py"
"tests/chart_tests/test_worker_hpa.py"
"tests/functional-tests/requirements.in"
"tests/functional-tests/requirements.txt"
"tests/functional-tests/test_chart.py"
```

## Related Issues

Found while debugging some elusive pgbouncer restart stuff. Opened a similar PR in astronomer: <https://github.com/astronomer/astronomer/pull/1573>

## Testing

N/A, but if tests pass then we're good.

## Merging

This should be merged into all supported branches.