### PR TITLE
Improve vector log parsing

### DIFF
--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -24,7 +24,7 @@ data:
           - "${SIDECAR_LOGS}/*.log"
         read_from: beginning
     transforms:
-      transform_syslog:
+      transform_airflow_logs:
         type: remap
         inputs:
           - airflow_log_files
@@ -37,7 +37,7 @@ data:
       filter_common_logs:
         type: filter
         inputs:
-          - transform_syslog
+          - transform_airflow_logs
         condition:
           type: "vrl"
           source: '!includes(["worker","scheduler"], .component)'
@@ -45,7 +45,7 @@ data:
       filter_scheduler_logs:
         type: filter
         inputs:
-          - transform_syslog
+          - transform_airflow_logs
         condition:
           type: "vrl"
           source: 'includes(["scheduler"], .component)'
@@ -53,7 +53,7 @@ data:
       filter_worker_logs:
         type: filter
         inputs:
-          - transform_syslog
+          - transform_airflow_logs
         condition:
           type: "vrl"
           source: 'includes(["worker"], .component)'
@@ -61,7 +61,7 @@ data:
       filter_gitsyncrelay_logs:
         type: filter
         inputs:
-          - transform_syslog
+          - transform_airflow_logs
         condition:
           type: "vrl"
           source: 'includes(["git-sync-relay"], .component)'

--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -32,7 +32,7 @@ data:
           .component = "${COMPONENT:--}"
           .workspace = "${WORKSPACE:--}"
           .release = "${RELEASE:--}"
-          .date_nano = parse_timestamp!(.@timestamp, format: "%Y-%m-%dT%H:%M:%S.%f%Z") ?? now()
+          .date_nano = parse_timestamp!(.@timestamp, format: "%Y-%m-%dT%H:%M:%S.%f%Z")
 
       filter_common_logs:
         type: filter

--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -32,7 +32,7 @@ data:
           .component = "${COMPONENT:--}"
           .workspace = "${WORKSPACE:--}"
           .release = "${RELEASE:--}"
-          .date_nano = parse_timestamp!(.@timestamp, format: "%Y-%m-%dT%H:%M:%S.%f%Z")
+          .date_nano = parse_timestamp!(.@timestamp, format: "%Y-%m-%dT%H:%M:%S.%f%Z") ?? now()
 
       filter_common_logs:
         type: filter
@@ -72,12 +72,11 @@ data:
           - filter_worker_logs
           - filter_scheduler_logs
         source: |-
-          # Parse Syslog input. The "!" means that the script should abort on error.
-          . = parse_json!(.message)
+          . = parse_json(.message) ?? .message
           .@timestamp = parse_timestamp(.timestamp, "%Y-%m-%dT%H:%M:%S%Z") ?? now()
           .check_log_id = exists(.log_id)
           if .check_log_id != true {
-          .log_id = join!([.dag_id, .task_id, .execution_date, .try_number], "_")
+          .log_id = join!([to_string!(.dag_id), to_string!(.task_id), to_string!(.execution_date), to_string!(.try_number)], "_")
           }
           .offset = to_int(now()) * 1000000000 + to_unix_timestamp(now()) * 1000000
 


### PR DESCRIPTION
## Description

- Only parse json lines as json, pass all other messages straight through.
- Rename transform_syslog to transform_airflow_logs to be more accurate

## Related Issues

- <https://github.com/astronomer/issues/issues/5060>

## Testing

I have tested this in aws with kubernetes executor and verified that the vector parse error messages no longer show up. 

## Merging

This should be merged everywhere.