### PR TITLE
add sidecar logging index prefix overrides

### DIFF
--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -115,6 +115,6 @@ data:
           password : {{ .Values.airflow.elasticsearch.connection.pass }}
       {{- end }}
         bulk:
-          index: "vector.${RELEASE:--}.{{ .Values.loggingSidecar.indexPattern }}"
+          index: "{{ .Values.loggingSidecar.indexNamePrefix }}.${RELEASE:--}.{{ .Values.loggingSidecar.indexPattern }}"
           action: create
 {{- end }}

--- a/tests/chart_tests/test_logging_sidecar.py
+++ b/tests/chart_tests/test_logging_sidecar.py
@@ -106,6 +106,6 @@ class TestLoggingSidecar:
         assert len(docs) == 1
         assert (vc := yaml.safe_load(docs[0]["data"]["vector-config.yaml"]))
         assert vc["sinks"]["out"]["bulk"] == {
-            "index": "fluentd.${RELEASE:--}.%Y.%m",
+            "index": "fluentd.${RELEASE:--}.%Y.%m.%d",
             "action": "create",
         }

--- a/tests/chart_tests/test_logging_sidecar.py
+++ b/tests/chart_tests/test_logging_sidecar.py
@@ -35,6 +35,7 @@ class TestLoggingSidecar:
             "user": "testuser",
             "password": "testpass",
         }
+        assert vc["sinks"]["out"]["bulk"]["index"] == "vector.${RELEASE:--}.%Y.%m.%d"
 
     def test_logging_sidecar_config_disabled(self, kube_version):
         """Test logging sidecar config with flag disabled"""
@@ -83,5 +84,28 @@ class TestLoggingSidecar:
         assert (vc := yaml.safe_load(docs[0]["data"]["vector-config.yaml"]))
         assert vc["sinks"]["out"]["bulk"] == {
             "index": "vector.${RELEASE:--}.%Y.%m",
+            "action": "create",
+        }
+
+    def test_logging_sidecar_index_prefix_overrides(self, kube_version):
+        """Test logging sidecar config with custom index prefix"""
+        test_custom_sidecar_config = textwrap.dedent(
+            """
+        loggingSidecar:
+          enabled: true
+          name: sidecar-logging-consumer
+          indexNamePrefix: "fluentd"
+            """
+        )
+        values = yaml.safe_load(test_custom_sidecar_config)
+        docs = render_chart(
+            kube_version=kube_version,
+            values=values,
+            show_only="templates/logging-sidecar-configmap.yaml",
+        )
+        assert len(docs) == 1
+        assert (vc := yaml.safe_load(docs[0]["data"]["vector-config.yaml"]))
+        assert vc["sinks"]["out"]["bulk"] == {
+            "index": "fluend.${RELEASE:--}.%Y.%m",
             "action": "create",
         }

--- a/tests/chart_tests/test_logging_sidecar.py
+++ b/tests/chart_tests/test_logging_sidecar.py
@@ -106,6 +106,6 @@ class TestLoggingSidecar:
         assert len(docs) == 1
         assert (vc := yaml.safe_load(docs[0]["data"]["vector-config.yaml"]))
         assert vc["sinks"]["out"]["bulk"] == {
-            "index": "fluend.${RELEASE:--}.%Y.%m",
+            "index": "fluentd.${RELEASE:--}.%Y.%m",
             "action": "create",
         }

--- a/values.yaml
+++ b/values.yaml
@@ -484,6 +484,7 @@ loggingSidecar:
   name: sidecar-logging-consumer
   customConfig: false
   indexPattern: "%Y.%m.%d"
+  indexNamePrefix: vector
   image: quay.io/astronomer/ap-vector:0.32.2
 # Ingress configuration
 ingress:


### PR DESCRIPTION
## Description

This PR adds supports to override default index prefix for sidecar logging. Allowing customisation for users to choose their own index prefix.

Note: This does not migrate existing index automatically users should take responsible to migrate their old index data to newer shifted ones.

## Related Issues

https://github.com/astronomer/issues/issues/5947

## Testing

QA should able to pass custom indexPrefix for sidecar logging

## Merging

to all valid releases
