### PR TITLE
update airflow chart version 1.11.1 for base 1.9

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -9,5 +9,5 @@ keywords:
   - airflow
 dependencies:
   - name: airflow
-    version: 1.11.0-astro
-    repository: https://github.com/astronomer/airflow/releases/download/oss-helm-chart/1.11.0-astro
+    version: 1.11.1-astro
+    repository: https://github.com/astronomer/airflow/releases/download/oss-helm-chart/1.11.1-astro

--- a/values.yaml
+++ b/values.yaml
@@ -69,6 +69,10 @@ airflow:
     logGroomerSidecar:
       args: ["/usr/local/bin/clean-airflow-logs"]
 
+  dagProcessor:
+    logGroomerSidecar:
+      args: ["/usr/local/bin/clean-airflow-logs"]
+
   # Airflow webserver settings
   webserver:
     allowPodLogReading: false


### PR DESCRIPTION
## Description

Includes fixes for worker pod liveliness probe failure 

## Related Issues

https://github.com/astronomer/issues/issues/5742

## Testing

QA should able to validate worker pod should work as usual without any probe failures

## Merging

cherry-pick to release 1.9 branch
