### PR TITLE
fix security CVE in release 1.4

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v2 is Helm 3
 apiVersion: v2
 name: airflow
-version: 1.4.2-rc1
+version: 1.4.2
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v2 is Helm 3
 apiVersion: v2
 name: airflow
-version: 1.4.1
+version: 1.4.2-rc1
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:

--- a/values.yaml
+++ b/values.yaml
@@ -29,19 +29,19 @@ airflow:
       tag: ~
     statsd:
       repository: quay.io/astronomer/ap-statsd-exporter
-      tag: 0.18.0
+      tag: 0.22.7
     redis:
       repository: quay.io/astronomer/ap-redis
       tag: 6.2.6
     pgbouncer:
       repository: quay.io/astronomer/ap-pgbouncer
-      tag: 1.17.0-1
+      tag: 1.17.0-4
     pgbouncerExporter:
       repository: quay.io/astronomer/ap-pgbouncer-exporter
-      tag: 0.13.0-2
+      tag: 0.13.0-5
     gitSync:
       repository: quay.io/astronomer/ap-git-sync
-      tag: 3.3.5
+      tag: 3.6.1
   # Airflow scheduler settings
   scheduler:
     livenessProbe:


### PR DESCRIPTION
## Description

Fix security CVE in airflow helm chart release 1.4 
image | old | new
-- | -- | --
ap-statsd-exporter |  0.18.0  | 0.22.7 
ap-pgbouncer.    | 1.17.0-1 | 1.17.0-4
ap-pgbouncer-exporter | 0.13.0-2 | 0.13.0-5 
ap-git-sync | 3.3.5 | 3.6.1

## Related Issues

https://github.com/astronomer/issues/issues/5004

## Testing

QA should verify all components are working fine with platform

## Merging

merge to release branch 1.4
