### PR TITLE
removed unused config var

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -384,7 +384,6 @@ loggingSidecar:
   enabled: false
   name: sidecar-logging-consumer
   customConfig: false
-  airflowSidecarConfig: ""
 
 # Ingress configuration
 ingress:


### PR DESCRIPTION
## Description

Removes unused config flag under loggingSidecar 

## Related Issues

https://github.com/astronomer/issues/issues/4733

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

0.29.2
