### PR TITLE
version 1.7.3

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v2 is Helm 3
 apiVersion: v2
 name: airflow
-version: 1.7.2
+version: 1.7.3
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:


### PR DESCRIPTION
## Description

Version 1.7.3. (rc1 was done in release-1.7 branch.)

~Blocked by <https://github.com/astronomer/airflow-chart/pull/375>~

## Related Issues

N/A

## Testing

Testing was done on airflow-chart 1.7.3-rc1 for astronomer 0.31.0 release.

## Merging

Merge into release-1.7 branch (there will be conflicts)