### PR TITLE
Remove deprecated transforms

### DIFF
--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -25,14 +25,14 @@ data:
         read_from: beginning
     transforms:
       transform_syslog:
-        type: add_fields
+        type: remap
         inputs:
           - airflow_log_files
-        fields:
-          component: "${COMPONENT:--}"
-          workspace: "${WORKSPACE:--}"
-          release: "${RELEASE:--}"
-          date_nano: "%Y-%m-%dT%H:%M:%S.%f%Z"
+        source: |
+          .component = "${COMPONENT:--}"
+          .workspace = "${WORKSPACE:--}"
+          .release = "${RELEASE:--}"
+          .date_nano = "%Y-%m-%dT%H:%M:%S.%f%Z"
 
       filter_common_logs:
         type: filter
@@ -74,14 +74,14 @@ data:
           .offset = to_int(now()) * 1000000000 + to_unix_timestamp(now()) * 1000000
 
       final_task_log:
-        type: add_fields
+        type: remap
         inputs:
           - transform_task_log
-        fields:
-          component: "${COMPONENT:--}"
-          workspace: "${WORKSPACE:--}"
-          release: "${RELEASE:--}"
-          date_nano: "%Y-%m-%dT%H:%M:%S.%f%Z"
+        source: |
+          .component = "${COMPONENT:--}"
+          .workspace = "${WORKSPACE:--}"
+          .release = "${RELEASE:--}"
+          .date_nano = "%Y-%m-%dT%H:%M:%S.%f%Z"
 
       transform_remove_fields:
         type: remove_fields

--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -84,13 +84,13 @@ data:
           .date_nano = "%Y-%m-%dT%H:%M:%S.%f%Z"
 
       transform_remove_fields:
-        type: remove_fields
+        type: remap
         inputs:
           - final_task_log
           - filter_common_logs
-        fields:
-          - host
-          - file
+        source: |
+          del(.host)
+          del(.file)
 
     sinks:
       out:


### PR DESCRIPTION
## Description

Replace transforms that were deprecated in vector 0.24 with new syntaxes.

## Related Issues

https://github.com/astronomer/issues/issues/5253

## Testing

I launched a deployment in qa.link and reproduced the problem, then upgraded astronomer to use the airflowChartVersion from this branch, re-deployed, and things worked again. My testing only made sure the pods came up, not that the logs actually exist, because I am not an astronomer admin in the qa.link astronomer deployment that I was testing in.

## Merging

AFAIK these changes are safe to merge anywhere, because these syntaxes have been deprecated for a while and should work with older versions of vector that we have. They are only really needed in release-1.7 though.