### PR TITLE
update astronomer airflow vendor images

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -35,13 +35,13 @@ airflow:
       tag: 6.2.7
     pgbouncer:
       repository: quay.io/astronomer/ap-pgbouncer
-      tag: 1.17.0-3
+      tag: 1.17.0-4
     pgbouncerExporter:
       repository: quay.io/astronomer/ap-pgbouncer-exporter
-      tag: 0.13.0-4
+      tag: 0.13.0-5
     gitSync:
       repository: quay.io/astronomer/ap-git-sync
-      tag: 3.5.0
+      tag: 3.6.1
   # Airflow scheduler settings
   scheduler:
     livenessProbe:


### PR DESCRIPTION
## Description

image | old | new
-- | -- | --
ap-pgbouncer                   |  1.17.0-3    |  1.17.0-4
ap-pgbouncer-exporter   |  0.13.0-4   |  0.13.0-5
ap-git-sync                       |  3.5.0         |  3.6.1

## Related Issues

https://github.com/astronomer/issues/issues/4993
https://github.com/astronomer/issues/issues/4998

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging
cherry-pick to possibly all applicable release branches
