### PR TITLE
Add the 'make show-docker-images' target from Astronomer "Software"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,9 @@ clean: ## Clean build and test artifacts
 update-requirements: ## Update all requirements.txt files
 	for FILE in tests/chart_tests/requirements.in tests/functional-tests/requirements.in ; do pip-compile --generate-hashes --quiet --allow-unsafe --upgrade $${FILE} ; done ;
 	-pre-commit run requirements-txt-fixer --all-files --show-diff-on-failure
+
+.PHONY: show-docker-images
+show-docker-images: ## Show all docker images and versions used in the helm chart
+	@helm template . 2>/dev/null \
+		-f tests/enable_all_features.yaml \
+		| gawk '/image: / {match($$2, /(([^"]*):[^"]*)/, a) ; printf "https://%s %s\n", a[2], a[1] ;}' | sort -u | column -t

--- a/tests/enable_all_features.yaml
+++ b/tests/enable_all_features.yaml
@@ -1,0 +1,16 @@
+airflow:
+  workers:
+    persistence:
+      enabled: true
+authSidecar:
+  enabled: true
+gitSyncRelay:
+  enabled: true
+ingress:
+  enabled: true
+loggingSidecar:
+  enabled: true
+sccEnabled: true
+workers:
+  autoscaling:
+    enabled: true


### PR DESCRIPTION
## Description

Add the same `make show-docker-images` target that Astronomer "Software" has.

## Related Issues

https://github.com/astronomer/issues/issues/4145

## Testing

N/A, this is just a make target that is not used anywhere yet and only reports data that exists in the repo.

## Merging

Merge to all supported branches.