### PR TITLE
5224 switch back to oss airflow chart

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: airflow
-  repository: https://github.com/astronomer/airflow/releases/download/oss-helm-chart/1.7.0-astro
-  version: 1.7.0-astro
-digest: sha256:b3d3c7e73c8c6237a5bee984da23c4f93af8b2e9acf4e1bfd1cdaf3f212c3f39
-generated: "2022-08-29T15:26:46.269775-05:00"
+  repository: https://airflow.apache.org
+  version: 1.7.0
+digest: sha256:c08baee767330da39f701fd0ba4e15c739c7054fe145c0483679bf5b640d952a
+generated: "2022-11-18T09:55:29.953356-05:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -9,5 +9,5 @@ keywords:
   - airflow
 dependencies:
   - name: airflow
-    version: 1.7.0-astro
-    repository: https://github.com/astronomer/airflow/releases/download/oss-helm-chart/1.7.0-astro
+    version: 1.7.0
+    repository: https://airflow.apache.org

--- a/tests/chart_tests/helm_template_generator.py
+++ b/tests/chart_tests/helm_template_generator.py
@@ -103,8 +103,6 @@ def render_chart(
             "--namespace",
             namespace,
         ]
-        if namespace:
-            command.extend(["--namespace", namespace])
         if show_only:
             if isinstance(show_only, str):
                 show_only = [show_only]

--- a/tests/chart_tests/test_default_chart.py
+++ b/tests/chart_tests/test_default_chart.py
@@ -6,7 +6,7 @@ from tests.chart_tests.helm_template_generator import render_chart
 def test_default_chart_with_basedomain():
     """Test that each template used with just baseDomain set renders."""
     docs = render_chart()
-    assert len(docs) == 28
+    assert len(docs) == 29
 
 
 @pytest.mark.parametrize("namespace", ["abc", "123", "123abc", "123-abc"])


### PR DESCRIPTION
## Description

- Switch back to OSS helm chart as a dependency
- Tweak default docs length to 29 for OSS statsd additions
- Remove redundant `--namespace` flag in `helm_template_generator()`

## Related Issues

https://github.com/astronomer/issues/issues/5224

## Testing

There were some statsd additions in the OSS helm chart so we should make sure those don't break anything. There may be other changes in OSS helm chart to look out for.

## Merging

This should be merged to all branches that use 1.7.0-astro