### PR TITLE
ap-base 3.16.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ workflows:
 jobs:
   run_pre_commit:
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2022-11
+      - image: quay.io/astronomer/ci-pre-commit:2022-12
     steps:
       - checkout
       - run:
@@ -179,7 +179,7 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2022-11
+      - image: quay.io/astronomer/ci-helm-release:2022-12
     steps:
       - setup_remote_docker:
           version: 20.10.18
@@ -195,7 +195,7 @@ jobs:
 
   build-and-release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2022-11
+      - image: quay.io/astronomer/ci-helm-release:2022-12
     steps:
       - checkout
       - run:
@@ -235,7 +235,7 @@ jobs:
           path: test-results
   release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2022-11
+      - image: quay.io/astronomer/ci-helm-release:2022-12
     steps:
       - checkout
       - run:
@@ -244,7 +244,7 @@ jobs:
 
   release-public:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2022-11
+      - image: quay.io/astronomer/ci-helm-release:2022-12
     steps:
       - checkout
       - publish-github-release

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -15,7 +15,7 @@ kube_versions = ["1.21.14", "1.22.15", "1.23.13", "1.24.7"]
 remote_docker_version = "20.10.18"
 
 executors = ["CeleryExecutor", "LocalExecutor", "KubernetesExecutor"]
-ci_runner_version = "2022-11"
+ci_runner_version = "2022-12"
 
 
 def main():

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,22 +7,22 @@ repos:
       - id: remove-tabs
         exclude_types: [makefile, binary]
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: v5.11.3
     hooks:
       - id: isort
         name: isort (python)
         args: ["--profile", "black"]
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 22.12.0
     hooks:
       - id: black
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.38.0
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
         args: ["--py38-plus"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-case-conflict
       - id: check-executables-have-shebangs
@@ -55,13 +55,13 @@ repos:
       - id: sort-simple-yaml
       - id: trailing-whitespace
   - repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 6.0.0
     hooks:
       - id: flake8
         args:
           - --ignore=E501,W503
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.8.0.4
+    rev: v0.9.0.2
     hooks:
       - id: shellcheck
   - repo: https://github.com/Lucas-C/pre-commit-hooks
@@ -85,7 +85,7 @@ repos:
         entry: .circleci/generate_circleci_config.py
         additional_dependencies: ["jinja2"]
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v2.7.1"
+    rev: "v3.0.0-alpha.4"
     hooks:
       - id: prettier
         args: ["--print-width=135"]

--- a/bin/install-ci-tools
+++ b/bin/install-ci-tools
@@ -6,7 +6,7 @@ if [[ -z "${KIND_VERSION}" ]]; then
 fi
 
 if [[ -z "${HELM_VERSION}" ]]; then
-  export HELM_VERSION="3.10.1"
+  export HELM_VERSION="3.10.3"
 fi
 
 # Determine the platform we are running on

--- a/bin/install-ci-tools
+++ b/bin/install-ci-tools
@@ -23,7 +23,7 @@ echo "Installing Kubernetes in Docker (kind) version ${KIND_VERSION}..."
 if [[ -f /tmp/bin/kind ]]; then
   echo "Already installed in /tmp/bin. Skipping!"
 else
-  curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-"${OS}"-amd64 > /dev/null 2>&1
+  curl -Lo ./kind "https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-${OS}-amd64" > /dev/null 2>&1
   chmod +x ./kind
   mv ./kind /tmp/bin/
 fi

--- a/bin/start-kind-cluster
+++ b/bin/start-kind-cluster
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2181
 
-KUBE_VERSION="${KUBE_VERSION:-1.21.2}"
+KUBE_VERSION="${KUBE_VERSION:-1.24.7}"
 
 # Create a kind cluster
 kind create cluster --image "kindest/node:v${KUBE_VERSION}"

--- a/values.yaml
+++ b/values.yaml
@@ -38,7 +38,7 @@ airflow:
       tag: 1.17.0-8
     pgbouncerExporter:
       repository: quay.io/astronomer/ap-pgbouncer-exporter
-      tag: 0.14.0
+      tag: 0.14.0-1
     gitSync:
       repository: quay.io/astronomer/ap-git-sync
       tag: 3.6.2

--- a/values.yaml
+++ b/values.yaml
@@ -38,7 +38,7 @@ airflow:
       tag: 1.17.0-8
     pgbouncerExporter:
       repository: quay.io/astronomer/ap-pgbouncer-exporter
-      tag: 0.14.0-1
+      tag: 0.13.0-9
     gitSync:
       repository: quay.io/astronomer/ap-git-sync
       tag: 3.6.2

--- a/values.yaml
+++ b/values.yaml
@@ -35,13 +35,13 @@ airflow:
       tag: 6.2.7
     pgbouncer:
       repository: quay.io/astronomer/ap-pgbouncer
-      tag: 1.17.0-5
+      tag: 1.17.0-8
     pgbouncerExporter:
       repository: quay.io/astronomer/ap-pgbouncer-exporter
-      tag: 0.13.0-6
+      tag: 0.14.0
     gitSync:
       repository: quay.io/astronomer/ap-git-sync
-      tag: 3.6.1
+      tag: 3.6.2
   # Airflow scheduler settings
   scheduler:
     livenessProbe:
@@ -438,10 +438,10 @@ gitSyncRelay:
   images:
     gitDaemon:
       repository: "quay.io/astronomer/ap-git-daemon"
-      tag: "3.16.2-1"
+      tag: "3.16.3"
     gitSync:
       repository: "quay.io/astronomer/ap-git-sync"
-      tag: "3.6.1"
+      tag: "3.6.2"
 
   repo:
     url: ~


### PR DESCRIPTION
## Description

- Use new components that have ap-base 3.16.3
- Update many dev component versions

## Related Issues

- https://github.com/astronomer/issues/issues/5291

## Testing

We'll need to check that pgbouncer and its stats are working, and that git-sync is working.

## Merging

Merge only to release-1.7 due to git-sync-relay changes being included, which are not supported prior to 1.7. Release a new version after merging.