### PR TITLE
allow customization of index time format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ workflows:
 jobs:
   run_pre_commit:
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2023-01
+      - image: quay.io/astronomer/ci-pre-commit:2023-02
     steps:
       - checkout
       - run:
@@ -233,7 +233,7 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2023-01
+      - image: quay.io/astronomer/ci-helm-release:2023-02
     steps:
       - setup_remote_docker:
           version: 20.10.18
@@ -249,7 +249,7 @@ jobs:
 
   build-and-release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2023-01
+      - image: quay.io/astronomer/ci-helm-release:2023-02
     steps:
       - checkout
       - run:
@@ -289,7 +289,7 @@ jobs:
           path: test-results
   release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2023-01
+      - image: quay.io/astronomer/ci-helm-release:2023-02
     steps:
       - checkout
       - run:
@@ -298,7 +298,7 @@ jobs:
 
   release-public:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2023-01
+      - image: quay.io/astronomer/ci-helm-release:2023-02
     steps:
       - checkout
       - publish-github-release

--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -107,6 +107,6 @@ data:
           password : {{ .Values.airflow.elasticsearch.connection.pass }}
       {{- end }}
         bulk:
-          index: "vector.${RELEASE:--}.%Y.%m.%d"
+          index: "vector.${RELEASE:--}.{{ .Values.loggingSidecar.indexPattern | default "%Y.%m.%d" }}"
           action: create
 {{- end }}

--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -107,6 +107,6 @@ data:
           password : {{ .Values.airflow.elasticsearch.connection.pass }}
       {{- end }}
         bulk:
-          index: "vector.${RELEASE:--}.{{ .Values.loggingSidecar.indexPattern | default "%Y.%m.%d" }}"
+          index: "vector.${RELEASE:--}.{{ .Values.loggingSidecar.indexPattern }}"
           action: create
 {{- end }}

--- a/tests/chart_tests/test_logging_sidecar.py
+++ b/tests/chart_tests/test_logging_sidecar.py
@@ -62,3 +62,27 @@ class TestLoggingSidecar:
             show_only="templates/logging-sidecar-configmap.yaml",
         )
         assert len(docs) == 0
+
+    def test_logging_sidecar_index_format_overrides(self, kube_version):
+        """Test logging sidecar config with custom timestamp format"""
+        test_custom_sidecar_config = textwrap.dedent(
+            """
+        loggingSidecar:
+          enabled: true
+          name: sidecar-logging-consumer
+          indexPattern: "%Y.%m"
+            """
+        )
+        values = yaml.safe_load(test_custom_sidecar_config)
+        docs = render_chart(
+            kube_version=kube_version,
+            values=values,
+            show_only="templates/logging-sidecar-configmap.yaml",
+        )
+        assert len(docs) == 1
+        assert (vc := yaml.safe_load(docs[0]["data"]["vector-config.yaml"]))
+        print(vc)
+        assert vc["sinks"]["out"]["bulk"] == {
+            "index": "vector.${RELEASE:--}.%Y.%m",
+            "action": "create",
+        }

--- a/tests/chart_tests/test_logging_sidecar.py
+++ b/tests/chart_tests/test_logging_sidecar.py
@@ -81,7 +81,6 @@ class TestLoggingSidecar:
         )
         assert len(docs) == 1
         assert (vc := yaml.safe_load(docs[0]["data"]["vector-config.yaml"]))
-        print(vc)
         assert vc["sinks"]["out"]["bulk"] == {
             "index": "vector.${RELEASE:--}.%Y.%m",
             "action": "create",

--- a/values.yaml
+++ b/values.yaml
@@ -381,7 +381,7 @@ loggingSidecar:
   enabled: false
   name: sidecar-logging-consumer
   customConfig: false
-
+  indexPattern: ~
 # Ingress configuration
 ingress:
   # Enable ingress resource

--- a/values.yaml
+++ b/values.yaml
@@ -381,7 +381,7 @@ loggingSidecar:
   enabled: false
   name: sidecar-logging-consumer
   customConfig: false
-  indexPattern: ~
+  indexPattern: "%Y.%m.%d"
 # Ingress configuration
 ingress:
   # Enable ingress resource


### PR DESCRIPTION
## Description

current vector index format for elasticsearch is set to create daily. This current change helps users to override the default to choose their own index timestamp 

## Related Issues
https://github.com/astronomer/issues/issues/5276
https://github.com/astronomer/issues/issues/5277

## Testing

Added static test case to validate the template

## Merging

cherry-pick/merge to release-1.7
