### PR TITLE
addNanoScaleDateTimeForVector

### DIFF
--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -66,6 +66,7 @@ data:
           # Parse Syslog input. The "!" means that the script should abort on error.
           . = parse_json!(.message)
           .@timestamp = parse_timestamp(.timestamp, "%Y-%m-%dT%H:%M:%S%Z") ?? now()
+          date_nano = parse_timestamp(.timestamp, "%Y-%m-%dT%H:%M:%S%Z") ?? now()
           .check_log_id = exists(.log_id)
           if .check_log_id != true {
           .log_id = join!([.dag_id, .task_id, .execution_date, .try_number], "_")


### PR DESCRIPTION
## Description

Adds a date_nano field to vector configmap such that recent changes to elasticsearch sorting order apply

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
