### PR TITLE
update git sync relay and airflow version

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v2 is Helm 3
 apiVersion: v2
 name: airflow
-version: 1.8.6
+version: 1.8.7
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:

--- a/values.yaml
+++ b/values.yaml
@@ -528,7 +528,7 @@ gitSyncRelay:
       tag: "3.16.5"
     gitSync:
       repository: "quay.io/astronomer/ap-git-sync-relay"
-      tag: "0.0.1"
+      tag: "0.0.2"
   repo:
     url: ~
     branch: main


### PR DESCRIPTION
## Description

git-sync relay improvements

## Related Issues

https://github.com/astronomer/issues/issues/5665

## Testing

QA should able to deploy git sync relay service without any issues 

## Merging

cherry-pick to release-0.32
