### PR TITLE
update sidecar triggerer args

### DIFF
--- a/tests/chart_tests/test_triggerer.py
+++ b/tests/chart_tests/test_triggerer.py
@@ -1,0 +1,17 @@
+from tests.chart_tests.helm_template_generator import render_chart
+
+
+class TestTriggerer:
+    def test_triggerer_log_grommer_defaults(self):
+        """Test Triggerer  Log Groomer defaults."""
+        docs = render_chart(
+            values={
+                "airflow": {"airflowVersion": "2.4.3"},
+            },
+            show_only=["charts/airflow/templates/triggerer/triggerer-deployment.yaml"],
+        )
+        assert len(docs) == 1
+        assert (
+            "/usr/local/bin/clean-airflow-logs"
+            in docs[0]["spec"]["template"]["spec"]["containers"][1]["args"]
+        )

--- a/values.yaml
+++ b/values.yaml
@@ -63,7 +63,6 @@ airflow:
     logGroomerSidecar:
       args: ["/usr/local/bin/clean-airflow-logs"]
 
-
   triggerer:
     persistence:
       enabled: false

--- a/values.yaml
+++ b/values.yaml
@@ -63,6 +63,13 @@ airflow:
     logGroomerSidecar:
       args: ["/usr/local/bin/clean-airflow-logs"]
 
+
+  triggerer:
+    persistence:
+      enabled: false
+    logGroomerSidecar:
+      args: ["/usr/local/bin/clean-airflow-logs"]
+
   # Airflow webserver settings
   webserver:
     allowPodLogReading: false


### PR DESCRIPTION
## Description

upstream OSS chart added config to clean triggerer logs by adding trigger log groomer. Our custom images have different location to run script. This PR adds correct location to run the cleanup script  

## Related Issues

https://github.com/astronomer/issues/issues/5720

## Testing

QA should able to see trigger container should run without any crashes

## Merging

cherry-pick to release-1.9 branch
