### PR TITLE
Fix Elasticsearch log_id_template (#326)

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -338,6 +338,10 @@ airflow:
       write_stdout: True
       elasticsearch_write_stdout: True
       elasticsearch_json_format: True
+      # "{dag_id}-{task_id}-{run_id}-{map_index}-{try_number}" for airflow >= 2.3.0 ref https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#log-id-template
+      # "{dag_id}_{task_id}_{execution_date}_{try_number}" for airflow < 2.3.0
+      log_id_template: '{{ternary "{dag_id}-{task_id}-{run_id}-{map_index}-{try_number}" "{dag_id}_{task_id}_{execution_date}_{try_number}" (semverCompare ">=2.3.0" .Values.airflowVersion)}}'
+      # For Airflow <1.10.4
       elasticsearch_log_id_template: "{dag_id}_{task_id}_{execution_date}_{try_number}"
     # The following kubernetes config is required to support Airflow 1.10.10
     kubernetes:


### PR DESCRIPTION
## Description

Turns out it was `elasticsearch_log_id_template` until 1.10.4, then was deprecated until 2.0.0, when even backcompat was removed. 2+ relied on the OSS chart's `log_id_template`, which matched our overridden value.

## Related Issues

https://github.com/astronomer/issues/issues/4634

## Testing

No testing needed. This was already merged to release-1.7

## Merging

This is only meant for master.