### PR TITLE
sync vector changes to release 1.6 branch

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: airflow
   repository: https://airflow.apache.org
-  version: 1.4.0
-digest: sha256:75f857a231746d64ab3dccdcf88959a7c5155715e21620535eb19ad9dd17b7c1
-generated: "2022-01-11T11:41:40.735569-07:00"
+  version: 1.6.0
+digest: sha256:88f5a8d12d66eae1424902b048ac77c3ec5cd133ebb7634710005d300eb42777
+generated: "2022-06-28T00:44:42.650889+05:30"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v2 is Helm 3
 apiVersion: v2
 name: airflow
-version: 1.6.0
+version: 1.6.1
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:

--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -1,7 +1,7 @@
 ######################################
 ## Logging sidecar configmap        ##
 ######################################
-{{- if .Values.loggingSidecar.enabled }}
+{{- if and .Values.loggingSidecar.enabled (not .Values.loggingSidecar.customConfig) }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -72,5 +72,4 @@ data:
         bulk:
           index: "vector.${RELEASE:--}.%Y.%m.%d"
           action: create
-
 {{- end }}

--- a/tests/chart_tests/test_logging_sidecar.py
+++ b/tests/chart_tests/test_logging_sidecar.py
@@ -1,3 +1,5 @@
+import textwrap
+
 import pytest
 import yaml
 
@@ -39,6 +41,24 @@ class TestLoggingSidecar:
         docs = render_chart(
             kube_version=kube_version,
             values={"loggingSidecar": {"enabled": False}},
+            show_only="templates/logging-sidecar-configmap.yaml",
+        )
+        assert len(docs) == 0
+
+    def test_logging_sidecar_custom_config(self, kube_version):
+        """Test logging sidecar config with customConfig flag enabled"""
+        test_custom_sidecar_config = textwrap.dedent(
+            """
+        loggingSidecar:
+          enabled: true
+          customConfig: true
+          name: sidecar-logging-consumer
+            """
+        )
+        values = yaml.safe_load(test_custom_sidecar_config)
+        docs = render_chart(
+            kube_version=kube_version,
+            values=values,
             show_only="templates/logging-sidecar-configmap.yaml",
         )
         assert len(docs) == 0

--- a/values.yaml
+++ b/values.yaml
@@ -387,6 +387,8 @@ authSidecar:
 loggingSidecar:
   enabled: false
   name: sidecar-logging-consumer
+  customConfig: false
+  airflowSidecarConfig: ""
 
 # Ingress configuration
 ingress:

--- a/values.yaml
+++ b/values.yaml
@@ -388,7 +388,6 @@ loggingSidecar:
   enabled: false
   name: sidecar-logging-consumer
   customConfig: false
-  airflowSidecarConfig: ""
 
 # Ingress configuration
 ingress:


### PR DESCRIPTION
## Description

A change to previous implementation (https://github.com/astronomer/airflow-chart/pull/332) to load entire configmap only if loggingSidecar: customConfig is disabled, else load from secret using configsyncer

## Related Issues

https://github.com/astronomer/issues/issues/4733

## Testing
Houston - https://github.com/astronomer/houston-api/pull/1154
Astronomer - https://github.com/astronomer/astronomer/pull/1575