### PR TITLE
fix local executor logs

### DIFF
--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -39,7 +39,15 @@ data:
           - transform_syslog
         condition:
           type: "vrl"
-          source: '!includes(["worker"], .component)'
+          source: '!includes(["worker","scheduler"], .component)'
+
+      filter_scheduler_logs:
+        type: filter
+        inputs:
+          - transform_syslog
+        condition:
+          type: "vrl"
+          source: 'includes(["scheduler"], .component)'
 
       filter_worker_logs:
         type: filter
@@ -53,6 +61,7 @@ data:
         type: remap
         inputs:
           - filter_worker_logs
+          - filter_scheduler_logs
         source: |-
           # Parse Syslog input. The "!" means that the script should abort on error.
           . = parse_json!(.message)


### PR DESCRIPTION


## Description

* logs were not displaying for local executor due to the way we parse the logs , that has been fixed with this change

## Related Issues

https://github.com/astronomer/issues/issues/4958

## Testing

QA should able to see airflow logs in airflow deployments UI if local executor is selected

## Merging

merge to release-1.7
