### PR TITLE
Backport securityfixes rel1 6

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v2 is Helm 3
 apiVersion: v2
 name: airflow
-version: 1.6.1
+version: 1.6.2
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:

--- a/values.yaml
+++ b/values.yaml
@@ -29,16 +29,16 @@ airflow:
       tag: ~
     statsd:
       repository: quay.io/astronomer/ap-statsd-exporter
-      tag: 0.22.4
+      tag: 0.22.7
     redis:
       repository: quay.io/astronomer/ap-redis
       tag: 6.2.7
     pgbouncer:
       repository: quay.io/astronomer/ap-pgbouncer
-      tag: 1.17.0-2
+      tag: 1.17.0-3
     pgbouncerExporter:
       repository: quay.io/astronomer/ap-pgbouncer-exporter
-      tag: 0.13.0-3
+      tag: 0.13.0-4
     gitSync:
       repository: quay.io/astronomer/ap-git-sync
       tag: 3.5.0


### PR DESCRIPTION
## Description

Backport security fixes for vendor images 
image | old | new
-- | -- | --
ap-statsd-exporter | 0.22.4 | 0.22.7 |
ap-pgbouncer          | 1.17.0-2 | 1.17.0-3 |
 ap-pgbouncer-exporter  |0.13.0-3 |  0.13.0-4 |


## Related Issues

https://github.com/astronomer/issues/issues/4877

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
