### PR TITLE
update vendor packages

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -29,16 +29,16 @@ airflow:
       tag: ~
     statsd:
       repository: quay.io/astronomer/ap-statsd-exporter
-      tag: 0.22.4
+      tag: 0.22.7
     redis:
       repository: quay.io/astronomer/ap-redis
       tag: 6.2.7
     pgbouncer:
       repository: quay.io/astronomer/ap-pgbouncer
-      tag: 1.17.0-2
+      tag: 1.17.0-3
     pgbouncerExporter:
       repository: quay.io/astronomer/ap-pgbouncer-exporter
-      tag: 0.13.0-3
+      tag: 0.13.0-4
     gitSync:
       repository: quay.io/astronomer/ap-git-sync
       tag: 3.5.0


### PR DESCRIPTION
## Description

Adds CVE fixes and base image imporvements


image | old | new
-- | -- | --
ap-statsd-exporter | 0.22.4 | 0.22.7 |
ap-pgbouncer          | 1.17.0-2 | 1.17.0-3 |
 ap-pgbouncer-exporter  |0.13.0-3 |  0.13.0-4 |

## Related Issues

https://github.com/astronomer/issues/issues/4877

## Testing

NA

## Merging

cherry-pick to release-1.6 and 1.7
