### PR TITLE
allow customization of index time format (#400)

### DIFF
--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -106,6 +106,6 @@ data:
           password : {{ .Values.airflow.elasticsearch.connection.pass }}
       {{- end }}
         bulk:
-          index: "vector.${RELEASE:--}.%Y.%m.%d"
+          index: "vector.${RELEASE:--}.{{ .Values.loggingSidecar.indexPattern }}"
           action: create
 {{- end }}


### PR DESCRIPTION
## Description

* allow customization of index time format

* update pre-commit images

* allow configuring vector index pattern timestamp from chart

* test case to asser index template format

* Update tests/chart_tests/test_logging_sidecar.py


## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
