### PR TITLE
Fix git-sync-relay networkpolicy spec.podSelector.matchLabels.tier

### DIFF
--- a/templates/git-sync-relay/git-sync-relay-networkpolicy.yaml
+++ b/templates/git-sync-relay/git-sync-relay-networkpolicy.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      tier: astronomer
+      tier: airflow
       component: git-sync-relay
       release: {{ .Release.Name }}
   policyTypes:


### PR DESCRIPTION
## Description

Fix a bug in the git-sync-relay networkpolicy where the tier was specified as astronomer instead of airflow.

## Related Issues

https://github.com/astronomer/issues/issues/5574

## Testing

I tested this manually in AWS. I didn't had any unit tests because nothing here is variable, it was just a misconfiguration.

## Merging

This should be merged to 0.32 and 0.31 since 0.30 does not have git-sync-relay.