### PR TITLE
Custom vector config

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: airflow
   repository: https://airflow.apache.org
-  version: 1.4.0
-digest: sha256:75f857a231746d64ab3dccdcf88959a7c5155715e21620535eb19ad9dd17b7c1
-generated: "2022-01-11T11:41:40.735569-07:00"
+  version: 1.6.0
+digest: sha256:88f5a8d12d66eae1424902b048ac77c3ec5cd133ebb7634710005d300eb42777
+generated: "2022-06-28T00:44:42.650889+05:30"

--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -14,6 +14,9 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   vector-config.yaml: |
+{{- if .Values.loggingSidecar.customConfig }}
+    {{ tpl .Values.loggingSidecar.airflowSidecarConfig . | nindent 4 }}
+{{- else }}
     log_schema:
       timestamp_key : "@timestamp"
     data_dir: "${SIDECAR_LOGS}"
@@ -72,5 +75,5 @@ data:
         bulk:
           index: "vector.${RELEASE:--}.%Y.%m.%d"
           action: create
-
+{{- end }}
 {{- end }}

--- a/tests/chart_tests/test_logging_sidecar.py
+++ b/tests/chart_tests/test_logging_sidecar.py
@@ -1,3 +1,5 @@
+import textwrap
+
 import pytest
 import yaml
 
@@ -45,14 +47,42 @@ class TestLoggingSidecar:
 
     def test_logging_sidecar_custom_config(self, kube_version):
         """Test logging sidecar config with customConfig flag enabled"""
+        custom_side_carconfig = textwrap.dedent(
+            """
+        loggingSidecar:
+          enabled: true
+          customConfig: true
+          name: sidecar-logging-consumer
+          airflowSidecarConfig: |2
+              log_schema:
+                timestamp_key : "@timestamp"
+              data_dir: "${SIDECAR_LOGS}"
+              sources:
+                generate_syslog:
+                  type: file
+                  include:
+                    - "${SIDECAR_LOGS}/*.log"
+                  read_from: beginning
+              transforms:
+                transform_syslog:
+                  type: add_fields
+                  inputs:
+                    - generate_syslog
+                  fields:
+                    component: "${COMPONENT:--}"
+                    workspace: "${WORKSPACE:--}"
+                    release: "${RELEASE:--}"
+              sinks:
+                out:
+                  type: datadog
+                  inputs:
+                    - transform_syslog
+                """
+        )
+        values = yaml.safe_load(custom_side_carconfig)
         docs = render_chart(
             kube_version=kube_version,
-            values={
-                "loggingSidecar": {
-                    "enabled": True,
-                    "customConfig": True,
-                },
-            },
+            values=values,
             show_only="templates/logging-sidecar-configmap.yaml",
         )
         assert len(docs) == 1
@@ -60,5 +90,4 @@ class TestLoggingSidecar:
         assert "ConfigMap" == doc["kind"]
         assert "v1" == doc["apiVersion"]
         assert (vc := yaml.safe_load(doc["data"]["vector-config.yaml"]))
-        # should not load default configmap
-        assert None in vc
+        assert vc["sinks"]["out"]["type"] == "datadog"

--- a/tests/chart_tests/test_logging_sidecar.py
+++ b/tests/chart_tests/test_logging_sidecar.py
@@ -47,13 +47,13 @@ class TestLoggingSidecar:
 
     def test_logging_sidecar_custom_config(self, kube_version):
         """Test logging sidecar config with customConfig flag enabled"""
-        custom_side_carconfig = textwrap.dedent(
+        test_custom_sidecar_config = textwrap.dedent(
             """
         loggingSidecar:
           enabled: true
           customConfig: true
           name: sidecar-logging-consumer
-          airflowSidecarConfig: |2
+          airflowSidecarConfig: |
               log_schema:
                 timestamp_key : "@timestamp"
               data_dir: "${SIDECAR_LOGS}"
@@ -79,7 +79,7 @@ class TestLoggingSidecar:
                     - transform_syslog
                 """
         )
-        values = yaml.safe_load(custom_side_carconfig)
+        values = yaml.safe_load(test_custom_sidecar_config)
         docs = render_chart(
             kube_version=kube_version,
             values=values,

--- a/tests/chart_tests/test_logging_sidecar.py
+++ b/tests/chart_tests/test_logging_sidecar.py
@@ -42,3 +42,49 @@ class TestLoggingSidecar:
             show_only="templates/logging-sidecar-configmap.yaml",
         )
         assert len(docs) == 0
+
+    def test_logging_sidecar_custom_config(self, kube_version):
+        """Test logging sidecar config with customConfig flag enabled"""
+        airflowSidecarConfig = """
+  airflowSidecarConfig: |2
+      log_schema:
+        timestamp_key : "@timestamp"
+      data_dir: "${SIDECAR_LOGS}"
+      sources:
+        generate_syslog:
+          type: file
+          include:
+            - "${SIDECAR_LOGS}/*.log"
+          read_from: beginning
+      transforms:
+        transform_syslog:
+          type: add_fields
+          inputs:
+            - generate_syslog
+          fields:
+            component: "${COMPONENT:--}"
+            workspace: "${WORKSPACE:--}"
+            release: "${RELEASE:--}"
+      sinks:
+        out:
+          type: datadog
+          inputs:
+            - transform_syslog
+"""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "loggingSidecar": {
+                    "enabled": True,
+                    "customConfig": True,
+                    "airflowSidecarConfig": airflowSidecarConfig,
+                },
+            },
+            show_only="templates/logging-sidecar-configmap.yaml",
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+        assert "ConfigMap" == doc["kind"]
+        assert "v1" == doc["apiVersion"]
+        assert (vc := yaml.safe_load(doc["data"]["vector-config.yaml"]))
+        assert vc["sinks"]["out"]["type"] == "datadog"

--- a/tests/chart_tests/test_logging_sidecar.py
+++ b/tests/chart_tests/test_logging_sidecar.py
@@ -54,29 +54,29 @@ class TestLoggingSidecar:
           customConfig: true
           name: sidecar-logging-consumer
           airflowSidecarConfig: |
-              log_schema:
-                timestamp_key : "@timestamp"
-              data_dir: "${SIDECAR_LOGS}"
-              sources:
-                generate_syslog:
-                  type: file
-                  include:
-                    - "${SIDECAR_LOGS}/*.log"
-                  read_from: beginning
-              transforms:
-                transform_syslog:
-                  type: add_fields
-                  inputs:
-                    - generate_syslog
-                  fields:
-                    component: "${COMPONENT:--}"
-                    workspace: "${WORKSPACE:--}"
-                    release: "${RELEASE:--}"
-              sinks:
-                out:
-                  type: datadog
-                  inputs:
-                    - transform_syslog
+            log_schema:
+              timestamp_key : "@timestamp"
+            data_dir: "${SIDECAR_LOGS}"
+            sources:
+              generate_syslog:
+                type: file
+                include:
+                  - "${SIDECAR_LOGS}/*.log"
+                read_from: beginning
+            transforms:
+              transform_syslog:
+                type: add_fields
+                inputs:
+                  - generate_syslog
+                fields:
+                  component: "${COMPONENT:--}"
+                  workspace: "${WORKSPACE:--}"
+                  release: "${RELEASE:--}"
+            sinks:
+              out:
+                type: datadog
+                inputs:
+                  - transform_syslog
                 """
         )
         values = yaml.safe_load(test_custom_sidecar_config)

--- a/values.yaml
+++ b/values.yaml
@@ -383,6 +383,7 @@ authSidecar:
 loggingSidecar:
   enabled: false
   name: sidecar-logging-consumer
+  customConfig: false
 
 # Ingress configuration
 ingress:

--- a/values.yaml
+++ b/values.yaml
@@ -384,6 +384,7 @@ loggingSidecar:
   enabled: false
   name: sidecar-logging-consumer
   customConfig: false
+  airflowSidecarConfig: ""
 
 # Ingress configuration
 ingress:


### PR DESCRIPTION
## Description

A change to previous implementation (https://github.com/astronomer/airflow-chart/pull/332) to load entire configmap only if loggingSidecar: customConfig is disabled, else load from secret using configsyncer

## Related Issues

https://github.com/astronomer/issues/issues/4733

## Related PRs
Houston - https://github.com/astronomer/houston-api/pull/1154
Astronomer - https://github.com/astronomer/astronomer/pull/1575

## Testing

Tested on kind cluster

## Merging

0.29.2
