### PR TITLE
release 1.6 - backport CVE fixes

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v2 is Helm 3
 apiVersion: v2
 name: airflow
-version: 1.6.4-rc1
+version: 1.6.4
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v2 is Helm 3
 apiVersion: v2
 name: airflow
-version: 1.6.3
+version: 1.6.4-rc1
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:

--- a/values.yaml
+++ b/values.yaml
@@ -35,10 +35,10 @@ airflow:
       tag: 6.2.7
     pgbouncer:
       repository: quay.io/astronomer/ap-pgbouncer
-      tag: 1.17.0-4
+      tag: 1.17.0-5
     pgbouncerExporter:
       repository: quay.io/astronomer/ap-pgbouncer-exporter
-      tag: 0.13.0-5
+      tag: 0.13.0-6
     gitSync:
       repository: quay.io/astronomer/ap-git-sync
       tag: 3.6.1


### PR DESCRIPTION


## Description

fix CVE-2022-40674 in pg-bouncer and pg-bouncer exporter service 

## Related Issues

https://github.com/astronomer/issues/issues/5065

## Testing

NA 

## Merging

cherry-picked to release-1.6 branch
