### PR TITLE
update upstream airflow helm chart 1.8.0

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v2 is Helm 3
 apiVersion: v2
 name: airflow
-version: 1.7.5
+version: 1.8.0
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:
@@ -9,5 +9,5 @@ keywords:
   - airflow
 dependencies:
   - name: airflow
-    version: 1.7.0
+    version: 1.8.0
     repository: https://airflow.apache.org


### PR DESCRIPTION
## Description

Update airflow upstream helm chart to 1.8.0 to get newer features and updates

## Related Issues

https://github.com/astronomer/issues/issues/5430

## Testing

QA should able to deploy airflow from astronomer without any issues, additionally this chart now supports pgbouncer replicas support - now those can be overridden .

## Merging

cherry-pick changes to release-1.8.
