### PR TITLE
update oss chart to 1.11.0

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -9,5 +9,5 @@ keywords:
   - airflow
 dependencies:
   - name: airflow
-    version: 1.11.1-astro
-    repository: https://github.com/astronomer/airflow/releases/download/oss-helm-chart/1.11.1-astro
+    version: 1.11.0
+    repository: https://airflow.apache.org

--- a/tests/chart_tests/test_standardnaming_config.py
+++ b/tests/chart_tests/test_standardnaming_config.py
@@ -1,0 +1,48 @@
+from tests.chart_tests.helm_template_generator import render_chart
+
+
+class TestAirflowDefaults:
+    def test_use_standard_naming_defaults(self):
+        """Test useStandardNaming feature defaults."""
+        docs = render_chart(
+            values={"airflow": {"executor": "CeleryExecutor"}},
+            show_only=[
+                "charts/airflow/templates/configmaps/configmap.yaml",
+                "charts/airflow/templates/secrets/metadata-connection-secret.yaml",
+                "charts/airflow/templates/secrets/result-backend-connection-secret.yaml",
+            ],
+        )
+        # print(docs)
+        assert len(docs) == 3
+        assert docs[0]["kind"] == "ConfigMap"
+        assert docs[0]["apiVersion"] == "v1"
+        assert docs[0]["metadata"]["name"] == "release-name-airflow-config"
+        assert docs[1]["kind"] == "Secret"
+        assert docs[1]["apiVersion"] == "v1"
+        assert docs[1]["metadata"]["name"] == "release-name-airflow-metadata"
+        assert docs[2]["kind"] == "Secret"
+        assert docs[2]["apiVersion"] == "v1"
+        assert docs[2]["metadata"]["name"] == "release-name-airflow-result-backend"
+
+    def test_use_standard_naming_overrides(self):
+        """Test useStandardNaming feature overrides."""
+        docs = render_chart(
+            values={
+                "airflow": {"executor": "CeleryExecutor", "useStandardNaming": False}
+            },
+            show_only=[
+                "charts/airflow/templates/configmaps/configmap.yaml",
+                "charts/airflow/templates/secrets/metadata-connection-secret.yaml",
+                "charts/airflow/templates/secrets/result-backend-connection-secret.yaml",
+            ],
+        )
+        assert len(docs) == 3
+        assert docs[0]["kind"] == "ConfigMap"
+        assert docs[0]["apiVersion"] == "v1"
+        assert docs[0]["metadata"]["name"] == "release-name-config"
+        assert docs[1]["kind"] == "Secret"
+        assert docs[1]["apiVersion"] == "v1"
+        assert docs[1]["metadata"]["name"] == "release-name-metadata"
+        assert docs[2]["kind"] == "Secret"
+        assert docs[2]["apiVersion"] == "v1"
+        assert docs[2]["metadata"]["name"] == "release-name-result-backend"

--- a/values.yaml
+++ b/values.yaml
@@ -464,6 +464,8 @@ airflow:
         match_type: regex
         action: drop
         name: "dropped"
+  # Note:fernet-key,redis-password and broker-url secrets don't use this logic yet,
+  # as this may break existing installations due to how they get installed via pre-install hook.
   useStandardNaming: true
 
 # Enable security context constraints required for OpenShift

--- a/values.yaml
+++ b/values.yaml
@@ -464,6 +464,7 @@ airflow:
         match_type: regex
         action: drop
         name: "dropped"
+  useStandardNaming: true
 
 # Enable security context constraints required for OpenShift
 sccEnabled: false


### PR DESCRIPTION
## Description

currently our astronomer/airflow-chart is pointed to custom airflow release, this PR re-points the chart to use oss chart.
we are retaining ```useStandardNaming``` to use old format naming in our chart to avoid issues while upgrade 

## Related Issues

https://github.com/astronomer/issues/issues/5895

## Testing

QA should able to deploy, upgrade airflow without issues

## Merging

cherry-pick to valid release branches
