### PR TITLE
5180 only test some k8s versions by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,6 @@ workflows:
             branches:
               only:
                 - '/^release-\d+\.\d+$/'
-                - 5180-only-test-some-k8s-versions-by-default
 
       - release-public:
           context:
@@ -141,7 +140,6 @@ workflows:
             branches:
               only:
                 - '/^release-\d+\.\d+$/'
-                - 5180-only-test-some-k8s-versions-by-default
 
 jobs:
   run_pre_commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,36 +20,28 @@ workflows:
             - run_pre_commit
             - unittest-charts
       - airflow-test:
-          name: test-1.21.14-CeleryExecutor
+          name: test-1-21-14-CeleryExecutor
           kube_version: version
           executor: exectuor
           requires:
             - build-and-release-internal
 
       - airflow-test:
-          name: test-1.21.14-LocalExecutor
+          name: test-1-21-14-LocalExecutor
           kube_version: version
           executor: exectuor
           requires:
             - build-and-release-internal
 
       - airflow-test:
-          name: test-1.21.14-KubernetesExecutor
+          name: test-1-21-14-KubernetesExecutor
           kube_version: version
           executor: exectuor
           requires:
             - build-and-release-internal
 
       - airflow-test:
-          name: test-1.22.15-CeleryExecutor
-          kube_version: version
-          executor: exectuor
-          requires:
-            - build-and-release-internal
-
-            - approve-test-all
-      - airflow-test:
-          name: test-1.22.15-LocalExecutor
+          name: test-1-22-15-CeleryExecutor
           kube_version: version
           executor: exectuor
           requires:
@@ -57,7 +49,7 @@ workflows:
 
             - approve-test-all
       - airflow-test:
-          name: test-1.22.15-KubernetesExecutor
+          name: test-1-22-15-LocalExecutor
           kube_version: version
           executor: exectuor
           requires:
@@ -65,7 +57,7 @@ workflows:
 
             - approve-test-all
       - airflow-test:
-          name: test-1.23.13-CeleryExecutor
+          name: test-1-22-15-KubernetesExecutor
           kube_version: version
           executor: exectuor
           requires:
@@ -73,7 +65,7 @@ workflows:
 
             - approve-test-all
       - airflow-test:
-          name: test-1.23.13-LocalExecutor
+          name: test-1-23-13-CeleryExecutor
           kube_version: version
           executor: exectuor
           requires:
@@ -81,7 +73,7 @@ workflows:
 
             - approve-test-all
       - airflow-test:
-          name: test-1.23.13-KubernetesExecutor
+          name: test-1-23-13-LocalExecutor
           kube_version: version
           executor: exectuor
           requires:
@@ -89,21 +81,29 @@ workflows:
 
             - approve-test-all
       - airflow-test:
-          name: test-1.24.7-CeleryExecutor
+          name: test-1-23-13-KubernetesExecutor
+          kube_version: version
+          executor: exectuor
+          requires:
+            - build-and-release-internal
+
+            - approve-test-all
+      - airflow-test:
+          name: test-1-24-7-CeleryExecutor
           kube_version: version
           executor: exectuor
           requires:
             - build-and-release-internal
 
       - airflow-test:
-          name: test-1.24.7-LocalExecutor
+          name: test-1-24-7-LocalExecutor
           kube_version: version
           executor: exectuor
           requires:
             - build-and-release-internal
 
       - airflow-test:
-          name: test-1.24.7-KubernetesExecutor
+          name: test-1-24-7-KubernetesExecutor
           kube_version: version
           executor: exectuor
           requires:
@@ -112,18 +112,18 @@ workflows:
       - approve-release-prod:
           type: approval
           requires:
-            - "test-1.21.14-CeleryExecutor"
-            - "test-1.21.14-LocalExecutor"
-            - "test-1.21.14-KubernetesExecutor"
-            - "test-1.22.15-CeleryExecutor"
-            - "test-1.22.15-LocalExecutor"
-            - "test-1.22.15-KubernetesExecutor"
-            - "test-1.23.13-CeleryExecutor"
-            - "test-1.23.13-LocalExecutor"
-            - "test-1.23.13-KubernetesExecutor"
-            - "test-1.24.7-CeleryExecutor"
-            - "test-1.24.7-LocalExecutor"
-            - "test-1.24.7-KubernetesExecutor"
+            - "test-1-21-14-CeleryExecutor"
+            - "test-1-21-14-LocalExecutor"
+            - "test-1-21-14-KubernetesExecutor"
+            - "test-1-22-15-CeleryExecutor"
+            - "test-1-22-15-LocalExecutor"
+            - "test-1-22-15-KubernetesExecutor"
+            - "test-1-23-13-CeleryExecutor"
+            - "test-1-23-13-LocalExecutor"
+            - "test-1-23-13-KubernetesExecutor"
+            - "test-1-24-7-CeleryExecutor"
+            - "test-1-24-7-LocalExecutor"
+            - "test-1-24-7-KubernetesExecutor"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,28 +21,28 @@ workflows:
             - unittest-charts
       - airflow-test:
           name: test-1-21-14-CeleryExecutor
-          kube_version: version
+          kube_version: 1.21.14
           executor: exectuor
           requires:
             - build-and-release-internal
 
       - airflow-test:
           name: test-1-21-14-LocalExecutor
-          kube_version: version
+          kube_version: 1.21.14
           executor: exectuor
           requires:
             - build-and-release-internal
 
       - airflow-test:
           name: test-1-21-14-KubernetesExecutor
-          kube_version: version
+          kube_version: 1.21.14
           executor: exectuor
           requires:
             - build-and-release-internal
 
       - airflow-test:
           name: test-1-22-15-CeleryExecutor
-          kube_version: version
+          kube_version: 1.22.15
           executor: exectuor
           requires:
             - build-and-release-internal
@@ -50,7 +50,7 @@ workflows:
             - approve-test-all
       - airflow-test:
           name: test-1-22-15-LocalExecutor
-          kube_version: version
+          kube_version: 1.22.15
           executor: exectuor
           requires:
             - build-and-release-internal
@@ -58,7 +58,7 @@ workflows:
             - approve-test-all
       - airflow-test:
           name: test-1-22-15-KubernetesExecutor
-          kube_version: version
+          kube_version: 1.22.15
           executor: exectuor
           requires:
             - build-and-release-internal
@@ -66,7 +66,7 @@ workflows:
             - approve-test-all
       - airflow-test:
           name: test-1-23-13-CeleryExecutor
-          kube_version: version
+          kube_version: 1.23.13
           executor: exectuor
           requires:
             - build-and-release-internal
@@ -74,7 +74,7 @@ workflows:
             - approve-test-all
       - airflow-test:
           name: test-1-23-13-LocalExecutor
-          kube_version: version
+          kube_version: 1.23.13
           executor: exectuor
           requires:
             - build-and-release-internal
@@ -82,7 +82,7 @@ workflows:
             - approve-test-all
       - airflow-test:
           name: test-1-23-13-KubernetesExecutor
-          kube_version: version
+          kube_version: 1.23.13
           executor: exectuor
           requires:
             - build-and-release-internal
@@ -90,21 +90,21 @@ workflows:
             - approve-test-all
       - airflow-test:
           name: test-1-24-7-CeleryExecutor
-          kube_version: version
+          kube_version: 1.24.7
           executor: exectuor
           requires:
             - build-and-release-internal
 
       - airflow-test:
           name: test-1-24-7-LocalExecutor
-          kube_version: version
+          kube_version: 1.24.7
           executor: exectuor
           requires:
             - build-and-release-internal
 
       - airflow-test:
           name: test-1-24-7-KubernetesExecutor
-          kube_version: version
+          kube_version: 1.24.7
           executor: exectuor
           requires:
             - build-and-release-internal

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,6 +128,7 @@ workflows:
             branches:
               only:
                 - '/^release-\d+\.\d+$/'
+                - 5180-only-test-some-k8s-versions-by-default
 
       - release-public:
           context:
@@ -140,6 +141,7 @@ workflows:
             branches:
               only:
                 - '/^release-\d+\.\d+$/'
+                - 5180-only-test-some-k8s-versions-by-default
 
 jobs:
   run_pre_commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,28 +22,28 @@ workflows:
       - airflow-test:
           name: test-1-21-14-CeleryExecutor
           kube_version: 1.21.14
-          executor: exectuor
+          executor: CeleryExecutor
           requires:
             - build-and-release-internal
 
       - airflow-test:
           name: test-1-21-14-LocalExecutor
           kube_version: 1.21.14
-          executor: exectuor
+          executor: LocalExecutor
           requires:
             - build-and-release-internal
 
       - airflow-test:
           name: test-1-21-14-KubernetesExecutor
           kube_version: 1.21.14
-          executor: exectuor
+          executor: KubernetesExecutor
           requires:
             - build-and-release-internal
 
       - airflow-test:
           name: test-1-22-15-CeleryExecutor
           kube_version: 1.22.15
-          executor: exectuor
+          executor: CeleryExecutor
           requires:
             - build-and-release-internal
 
@@ -51,7 +51,7 @@ workflows:
       - airflow-test:
           name: test-1-22-15-LocalExecutor
           kube_version: 1.22.15
-          executor: exectuor
+          executor: LocalExecutor
           requires:
             - build-and-release-internal
 
@@ -59,7 +59,7 @@ workflows:
       - airflow-test:
           name: test-1-22-15-KubernetesExecutor
           kube_version: 1.22.15
-          executor: exectuor
+          executor: KubernetesExecutor
           requires:
             - build-and-release-internal
 
@@ -67,7 +67,7 @@ workflows:
       - airflow-test:
           name: test-1-23-13-CeleryExecutor
           kube_version: 1.23.13
-          executor: exectuor
+          executor: CeleryExecutor
           requires:
             - build-and-release-internal
 
@@ -75,7 +75,7 @@ workflows:
       - airflow-test:
           name: test-1-23-13-LocalExecutor
           kube_version: 1.23.13
-          executor: exectuor
+          executor: LocalExecutor
           requires:
             - build-and-release-internal
 
@@ -83,7 +83,7 @@ workflows:
       - airflow-test:
           name: test-1-23-13-KubernetesExecutor
           kube_version: 1.23.13
-          executor: exectuor
+          executor: KubernetesExecutor
           requires:
             - build-and-release-internal
 
@@ -91,21 +91,21 @@ workflows:
       - airflow-test:
           name: test-1-24-7-CeleryExecutor
           kube_version: 1.24.7
-          executor: exectuor
+          executor: CeleryExecutor
           requires:
             - build-and-release-internal
 
       - airflow-test:
           name: test-1-24-7-LocalExecutor
           kube_version: 1.24.7
-          executor: exectuor
+          executor: LocalExecutor
           requires:
             - build-and-release-internal
 
       - airflow-test:
           name: test-1-24-7-KubernetesExecutor
           kube_version: 1.24.7
-          executor: exectuor
+          executor: KubernetesExecutor
           requires:
             - build-and-release-internal
 

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -42,7 +42,6 @@ workflows:
             branches:
               only:
                 - '/^release-\d+\.\d+$/'
-                - 5180-only-test-some-k8s-versions-by-default
 
       - release-public:
           context:
@@ -55,7 +54,6 @@ workflows:
             branches:
               only:
                 - '/^release-\d+\.\d+$/'
-                - 5180-only-test-some-k8s-versions-by-default
 
 jobs:
   run_pre_commit:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -20,7 +20,7 @@ workflows:
 {%- for version in kube_versions %}
 {%- for executor in executors %}
       - airflow-test:
-          name: test-{{ version }}-{{ executor }}
+          name: test-{{ version | replace(".", "-") }}-{{ executor }}
           kube_version: version
           executor: exectuor
           requires:
@@ -35,7 +35,7 @@ workflows:
           requires:
 {%- for version in kube_versions %}
 {%- for executor in executors %}
-            - "test-{{ version }}-{{ executor }}"
+            - "test-{{ version | replace(".", "-") }}-{{ executor }}"
 {%- endfor %}
 {%- endfor %}
           filters:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -22,7 +22,7 @@ workflows:
       - airflow-test:
           name: test-{{ version | replace(".", "-") }}-{{ executor }}
           kube_version: {{ version }}
-          executor: exectuor
+          executor: {{ executor }}
           requires:
             - build-and-release-internal
 {% if version in kube_versions[1:-1] %}

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -1,5 +1,3 @@
-# Warning: automatically generated file
-# Please edit config.yml.j2, and use the script generate_circleci_config.py
 ---
 version: 2.1
 
@@ -19,111 +17,27 @@ workflows:
             - lint
             - run_pre_commit
             - unittest-charts
+{%- for version in kube_versions %}
+{%- for executor in executors %}
       - airflow-test:
-          name: test-1.21.14-CeleryExecutor
+          name: test-{{ version }}-{{ executor }}
           kube_version: version
           executor: exectuor
           requires:
             - build-and-release-internal
-
-      - airflow-test:
-          name: test-1.21.14-LocalExecutor
-          kube_version: version
-          executor: exectuor
-          requires:
-            - build-and-release-internal
-
-      - airflow-test:
-          name: test-1.21.14-KubernetesExecutor
-          kube_version: version
-          executor: exectuor
-          requires:
-            - build-and-release-internal
-
-      - airflow-test:
-          name: test-1.22.15-CeleryExecutor
-          kube_version: version
-          executor: exectuor
-          requires:
-            - build-and-release-internal
-
+{% if version in kube_versions[1:-1] %}
             - approve-test-all
-      - airflow-test:
-          name: test-1.22.15-LocalExecutor
-          kube_version: version
-          executor: exectuor
-          requires:
-            - build-and-release-internal
-
-            - approve-test-all
-      - airflow-test:
-          name: test-1.22.15-KubernetesExecutor
-          kube_version: version
-          executor: exectuor
-          requires:
-            - build-and-release-internal
-
-            - approve-test-all
-      - airflow-test:
-          name: test-1.23.13-CeleryExecutor
-          kube_version: version
-          executor: exectuor
-          requires:
-            - build-and-release-internal
-
-            - approve-test-all
-      - airflow-test:
-          name: test-1.23.13-LocalExecutor
-          kube_version: version
-          executor: exectuor
-          requires:
-            - build-and-release-internal
-
-            - approve-test-all
-      - airflow-test:
-          name: test-1.23.13-KubernetesExecutor
-          kube_version: version
-          executor: exectuor
-          requires:
-            - build-and-release-internal
-
-            - approve-test-all
-      - airflow-test:
-          name: test-1.24.7-CeleryExecutor
-          kube_version: version
-          executor: exectuor
-          requires:
-            - build-and-release-internal
-
-      - airflow-test:
-          name: test-1.24.7-LocalExecutor
-          kube_version: version
-          executor: exectuor
-          requires:
-            - build-and-release-internal
-
-      - airflow-test:
-          name: test-1.24.7-KubernetesExecutor
-          kube_version: version
-          executor: exectuor
-          requires:
-            - build-and-release-internal
-
+{%- endif %}
+{%- endfor %}
+{%- endfor %}
       - approve-release-prod:
           type: approval
           requires:
-            - "test-1.21.14-CeleryExecutor"
-            - "test-1.21.14-LocalExecutor"
-            - "test-1.21.14-KubernetesExecutor"
-            - "test-1.22.15-CeleryExecutor"
-            - "test-1.22.15-LocalExecutor"
-            - "test-1.22.15-KubernetesExecutor"
-            - "test-1.23.13-CeleryExecutor"
-            - "test-1.23.13-LocalExecutor"
-            - "test-1.23.13-KubernetesExecutor"
-            - "test-1.24.7-CeleryExecutor"
-            - "test-1.24.7-LocalExecutor"
-            - "test-1.24.7-KubernetesExecutor"
+{%- for version in kube_versions %}
+{%- for executor in executors %}
+            - "test-{{ version }}-{{ executor }}"
+{%- endfor %}
+{%- endfor %}
           filters:
             branches:
               only:
@@ -144,7 +58,7 @@ workflows:
 jobs:
   run_pre_commit:
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2022-11
+      - image: quay.io/astronomer/ci-pre-commit:{{ ci_runner_version }}
     steps:
       - checkout
       - run:
@@ -154,12 +68,12 @@ jobs:
             python --version --version | sed 's/^/# /' >> /tmp/pre-commit-cache-key.txt
       - restore_cache:
           keys:
-            - pre-commit-cache-{{ checksum "/tmp/pre-commit-cache-key.txt" }}
+            - pre-commit-cache-{{ '{{' }} checksum "/tmp/pre-commit-cache-key.txt" }}
       - run:
           name: Install pre-commit hooks
           command: pre-commit install-hooks
       - save_cache:
-          key: pre-commit-cache-{{ checksum "/tmp/pre-commit-cache-key.txt" }}
+          key: pre-commit-cache-{{ '{{' }} checksum "/tmp/pre-commit-cache-key.txt" }}
           paths:
             - ~/.cache/pre-commit
       - run:
@@ -179,10 +93,10 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2022-11
+      - image: quay.io/astronomer/ci-helm-release:{{ ci_runner_version }}
     steps:
       - setup_remote_docker:
-          version: 20.10.18
+          version: {{ remote_docker_version }}
           docker_layer_caching: true
       - checkout
       - run:
@@ -195,7 +109,7 @@ jobs:
 
   build-and-release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2022-11
+      - image: quay.io/astronomer/ci-helm-release:{{ ci_runner_version }}
     steps:
       - checkout
       - run:
@@ -236,7 +150,7 @@ jobs:
           path: test-results
   release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2022-11
+      - image: quay.io/astronomer/ci-helm-release:{{ ci_runner_version }}
     steps:
       - checkout
       - run:
@@ -245,7 +159,7 @@ jobs:
 
   release-public:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2022-11
+      - image: quay.io/astronomer/ci-helm-release:{{ ci_runner_version }}
     steps:
       - checkout
       - publish-github-release

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -21,7 +21,7 @@ workflows:
 {%- for executor in executors %}
       - airflow-test:
           name: test-{{ version | replace(".", "-") }}-{{ executor }}
-          kube_version: version
+          kube_version: {{ version }}
           executor: exectuor
           requires:
             - build-and-release-internal

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -42,6 +42,7 @@ workflows:
             branches:
               only:
                 - '/^release-\d+\.\d+$/'
+                - 5180-only-test-some-k8s-versions-by-default
 
       - release-public:
           context:
@@ -54,6 +55,7 @@ workflows:
             branches:
               only:
                 - '/^release-\d+\.\d+$/'
+                - 5180-only-test-some-k8s-versions-by-default
 
 jobs:
   run_pre_commit:

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -6,14 +6,15 @@ from pathlib import Path
 
 from jinja2 import Template
 
-# When adding a new version, look up the most
-# recent patch version on Dockerhub
+# When adding a new version, look up the most recent patch version on Dockerhub
 # https://hub.docker.com/r/kindest/node/tags
 # This should match what is in tests/__init__.py
 kube_versions = ["1.21.14", "1.22.15", "1.23.13", "1.24.7"]
-executors = ["CeleryExecutor", "LocalExecutor", "KubernetesExecutor"]
+
 # https://circleci.com/docs/2.0/building-docker-images/#docker-version
 remote_docker_version = "20.10.18"
+
+executors = ["CeleryExecutor", "LocalExecutor", "KubernetesExecutor"]
 ci_runner_version = "2022-11"
 
 

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""This script is used to create the circle config file so that we can stay
+DRY."""
+import os
+from pathlib import Path
+
+from jinja2 import Template
+
+# When adding a new version, look up the most
+# recent patch version on Dockerhub
+# https://hub.docker.com/r/kindest/node/tags
+# This should match what is in tests/__init__.py
+kube_versions = ["1.21.14", "1.22.15", "1.23.13", "1.24.7"]
+executors = ["CeleryExecutor", "LocalExecutor", "KubernetesExecutor"]
+# https://circleci.com/docs/2.0/building-docker-images/#docker-version
+remote_docker_version = "20.10.18"
+ci_runner_version = "2022-11"
+
+
+def main():
+    """Render the Jinja2 template file."""
+    circle_directory = os.path.dirname(os.path.realpath(__file__))
+    config_template_path = os.path.join(circle_directory, "config.yml.j2")
+    config_path = os.path.join(circle_directory, "config.yml")
+
+    templated_file_content = Path(config_template_path).read_text()
+    template = Template(templated_file_content)
+    config = template.render(
+        kube_versions=kube_versions,
+        executors=executors,
+        ci_runner_version=ci_runner_version,
+        remote_docker_version=remote_docker_version,
+    )
+    with open(config_path, "w") as circle_ci_config_file:
+        warning_header = (
+            "# Warning: automatically generated file\n"
+            + "# Please edit config.yml.j2, and use the script generate_circleci_config.py\n"
+        )
+        circle_ci_config_file.write(warning_header)
+        circle_ci_config_file.write(config)
+        circle_ci_config_file.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,12 +6,6 @@ repos:
     hooks:
       - id: remove-tabs
         exclude_types: [makefile, binary]
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v2.7.1"
-    hooks:
-      - id: prettier
-        args: ["--print-width=135"]
-        exclude: "(charts|templates|files)"
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1
     hooks:
@@ -90,3 +84,9 @@ repos:
         files: "config.yml$|config.yml.j2|generate_circleci_config.py$"
         entry: .circleci/generate_circleci_config.py
         additional_dependencies: ["jinja2"]
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v2.7.1"
+    hooks:
+      - id: prettier
+        args: ["--print-width=135"]
+        exclude: "(charts|templates|files)"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,3 +82,11 @@ repos:
       - id: remove-unicode-non-breaking-spaces
       - id: remove-unicode-zero-width-non-breaking-spaces
       - id: remove-unicode-zero-width-space
+  - repo: local
+    hooks:
+      - id: circle-config-yaml
+        name: Ensure .circleci/config.yml is up to date
+        language: python
+        files: "config.yml$|config.yml.j2|generate_circleci_config.py$"
+        entry: .circleci/generate_circleci_config.py
+        additional_dependencies: ["jinja2"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,11 +10,6 @@ git_root_dir = Path(git_repo.git.rev_parse("--show-toplevel"))
 with open(f"{git_root_dir}/.circleci/config.yml") as f:
     circleci_config = yaml.safe_load(f.read())
 
-# fmt: off
-# Load supported versions and replace patch segment with 0
-supported_k8s_versions = [
-    '.'.join(zero_version_list)
-    for version_str in circleci_config["workflows"]["install-airflow-chart"]["jobs"][4]["airflow-test"]["matrix"]["parameters"]["kube_version"]
-    for zero_version_list in [version_str.split('.')[:2] + ['0']]
-]
-# fmt: on
+# This should match the major.minor version list in .circleci/generate_circleci_config.py
+# Patch version should always be 0
+supported_k8s_versions = ["1.21.0", "1.22.0", "1.23.0", "1.24.0"]


### PR DESCRIPTION
## Description

Stop testing all k8s versions in every CI run, like we do in astronomer/astronomer: only test the newest and oldest version.

### Release branch before

<img width="1735" alt="before" src="https://user-images.githubusercontent.com/1323808/201232204-e1c7870f-168f-4b84-a474-95d3ea2c985f.png">

### Release branch after

<img width="1742" alt="after" src="https://user-images.githubusercontent.com/1323808/201231996-ae20daa9-8451-44a8-9842-b0c0c3e54e25.png">

### Feature branch before

<img width="1005" alt="before" src="https://user-images.githubusercontent.com/1323808/201232421-f851d435-61ef-42c2-95a9-b0888b7be25f.png">

### Feature branch after

<img width="1015" alt="after" src="https://user-images.githubusercontent.com/1323808/201233338-45f4e38e-84b8-43f8-9f8a-1c25fb0b94d0.png">

## Related Issues

https://github.com/astronomer/issues/issues/5180

## Testing

These are all CI changes, so no further testing is needed if CI passes.

## Merging

Merge into all supported branches.