### PR TITLE
Chart version 1.9.0 with apache/airflow chart 1.11.0-astro

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: airflow
-  repository: https://airflow.apache.org
-  version: 1.8.0
-digest: sha256:0b82db678ce5fb5a100b315f893eb91cc9bf9fee9067074e1b16244c8b5fa295
-generated: "2023-03-16T18:31:10.54017-04:00"
+  repository: https://github.com/astronomer/airflow/releases/download/oss-helm-chart/1.11.0-astro
+  version: 1.11.0-astro
+digest: sha256:278bdbbf08fc34309a300e82f14530c6ad2cf7666a4674597d7033a874051bcc
+generated: "2023-07-18T15:06:11.852405-04:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v2 is Helm 3
 apiVersion: v2
 name: airflow
-version: 1.8.7
+version: 1.9.0
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:
@@ -9,5 +9,5 @@ keywords:
   - airflow
 dependencies:
   - name: airflow
-    version: 1.8.0
-    repository: https://airflow.apache.org
+    version: 1.11.0-astro
+    repository: https://github.com/astronomer/airflow/releases/download/oss-helm-chart/1.11.0-astro


### PR DESCRIPTION
## Description

- Use apache/airflow chart version 1.11.0 with cron job template change
- Bump to version 1.9.0 because of the big dependency jump (our chart version does not correlate to the OSS chart version)

## Related Issues

https://github.com/astronomer/issues/issues/5670

## Testing

We will need to be on the lookout for changes in airlfow deployments. I have looked at the change list between 1.8.0 and 1.11.0-astro and nothing big jumped out at me, but we should be diligent since we have been bitten by OSS airflow chart changes in the past.

## Merging

This should be merged into 0.33.0, probably 0.32.0 too.