### PR TITLE
update gitsync network policy in airflow chart

### DIFF
--- a/templates/git-sync-relay/git-sync-relay-networkpolicy.yaml
+++ b/templates/git-sync-relay/git-sync-relay-networkpolicy.yaml
@@ -22,10 +22,7 @@ spec:
   - Ingress
   ingress:
   - from:
-    - namespaceSelector:
-        matchLabels:
-          name: {{ .Release.Namespace }}
-      podSelector:
+    - podSelector:
         matchLabels:
           release: {{ .Release.Name }}
           tier: airflow


### PR DESCRIPTION
## Description

Updating gitsync network policy to remove namespace matchLabel Selector and only use podlablel selector

## Related Issues

Need to reference git-sync network policy ticket here 

## Testing

QA should able to deploy airflow with gitsync service and able to use that service from worker , scheduler and triggerer without issues 

## Merging

cherry-pick to release-1.8
