### PR TITLE
update vendor packages in airflow chart

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,8 @@
 ---
 exclude: '^(venv|\.vscode|tests/k8s_schema)' # regex
 repos:
-  - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.4
-    hooks:
-      - id: remove-tabs
-        exclude_types: [makefile, binary]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.287"
+    rev: "v0.0.291"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --ignore, E501]
@@ -53,7 +48,7 @@ repos:
     hooks:
       - id: shellcheck
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.4
+    rev: v1.4.2
     hooks:
       - id: remove-tabs
         exclude_types: [makefile, binary]

--- a/values.yaml
+++ b/values.yaml
@@ -29,19 +29,19 @@ airflow:
       tag: ~
     statsd:
       repository: quay.io/astronomer/ap-statsd-exporter
-      tag: 0.23.1
+      tag: 0.24.0
     redis:
       repository: quay.io/astronomer/ap-redis
-      tag: 6.2.7
+      tag: 6.2.13
     pgbouncer:
       repository: quay.io/astronomer/ap-pgbouncer
-      tag: 1.17.0-10
+      tag: 1.20.1
     pgbouncerExporter:
       repository: quay.io/astronomer/ap-pgbouncer-exporter
-      tag: 0.14.0-1
+      tag: 0.15.0-2
     gitSync:
       repository: quay.io/astronomer/ap-git-sync
-      tag: 3.6.8
+      tag: 3.6.9
   # Airflow scheduler settings
   scheduler:
     livenessProbe:

--- a/values.yaml
+++ b/values.yaml
@@ -525,7 +525,7 @@ astronomer:
   images:
     certgenerator:
       repository: quay.io/astronomer/ap-certgenerator
-      tag: 0.1.5
+      tag: 0.1.6
 
 gitSyncRelay:
   enabled: ~

--- a/values.yaml
+++ b/values.yaml
@@ -474,8 +474,8 @@ extraObjects: []
 # Enable nginx auth sidecar
 authSidecar:
   enabled: false
-  repository: nginxinc/nginx-unprivileged
-  tag: stable
+  repository: quay.io/astronomer/ap-auth-sidecar
+  tag: 1.25.2
   pullPolicy: IfNotPresent
   port: 8084
 
@@ -484,7 +484,7 @@ loggingSidecar:
   name: sidecar-logging-consumer
   customConfig: false
   indexPattern: "%Y.%m.%d"
-  image: quay.io/astronomer/ap-vector:0.28.2-1
+  image: quay.io/astronomer/ap-vector:0.32.2
 # Ingress configuration
 ingress:
   # Enable ingress resource
@@ -535,7 +535,7 @@ gitSyncRelay:
   images:
     gitDaemon:
       repository: "quay.io/astronomer/ap-git-daemon"
-      tag: "3.16.5"
+      tag: "3.18.3"
     gitSync:
       repository: "quay.io/astronomer/ap-git-sync-relay"
       tag: "0.0.2"


### PR DESCRIPTION
## Description

| imageName | oldTag | newTag |
|--------|--------|--------|
| ap-statsd-exporter | 0.23.1 | 0.24.0 |
| ap-redis | 6.2.7 | 6.2.13 |
| ap-pgbouncer | 1.17.0-10 | 1.20.1 |
| ap-pgbouncer-exporter | 0.14.0-1 | 0.15.0-2 |
| ap-git-sync| 3.6.8 | 3.6.9 | 
| ap-vector| 0.28.2-1 | 0.32.2|
| ap-git-daemon | 3.16.5| 3.18.3 |
| ap-certgenerator | 0.1.5 | 0.1.6|



## Related Issues

https://github.com/astronomer/issues/issues/5874
https://github.com/astronomer/issues/issues/5870
https://github.com/astronomer/issues/issues/5855

## Testing
QA should able to deploy airflow and upgrade redis without any issues

## Merging

cherry-pick to all valid release branches
