### PR TITLE
Drop 1.19, 1.20. Add 1.24.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ workflows:
 jobs:
   run_pre_commit:
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2022-09
+      - image: quay.io/astronomer/ci-pre-commit:2022-11
     steps:
       - checkout
       - run:
@@ -84,9 +84,10 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2022-09
+      - image: quay.io/astronomer/ci-helm-release:2022-11
     steps:
       - setup_remote_docker:
+          version: 20.10.14
           docker_layer_caching: true
       - checkout
       - run:
@@ -99,7 +100,7 @@ jobs:
 
   build-and-release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2022-09
+      - image: quay.io/astronomer/ci-helm-release:2022-11
     steps:
       - checkout
       - run:
@@ -140,7 +141,7 @@ jobs:
           path: test-results
   release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2022-09
+      - image: quay.io/astronomer/ci-helm-release:2022-11
     steps:
       - checkout
       - run:
@@ -149,7 +150,7 @@ jobs:
 
   release-public:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2022-09
+      - image: quay.io/astronomer/ci-helm-release:2022-11
     steps:
       - checkout
       - publish-github-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ workflows:
           matrix:
             parameters:
               # https://hub.docker.com/r/kindest/node/tags
-              kube_version: ["1.19.11", "1.20.7", "1.21.2", "1.22.7", "1.23.4"]
+              kube_version: ["1.21.14", "1.22.15", "1.23.13", "1.24.7"]
               executor: ["CeleryExecutor", "LocalExecutor", "KubernetesExecutor"]
           requires:
             - build-and-release-internal

--- a/bin/install-ci-tools
+++ b/bin/install-ci-tools
@@ -2,11 +2,11 @@
 set -e
 
 if [[ -z "${KIND_VERSION}" ]]; then
-  export KIND_VERSION="0.11.1"
+  export KIND_VERSION="0.17.0"
 fi
 
 if [[ -z "${HELM_VERSION}" ]]; then
-  export HELM_VERSION="3.7.1"
+  export HELM_VERSION="3.10.1"
 fi
 
 # Determine the platform we are running on


### PR DESCRIPTION
## Description

Stop testing on deprecated versions of k8s. Start testing on 1.24.

## Related Issues

- https://github.com/astronomer/issues/issues/5179
- https://github.com/astronomer/issues/issues/5148
- https://github.com/astronomer/issues/issues/5177

## Testing

As long as CI is passing we should be good.

## Merging

This should be merged into all supported 1.x branches. 0.20 is only used by astronomer/astronomer 0.25, which we are leaving as is.
