### PR TITLE
update vendor packages to airflow chart

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -35,10 +35,10 @@ airflow:
       tag: 6.2.13
     pgbouncer:
       repository: quay.io/astronomer/ap-pgbouncer
-      tag: 1.20.1
+      tag: 1.20.1-2
     pgbouncerExporter:
       repository: quay.io/astronomer/ap-pgbouncer-exporter
-      tag: 0.15.0-2
+      tag: 0.15.0-4
     gitSync:
       repository: quay.io/astronomer/ap-git-sync
       tag: 3.6.9
@@ -475,7 +475,7 @@ extraObjects: []
 authSidecar:
   enabled: false
   repository: quay.io/astronomer/ap-auth-sidecar
-  tag: 1.25.2
+  tag: 1.25.2-2
   pullPolicy: IfNotPresent
   port: 8084
 
@@ -485,7 +485,7 @@ loggingSidecar:
   customConfig: false
   indexPattern: "%Y.%m.%d"
   indexNamePrefix: vector
-  image: quay.io/astronomer/ap-vector:0.32.2
+  image: quay.io/astronomer/ap-vector:0.32.2-1
 # Ingress configuration
 ingress:
   # Enable ingress resource

--- a/values.yaml
+++ b/values.yaml
@@ -485,7 +485,7 @@ loggingSidecar:
   customConfig: false
   indexPattern: "%Y.%m.%d"
   indexNamePrefix: vector
-  image: quay.io/astronomer/ap-vector:0.32.2-1
+  image: quay.io/astronomer/ap-vector:0.32.2-2
 # Ingress configuration
 ingress:
   # Enable ingress resource


### PR DESCRIPTION
## Description

| imageName | oldTag | newTag |
|--------|--------|--------|
| ap-pgbouncer | 1.20.1 | 1.20.1-2 |
| ap-pgbouncer-exporter | 0.15.0-2 | 0.15.0-4 |
| ap-auth-sidecar | 1.25.2 | 1.25.2-2 | 
| ap-vector | 0.32.2 | 0.32.2-2|
## Related Issues

https://github.com/astronomer/issues/issues/5870
https://github.com/astronomer/issues/issues/5988
## Testing

QA should validate pgbouncer and exporter services should function as expected

## Merging

cherry-pick to all valid releases
