### PR TITLE
update vendor packages

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -38,10 +38,10 @@ airflow:
       tag: 1.17.0-10
     pgbouncerExporter:
       repository: quay.io/astronomer/ap-pgbouncer-exporter
-      tag: 0.13.0-13
+      tag: 0.14.0-1
     gitSync:
       repository: quay.io/astronomer/ap-git-sync
-      tag: 3.6.5
+      tag: 3.6.8
   # Airflow scheduler settings
   scheduler:
     livenessProbe:


### PR DESCRIPTION
## Description

ap-pgbouncer-exporter 0.13.0-13 ->  0.14.0-1
ap-git-sync 3.6.5 -> 3.6.8

## Related Issues

gitsync image update issue -> https://github.com/astronomer/issues/issues/5689
pgbouncer-exporter issue -> https://github.com/astronomer/issues/issues/5316

## Testing

QA should able to validate pgbouncer exporter metrics

## Merging

cherry-pick to all valid releases
