### PR TITLE
Add certgenerator affinity

### DIFF
--- a/templates/generate-ssl.yaml
+++ b/templates/generate-ssl.yaml
@@ -68,6 +68,7 @@ spec:
         component: pgbouncer
         release: {{ .Release.Name }}
     spec:
+      affinity: {{- toYaml .Values.certgenerator.affinity | nindent 10 }}
       {{- if or .Values.airflow.registry.secretName .Values.airflow.registry.connection }}
       imagePullSecrets:
         - name: {{ template "astro.registry_secret" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -551,3 +551,4 @@ gitSyncRelay:
 
 certgenerator:
   extraAnnotations: {}
+  affinity: {}


### PR DESCRIPTION
## Description

Add ability to specify affinity for certgenerator workload.

## Related Issues

https://github.com/astronomer/issues/issues/5610

## Testing

Unit tests are included, which includes a jsonschema check for valid k8s spec, which is good. Better would be to actually check this in an e2e test by setting up the required k8s node annotations.

## Merging

This should be merged into all supported branches.