### PR TITLE
sync master branch to release-1.7

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v2 is Helm 3
 apiVersion: v2
 name: airflow
-version: 1.7.0-rc1
+version: 1.7.0-rc2
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:

--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -33,10 +33,26 @@ data:
           workspace: "${WORKSPACE:--}"
           release: "${RELEASE:--}"
 
+      filter_common_logs:
+        type: filter
+        inputs:
+          - transform_syslog
+        condition:
+          type: "vrl"
+          source: '!includes(["worker"], .component)'
+
+      filter_worker_logs:
+        type: filter
+        inputs:
+          - transform_syslog
+        condition:
+          type: "vrl"
+          source: 'includes(["worker"], .component)'
+
       transform_task_log:
         type: remap
         inputs:
-          - transform_syslog
+          - filter_worker_logs
         source: |-
           # Parse Syslog input. The "!" means that the script should abort on error.
           . = parse_json!(.message)
@@ -47,10 +63,20 @@ data:
           }
           .offset = to_int(now()) * 1000000000 + to_unix_timestamp(now()) * 1000000
 
+      final_task_log:
+        type: add_fields
+        inputs:
+          - transform_task_log
+        fields:
+          component: "${COMPONENT:--}"
+          workspace: "${WORKSPACE:--}"
+          release: "${RELEASE:--}"
+
       transform_remove_fields:
         type: remove_fields
         inputs:
-          - transform_task_log
+          - final_task_log
+          - filter_common_logs
         fields:
           - host
           - file

--- a/values.yaml
+++ b/values.yaml
@@ -29,16 +29,16 @@ airflow:
       tag: ~
     statsd:
       repository: quay.io/astronomer/ap-statsd-exporter
-      tag: 0.22.4
+      tag: 0.22.7
     redis:
       repository: quay.io/astronomer/ap-redis
       tag: 6.2.7
     pgbouncer:
       repository: quay.io/astronomer/ap-pgbouncer
-      tag: 1.17.0-2
+      tag: 1.17.0-3
     pgbouncerExporter:
       repository: quay.io/astronomer/ap-pgbouncer-exporter
-      tag: 0.13.0-3
+      tag: 0.13.0-4
     gitSync:
       repository: quay.io/astronomer/ap-git-sync
       tag: 3.5.0


### PR DESCRIPTION
## Description

- added enhancements to sidecar logging template
- multiple cve fixes for vendor packages

## Related Issues

https://github.com/astronomer/issues/issues/4648

## Testing

QA should now able to get proper logs for worker.
Not error logs will be displayed on web server, scheduler , triggerer services 

## Merging

cherry-pick to release-1.7
