### PR TITLE
5145 git-daemon healthcheck

### DIFF
--- a/templates/git-sync-relay/git-sync-relay-deployment.yaml
+++ b/templates/git-sync-relay/git-sync-relay-deployment.yaml
@@ -93,4 +93,11 @@ spec:
           env:
             - name: GIT_ROOT
               value: /git
+          livenessProbe:
+            exec:
+              command:
+              - touch
+              - /git/.git/git-daemon-export-ok
+            initialDelaySeconds: 5
+            periodSeconds: 15
 {{- end -}}

--- a/tests/chart_tests/test_git_sync_relay_deployment.py
+++ b/tests/chart_tests/test_git_sync_relay_deployment.py
@@ -39,6 +39,7 @@ class TestGitSyncRelayDeployment:
         assert c_by_name["git-daemon"]["image"].startswith(
             "quay.io/astronomer/ap-git-daemon:"
         )
+        assert c_by_name["git-daemon"]["livenessProbe"]
 
     def test_gsr_deployment_with_ssh_credentials_and_known_hosts(self, kube_version):
         """Test that a valid deployment is rendered when enabling git-sync with ssh credentials and known hosts and other custom configs."""
@@ -121,6 +122,7 @@ class TestGitSyncRelayDeployment:
             "--wait=333",
             "--root=/git",
         ]
+        assert c_by_name["git-daemon"]["livenessProbe"]
 
     def test_gsr_deployment_without_ssh_credentials_and_known_hosts(self, kube_version):
         """Test that a valid deployment is rendered when enabling git-sync without ssh credentials."""
@@ -178,3 +180,4 @@ class TestGitSyncRelayDeployment:
             "--wait=333",
             "--root=/git",
         ]
+        assert c_by_name["git-daemon"]["livenessProbe"]

--- a/values.yaml
+++ b/values.yaml
@@ -433,10 +433,10 @@ gitSyncRelay:
   images:
     gitDaemon:
       repository: "quay.io/astronomer/ap-git-daemon"
-      tag: "3.15.0"
+      tag: "3.16.2-1"
     gitSync:
       repository: "quay.io/astronomer/ap-git-sync"
-      tag: "3.3.4"
+      tag: "3.6.1"
 
   repo:
     url: ~


### PR DESCRIPTION
## Description

- Add a livenessProbe health check to the git-daemon container to make sure it is exporting the git repo.
- Use latest git-daemon and git-sync image versions.

## Related Issues

https://github.com/astronomer/issues/issues/5145

## Testing

We should test this in a cluster by deleting the `/git/.git/git-daemon-export-ok` file and making sure the healthcheck puts it back. The healthcheck will fail if it is unable to touch the file, which serves as double duty for auto-healing and also alerting when it cannot achieve a healthy state.

Edit: Verified that this new livenessProbe is working as expected, keeping the git dir exported.

Edit: Verified that the new images with non-verbose work as expected.

## Merging

This should be merged into all branches that support git-sync-relay.