### PR TITLE
Fix scheduler null message field

### DIFF
--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -72,7 +72,7 @@ data:
           - filter_worker_logs
           - filter_scheduler_logs
         source: |-
-          . = parse_json(.message) ?? .message
+          . = parse_json(.message) ?? .
           .@timestamp = parse_timestamp(.timestamp, "%Y-%m-%dT%H:%M:%S%Z") ?? now()
           .check_log_id = exists(.log_id)
           if .check_log_id != true {


### PR DESCRIPTION
## Description

Fix the scheduler logs having a null message field.

## Related Issues

https://github.com/astronomer/issues/issues/5060

## Testing

I have manually tested this on my workstation. Slack thread with some of those details here: <https://astronomer.slack.com/archives/C04JELRC6J3/p1682027094695459>

## Merging

This should be merged into release-1.8. It looks like the prior changes have not been merged into release-1.7, but if we do that then these changes should also come along.