### PR TITLE
Improve docs to avoid confusion related to the core git-sync feature

### DIFF
--- a/docs/git-sync-relay.md
+++ b/docs/git-sync-relay.md
@@ -42,6 +42,16 @@ gitSyncRelay:
     wait: 60 # seconds between synchronizations with upstream git repo
     subPath: dags # if your dags dir is not the repo root, specify the path relative to the repo root
     sshPrivateKeySecretName: git-ssh-private-key # This is the secret we created earlier. This is not requred with https git remotes.
+
+airflow:
+  dags:
+    gitSync:
+      enabled: True
+      repo: git://airflow-git-sync-relay.${NAMESPACE}.svc.cluster.local./git
+      branch: main
+  dagDeployment:
+    repositoryUrl: https://github.com/astronomer/2-4-example-dags
+    type: git_sync
 ```
 
 ### Install airflow

--- a/docs/git-sync-relay.md
+++ b/docs/git-sync-relay.md
@@ -56,7 +56,7 @@ airflow:
 
 ### Install airflow
 
-You must also follow the git-sync configuration setup that you would normally follow to install the apache airflow chart. The one customization you must make is to use the git repo served by the git-sync-relay's git-daemon pod as your git remote. That URL is `git://airflow-git-sync-relay.${NAMESPACE}.svc.cluster.local./git` where `${NAMESPACE}` is the airflow installation namespace. Once you have those values set up in your values.yaml file, you can install the astronomer airflow-chart:
+Once you have those values set up in your values.yaml file, you can install the astronomer airflow-chart using this repo as your source:
 
 ```sh
 helm install airflow . -n aftest -f values.yaml  # where `.` is the root of this repository checked out to your filesystem

--- a/docs/git-sync-relay.md
+++ b/docs/git-sync-relay.md
@@ -49,9 +49,6 @@ airflow:
       enabled: True
       repo: git://airflow-git-sync-relay.${NAMESPACE}.svc.cluster.local./git
       branch: main
-  dagDeployment:
-    repositoryUrl: https://github.com/astronomer/2-4-example-dags
-    type: git_sync
 ```
 
 ### Install airflow

--- a/values.yaml
+++ b/values.yaml
@@ -449,7 +449,7 @@ gitSyncRelay:
     depth: 1 # default to a shallow clone because it is faster and this isn't a dev environment
     wait: 60 # seconds between synchronizations with upstream git repo
     subPath: ~ # if your dags dir is not the repo root, specify the path relative to the repo root
-    sshPrivateKeySecretName: ~ # The name of a secret that holds the private key. This secret is not maintained by this chart. TODO: replace this URL with the master branch location https://github.com/astronomer/airflow-chart/blob/3708-git-sync/docs/git-sync-relay.md#configuration
+    sshPrivateKeySecretName: ~ # The name of a secret that holds the private key. This secret is not maintained by this chart.
     gitSyncTimeout: 300 # How long to wait for the clone or fetch to take before aborting
     # knownHosts can be generated with: ssh-keyscan -t ed25519 github.com 2>/dev/null
     knownHosts: |


### PR DESCRIPTION
## Description

Improve docs to avoid confusion related to the core git-sync feature, and other small improvements. This is in response to the issue in this thread:

- <https://astronomer.slack.com/archives/C02NZELT2/p1671464975671469>
- <https://apache-airflow.slack.com/archives/C03T0AVNA6A/p1671450081264109>

## Related Issues

N/A

## Testing

Only docs changes, no testing is needed. I did set up a kind cluster and test these instructions out while changing them.

Because these are only docs changes, the only CI step that needs to pass is run_pre_commit

## Merging

Merge everywhere git-sync-relay is supported.