### PR TITLE
Add all public keys for github and gitlab

### DIFF
--- a/tests/chart_tests/test_git_sync_relay_configmap.py
+++ b/tests/chart_tests/test_git_sync_relay_configmap.py
@@ -26,31 +26,18 @@ class TestGitSyncRelayConfigmap:
         assert len(docs) == 1
         doc = docs[0]
 
-        expected_result = {
-            "apiVersion": "v1",
-            "data": {
-                "known_hosts": "github.com ssh-ed25519 "
-                "AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl\n"
-                "gitlab.com ssh-ed25519 "
-                "AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf\n"
-            },
-            "kind": "ConfigMap",
-            "metadata": {
-                "labels": {
-                    "chart": "release-name-1.1.0-rc1",
-                    "component": "release-name-git-sync-relay",
-                    "heritage": "Helm",
-                    "release": "release-name",
-                    "tier": "airflow",
-                },
-                "name": "release-name-git-sync-config",
-            },
-        }
-
-        expected_result["metadata"]["labels"].pop("chart")
-        doc["metadata"]["labels"].pop("chart")
-
-        assert doc == expected_result
+        assert doc["kind"] == "ConfigMap"
+        assert len(doc["data"]) == 1
+        # ed25519 keys, and substrings of other key types
+        key_lines = [
+            "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTt",
+            "github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENj",
+            "github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl",
+            "gitlab.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsj2bNKTBSpIYDEGk9KxsGh3mySTRgMtXL583qmBpz",
+            "gitlab.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFSMqzJe",
+            "gitlab.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf",
+        ]
+        assert all(x in doc["data"]["known_hosts"] for x in key_lines)
 
     def test_gsr_configmap_gsr_enabled_with_custom_known_hosts(self, kube_version):
         """Test that valid configmaps are rendered when git-sync-relay is enabled and has custom knownHosts."""

--- a/values.yaml
+++ b/values.yaml
@@ -447,6 +447,12 @@ gitSyncRelay:
     gitSyncTimeout: 300 # How long to wait for the clone or fetch to take before aborting
     # knownHosts can be generated with: ssh-keyscan -t ed25519 github.com 2>/dev/null
     knownHosts: |
+      # https://api.github.com/meta
+      github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
+      github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
       github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+      # https://docs.gitlab.com/ee/user/gitlab_com/#ssh-host-keys-fingerprints
+      gitlab.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsj2bNKTBSpIYDEGk9KxsGh3mySTRgMtXL583qmBpzeQ+jqCMRgBqB98u3z++J1sKlXHWfM9dyhSevkMwSbhoR8XIq/U0tCNyokEi/ueaBMCvbcTHhO7FcwzY92WK4Yt0aGROY5qX2UKSeOvuP4D6TPqKF1onrSzH9bx9XUf2lEdWT/ia1NEKjunUqu1xOB/StKDHMoX4/OKyIzuS0q/T1zOATthvasJFoPrAjkohTyaDUz2LN5JoH839hViyEG82yB+MjcFV5MU3N1l1QL3cVUCh93xSaua1N85qivl+siMkPGbO5xR/En4iEY6K2XPASUEMaieWVNTRCtJ4S8H+9
+      gitlab.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFSMqzJeV9rUzU4kWitGjeR4PWSa29SPqJ1fVkhtj3Hw9xjLVXVYrU9QlYWrOLXBpQ6KWjbjTDTdDkoohFzgbEY=
       gitlab.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf
   extraContainers: []


### PR DESCRIPTION
## Description

Add all public keys for github and gitlab with links to where the info is posted, though it can also be found via ssh-keyscan, which is also noted in the comments.

## Related Issues

- <https://github.com/astronomer/issues/issues/5488>

## Testing

None needed. This is is just data additions, not code changes.

## Merging

This should be merged to all supported branches.