### PR TITLE
Add repo state report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ charts
 dev-account.json
 kubeconfig
 letsencrypt*
+repo_state.log
 repository

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
           ]
       - id: sort-simple-yaml
       - id: trailing-whitespace
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
       - id: flake8

--- a/bin/package-and-release-internal
+++ b/bin/package-and-release-internal
@@ -33,7 +33,7 @@ else
   filename="airflow-${version}.tgz"
   extra_args=( '--version' "${version}" )
   sed -i "s#^description: .*#description: $(date "+%FT%T%z") ${CIRCLE_BRANCH} ${CIRCLE_BUILD_URL} https://github.com/astronomer/airflow-chart/commits/${CIRCLE_SHA1}#" airflow/Chart.yaml
-  bin/repo-state-report.sh > airflow/repo_state.log
+  (cd airflow && bin/repo-state-report.sh > repo_state.log)
 fi
 
 helm package airflow --dependency-update --app-version "${app_version}" "${extra_args[@]}"

--- a/bin/package-and-release-internal
+++ b/bin/package-and-release-internal
@@ -33,6 +33,7 @@ else
   filename="airflow-${version}.tgz"
   extra_args=( '--version' "${version}" )
   sed -i "s#^description: .*#description: $(date "+%FT%T%z") ${CIRCLE_BRANCH} ${CIRCLE_BUILD_URL} https://github.com/astronomer/airflow-chart/commits/${CIRCLE_SHA1}#" airflow/Chart.yaml
+  bin/repo-state-report.sh > airflow/repo_state.log
 fi
 
 helm package airflow --dependency-update --app-version "${app_version}" "${extra_args[@]}"

--- a/bin/repo-state-report.sh
+++ b/bin/repo-state-report.sh
@@ -6,19 +6,19 @@ GIT_SHA=$(git rev-parse HEAD)$(if [[ -n "$(git status --porcelain)" ]] ; then ec
 BUILD_DATE_ISO8601=$(date +%FT%T%z)
 
 output=(
-    "Git repo:|${GIT_ORIGIN}"
-    "Git branch:|${GIT_BRANCH}"
-    "Git SHA:|${GIT_SHA}"
-    "Build time:|${BUILD_DATE_ISO8601}"
+    "Build time:  ${BUILD_DATE_ISO8601}"
+    "Git repo:    ${GIT_ORIGIN}"
+    "Git branch:  ${GIT_BRANCH}"
+    "Git SHA:     ${GIT_SHA}"
 )
 
-[[ -n "${CIRCLE_BUILD_URL}" ]] && output+=( "CircleCI Build URL:|${CIRCLE_BUILD_URL}" )
-[[ -n "${CIRCLE_BUILD_NUM}" ]] && output+=( "CircleCI Build Number:|${CIRCLE_BUILD_NUM}" )
-[[ -n "${CIRCLE_REPOSITORY_URL}" ]] && output+=( "CircleCI Repository URL:|${CIRCLE_REPOSITORY_URL}" )
-[[ -n "${CIRCLE_SHA1}" ]] && output+=( "CircleCI SHA1:|${CIRCLE_SHA1}" )
-[[ -n "${CIRCLE_WORKFLOW_ID}" ]] && output+=( "CircleCI Workflow ID:|${CIRCLE_WORKFLOW_ID}" )
-[[ -n "${CIRCLE_JOB}" ]] && output+=( "CircleCI Job:|${CIRCLE_JOB}" )
+[[ -n "${CIRCLE_BUILD_URL}" ]] && output+=( "CircleCI Build URL:       ${CIRCLE_BUILD_URL}" )
+[[ -n "${CIRCLE_BUILD_NUM}" ]] && output+=( "CircleCI Build Number:    ${CIRCLE_BUILD_NUM}" )
+[[ -n "${CIRCLE_REPOSITORY_URL}" ]] && output+=( "CircleCI Repository URL:  ${CIRCLE_REPOSITORY_URL}" )
+[[ -n "${CIRCLE_SHA1}" ]] && output+=( "CircleCI SHA1:            ${CIRCLE_SHA1}" )
+[[ -n "${CIRCLE_WORKFLOW_ID}" ]] && output+=( "CircleCI Workflow ID:     ${CIRCLE_WORKFLOW_ID}" )
+[[ -n "${CIRCLE_JOB}" ]] && output+=( "CircleCI Job:             ${CIRCLE_JOB}" )
 
 for item in "${output[@]}" ; do
     echo "$item"
-done | column -t -s'|'
+done

--- a/bin/repo-state-report.sh
+++ b/bin/repo-state-report.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+GIT_ORIGIN=$(git config --get remote.origin.url)
+GIT_SHA=$(git rev-parse HEAD)$(if [[ -n "$(git status --porcelain)" ]] ; then echo " DIRTY" ; fi)
+BUILD_DATE_ISO8601=$(date +%FT%T%z)
+
+output=(
+    "Git repo:|${GIT_ORIGIN}"
+    "Git branch:|${GIT_BRANCH}"
+    "Git SHA:|${GIT_SHA}"
+    "Build time:|${BUILD_DATE_ISO8601}"
+)
+
+[[ -n "${CIRCLE_BUILD_URL}" ]] && output+=( "CircleCI Build URL:|${CIRCLE_BUILD_URL}" )
+[[ -n "${CIRCLE_BUILD_NUM}" ]] && output+=( "CircleCI Build Number:|${CIRCLE_BUILD_NUM}" )
+[[ -n "${CIRCLE_REPOSITORY_URL}" ]] && output+=( "CircleCI Repository URL:|${CIRCLE_REPOSITORY_URL}" )
+[[ -n "${CIRCLE_SHA1}" ]] && output+=( "CircleCI SHA1:|${CIRCLE_SHA1}" )
+[[ -n "${CIRCLE_WORKFLOW_ID}" ]] && output+=( "CircleCI Workflow ID:|${CIRCLE_WORKFLOW_ID}" )
+[[ -n "${CIRCLE_JOB}" ]] && output+=( "CircleCI Job:|${CIRCLE_JOB}" )
+
+for item in "${output[@]}" ; do
+    echo "$item"
+done | column -t -s'|'


### PR DESCRIPTION
## Description

Add repo and CI metadata to helm package.

Also fix a minor pre-commit bug that began blocking CI.

## Related Issues

https://github.com/astronomer/issues/issues/5152

## Testing

```
$ helm pull astronomer-internal/airflow --version 1.7.1-build18945
$ tar -xzf airflow-1.7.1-build18945.tgz
$ cat air
airflow/                      airflow-1.7.1-build18945.tgz
$ cat airflow/repo_state.log
Build time:  2022-11-14T23:35:43+0000
Git repo:    git@github.com:astronomer/airflow-chart.git
Git branch:  5152-add-repo-state-report
Git SHA:     834fcac32b61512354dee2e412461f44fb1aba7e DIRTY
CircleCI Build URL:       https://circleci.com/gh/astronomer/airflow-chart/18945
CircleCI Build Number:    18945
CircleCI Repository URL:  git@github.com:astronomer/airflow-chart.git
CircleCI SHA1:            834fcac32b61512354dee2e412461f44fb1aba7e
CircleCI Workflow ID:     829910b9-679c-449f-86cd-4bfd95462fe5
CircleCI Job:             build-and-release-internal
```

## Merging

This should be merged to all supported branches.