### PR TITLE
fix chart version and missing commits

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: airflow
   repository: https://airflow.apache.org
-  version: 1.8.0
-digest: sha256:0b82db678ce5fb5a100b315f893eb91cc9bf9fee9067074e1b16244c8b5fa295
+  version: 1.7.0
+digest: sha256:c08baee767330da39f701fd0ba4e15c739c7054fe145c0483679bf5b640d952a
 generated: "2023-03-16T18:31:10.54017-04:00"

--- a/values.yaml
+++ b/values.yaml
@@ -527,3 +527,6 @@ astronomer:
     certgenerator:
       repository: quay.io/astronomer/ap-certgenerator
       tag: 0.1.5
+
+certgenerator:
+  extraAnnotations: {}


### PR DESCRIPTION
## Description

sync airflow chart version with release and backport commits needed for 1.7

## Related Issues

https://github.com/astronomer/issues/issues/5633

## Testing

QA should able to deploy airflow chart without issues 

## Merging

cherry-pick to release-1.7
