### PR TITLE
update pgbouncer images (#359)

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -35,10 +35,10 @@ airflow:
       tag: 6.2.6
     pgbouncer:
       repository: quay.io/astronomer/ap-pgbouncer
-      tag: 1.17.0-4
+      tag: 1.17.0-5
     pgbouncerExporter:
       repository: quay.io/astronomer/ap-pgbouncer-exporter
-      tag: 0.13.0-5
+      tag: 0.13.0-6
     gitSync:
       repository: quay.io/astronomer/ap-git-sync
       tag: 3.6.1


### PR DESCRIPTION

## Description

fix CVE-2022-40674

## Related Issues

https://github.com/astronomer/issues/issues/5065

## Testing

QA should validate pgbouncer service should work as expected

## Merging

This is only for release-1.4 branch.