### PR TITLE
updated condition to load vector configmap

### DIFF
--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -1,7 +1,7 @@
 ######################################
 ## Logging sidecar configmap        ##
 ######################################
-{{- if .Values.loggingSidecar.enabled }}
+{{- if and .Values.loggingSidecar.enabled (not .Values.loggingSidecar.customConfig) }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -14,9 +14,6 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   vector-config.yaml: |
-{{- if .Values.loggingSidecar.customConfig }}
-    {{ tpl .Values.loggingSidecar.airflowSidecarConfig . | nindent 4 }}
-{{- else }}
     log_schema:
       timestamp_key : "@timestamp"
     data_dir: "${SIDECAR_LOGS}"
@@ -75,5 +72,4 @@ data:
         bulk:
           index: "vector.${RELEASE:--}.%Y.%m.%d"
           action: create
-{{- end }}
 {{- end }}

--- a/tests/chart_tests/test_logging_sidecar.py
+++ b/tests/chart_tests/test_logging_sidecar.py
@@ -53,31 +53,7 @@ class TestLoggingSidecar:
           enabled: true
           customConfig: true
           name: sidecar-logging-consumer
-          airflowSidecarConfig: |
-            log_schema:
-              timestamp_key : "@timestamp"
-            data_dir: "${SIDECAR_LOGS}"
-            sources:
-              generate_syslog:
-                type: file
-                include:
-                  - "${SIDECAR_LOGS}/*.log"
-                read_from: beginning
-            transforms:
-              transform_syslog:
-                type: add_fields
-                inputs:
-                  - generate_syslog
-                fields:
-                  component: "${COMPONENT:--}"
-                  workspace: "${WORKSPACE:--}"
-                  release: "${RELEASE:--}"
-            sinks:
-              out:
-                type: datadog
-                inputs:
-                  - transform_syslog
-                """
+            """
         )
         values = yaml.safe_load(test_custom_sidecar_config)
         docs = render_chart(
@@ -85,9 +61,4 @@ class TestLoggingSidecar:
             values=values,
             show_only="templates/logging-sidecar-configmap.yaml",
         )
-        assert len(docs) == 1
-        doc = docs[0]
-        assert "ConfigMap" == doc["kind"]
-        assert "v1" == doc["apiVersion"]
-        assert (vc := yaml.safe_load(doc["data"]["vector-config.yaml"]))
-        assert vc["sinks"]["out"]["type"] == "datadog"
+        assert len(docs) == 0


### PR DESCRIPTION
## Description

A change to previous implementation (https://github.com/astronomer/airflow-chart/pull/332) to load entire configmap only if loggingSidecar: customConfig is disabled, else load from secret using configsyncer

## Related Issues

https://github.com/astronomer/issues/issues/4733

## Related PRs
Houston - https://github.com/astronomer/houston-api/pull/1154
Astronomer - https://github.com/astronomer/astronomer/pull/1575

## Testing

Tested on kind cluster

## Merging

0.29.2