### PR TITLE
add k8s 1.27 CI support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,48 +65,48 @@ workflows:
 
             - approve-test-all
       - airflow-test:
-          name: test-1-24-13-CeleryExecutor
-          kube_version: 1.24.13
+          name: test-1-24-15-CeleryExecutor
+          kube_version: 1.24.15
           executor: CeleryExecutor
           requires:
             - build-and-release-internal
 
             - approve-test-all
       - airflow-test:
-          name: test-1-24-13-LocalExecutor
-          kube_version: 1.24.13
+          name: test-1-24-15-LocalExecutor
+          kube_version: 1.24.15
           executor: LocalExecutor
           requires:
             - build-and-release-internal
 
             - approve-test-all
       - airflow-test:
-          name: test-1-24-13-KubernetesExecutor
-          kube_version: 1.24.13
+          name: test-1-24-15-KubernetesExecutor
+          kube_version: 1.24.15
           executor: KubernetesExecutor
           requires:
             - build-and-release-internal
 
             - approve-test-all
       - airflow-test:
-          name: test-1-25-9-CeleryExecutor
-          kube_version: 1.25.9
+          name: test-1-25-11-CeleryExecutor
+          kube_version: 1.25.11
           executor: CeleryExecutor
           requires:
             - build-and-release-internal
 
             - approve-test-all
       - airflow-test:
-          name: test-1-25-9-LocalExecutor
-          kube_version: 1.25.9
+          name: test-1-25-11-LocalExecutor
+          kube_version: 1.25.11
           executor: LocalExecutor
           requires:
             - build-and-release-internal
 
             - approve-test-all
       - airflow-test:
-          name: test-1-25-9-KubernetesExecutor
-          kube_version: 1.25.9
+          name: test-1-25-11-KubernetesExecutor
+          kube_version: 1.25.11
           executor: KubernetesExecutor
           requires:
             - build-and-release-internal
@@ -119,6 +119,7 @@ workflows:
           requires:
             - build-and-release-internal
 
+            - approve-test-all
       - airflow-test:
           name: test-1-26-4-LocalExecutor
           kube_version: 1.26.4
@@ -126,9 +127,32 @@ workflows:
           requires:
             - build-and-release-internal
 
+            - approve-test-all
       - airflow-test:
           name: test-1-26-4-KubernetesExecutor
           kube_version: 1.26.4
+          executor: KubernetesExecutor
+          requires:
+            - build-and-release-internal
+
+            - approve-test-all
+      - airflow-test:
+          name: test-1-27-3-CeleryExecutor
+          kube_version: 1.27.3
+          executor: CeleryExecutor
+          requires:
+            - build-and-release-internal
+
+      - airflow-test:
+          name: test-1-27-3-LocalExecutor
+          kube_version: 1.27.3
+          executor: LocalExecutor
+          requires:
+            - build-and-release-internal
+
+      - airflow-test:
+          name: test-1-27-3-KubernetesExecutor
+          kube_version: 1.27.3
           executor: KubernetesExecutor
           requires:
             - build-and-release-internal
@@ -142,15 +166,18 @@ workflows:
             - "test-1-23-17-CeleryExecutor"
             - "test-1-23-17-LocalExecutor"
             - "test-1-23-17-KubernetesExecutor"
-            - "test-1-24-13-CeleryExecutor"
-            - "test-1-24-13-LocalExecutor"
-            - "test-1-24-13-KubernetesExecutor"
-            - "test-1-25-9-CeleryExecutor"
-            - "test-1-25-9-LocalExecutor"
-            - "test-1-25-9-KubernetesExecutor"
+            - "test-1-24-15-CeleryExecutor"
+            - "test-1-24-15-LocalExecutor"
+            - "test-1-24-15-KubernetesExecutor"
+            - "test-1-25-11-CeleryExecutor"
+            - "test-1-25-11-LocalExecutor"
+            - "test-1-25-11-KubernetesExecutor"
             - "test-1-26-4-CeleryExecutor"
             - "test-1-26-4-LocalExecutor"
             - "test-1-26-4-KubernetesExecutor"
+            - "test-1-27-3-CeleryExecutor"
+            - "test-1-27-3-LocalExecutor"
+            - "test-1-27-3-KubernetesExecutor"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,24 +113,24 @@ workflows:
 
             - approve-test-all
       - airflow-test:
-          name: test-1-26-4-CeleryExecutor
-          kube_version: 1.26.4
+          name: test-1-26-6-CeleryExecutor
+          kube_version: 1.26.6
           executor: CeleryExecutor
           requires:
             - build-and-release-internal
 
             - approve-test-all
       - airflow-test:
-          name: test-1-26-4-LocalExecutor
-          kube_version: 1.26.4
+          name: test-1-26-6-LocalExecutor
+          kube_version: 1.26.6
           executor: LocalExecutor
           requires:
             - build-and-release-internal
 
             - approve-test-all
       - airflow-test:
-          name: test-1-26-4-KubernetesExecutor
-          kube_version: 1.26.4
+          name: test-1-26-6-KubernetesExecutor
+          kube_version: 1.26.6
           executor: KubernetesExecutor
           requires:
             - build-and-release-internal
@@ -172,9 +172,9 @@ workflows:
             - "test-1-25-11-CeleryExecutor"
             - "test-1-25-11-LocalExecutor"
             - "test-1-25-11-KubernetesExecutor"
-            - "test-1-26-4-CeleryExecutor"
-            - "test-1-26-4-LocalExecutor"
-            - "test-1-26-4-KubernetesExecutor"
+            - "test-1-26-6-CeleryExecutor"
+            - "test-1-26-6-LocalExecutor"
+            - "test-1-26-6-KubernetesExecutor"
             - "test-1-27-3-CeleryExecutor"
             - "test-1-27-3-LocalExecutor"
             - "test-1-27-3-KubernetesExecutor"

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -9,7 +9,7 @@ from jinja2 import Template
 # When adding a new version, look up the most recent patch version on Dockerhub
 # https://hub.docker.com/r/kindest/node/tags
 # This should match what is in tests/__init__.py
-kube_versions = ["1.22.17", "1.23.17", "1.24.15", "1.25.11", "1.26.4", "1.27.3"]
+kube_versions = ["1.22.17", "1.23.17", "1.24.15", "1.25.11", "1.26.6", "1.27.3"]
 
 # https://circleci.com/docs/2.0/building-docker-images/#docker-version
 remote_docker_version = "20.10.18"

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -9,13 +9,7 @@ from jinja2 import Template
 # When adding a new version, look up the most recent patch version on Dockerhub
 # https://hub.docker.com/r/kindest/node/tags
 # This should match what is in tests/__init__.py
-kube_versions = [
-    "1.22.17",
-    "1.23.17",
-    "1.24.13",
-    "1.25.9",
-    "1.26.4",
-]
+kube_versions = ["1.22.17", "1.23.17", "1.24.15", "1.25.11", "1.26.4", "1.27.3"]
 
 # https://circleci.com/docs/2.0/building-docker-images/#docker-version
 remote_docker_version = "20.10.18"

--- a/bin/install-ci-tools
+++ b/bin/install-ci-tools
@@ -2,7 +2,7 @@
 set -e
 
 if [[ -z "${KIND_VERSION}" ]]; then
-  export KIND_VERSION="0.19.0"
+  export KIND_VERSION="0.20.0"
 fi
 
 if [[ -z "${HELM_VERSION}" ]]; then


### PR DESCRIPTION
## Description

Adds support for k8s 1.27 for CI testing

## Related Issues

https://github.com/astronomer/issues/issues/5702

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
