### PR TITLE
Add extraAnnotations to certgenerator

### DIFF
--- a/templates/generate-ssl.yaml
+++ b/templates/generate-ssl.yaml
@@ -62,6 +62,7 @@ metadata:
 spec:
   template:
     metadata:
+      annotations: {{- toYaml .Values.certgenerator.extraAnnotations | nindent 8 }}
       labels:
         tier: airflow
         component: pgbouncer

--- a/tests/chart_tests/test_pgbouncer_certgenerator.py
+++ b/tests/chart_tests/test_pgbouncer_certgenerator.py
@@ -52,3 +52,25 @@ class TestPgbouncersslFeature:
         assert [{"name": "gscsecret"}] == docs[3]["spec"]["template"]["spec"][
             "imagePullSecrets"
         ]
+
+    def test_pgbouncer_certgenerator_pgbouncerssl_extraannotations(self, kube_version):
+        """Test that pgbouncerssl extraAnnotations correctly inserts the annotations."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "airflow": {
+                    "pgbouncer": {
+                        "enabled": True,
+                        "sslmode": "require",
+                    }
+                },
+                "certgenerator": {
+                    "extraAnnotations": {"test": "test"},
+                },
+            },
+            show_only="templates/generate-ssl.yaml",
+        )
+        assert len(docs) == 4
+        assert docs[3]["spec"]["template"]["metadata"]["annotations"] == {
+            "test": "test"
+        }

--- a/values.yaml
+++ b/values.yaml
@@ -548,3 +548,6 @@ gitSyncRelay:
       gitlab.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFSMqzJeV9rUzU4kWitGjeR4PWSa29SPqJ1fVkhtj3Hw9xjLVXVYrU9QlYWrOLXBpQ6KWjbjTDTdDkoohFzgbEY=
       gitlab.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf
   extraContainers: []
+
+certgenerator:
+  extraAnnotations: {}


### PR DESCRIPTION
## Description

Add extraAnnotations to certgenerator. This is primarily so we can cause this workload to run on specific nodes.

## Related Issues

https://github.com/astronomer/issues/issues/5610

## Testing

Unit tests are included, but we should verify that the annotations show up in an e2e test by specifying them in the values and making sure the pod that is generated by the job has the correct annotations.

## Merging

This should be merged everywhere.
