### PR TITLE
Add hook that runs 'helm dependency update' when Chart.yaml has changed.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,6 +67,12 @@ repos:
         files: "config.yml$|config.yml.j2|generate_circleci_config.py$"
         entry: .circleci/generate_circleci_config.py
         additional_dependencies: ["jinja2"]
+      - id: helm-dep-update
+        name: Ensure helm lock is up to date with requirements in Chart.yaml
+        files: "Chart.yaml"
+        language: system
+        entry: helm dep update
+        pass_filenames: false
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v3.0.3"
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,11 +67,11 @@ repos:
         files: "config.yml$|config.yml.j2|generate_circleci_config.py$"
         entry: .circleci/generate_circleci_config.py
         additional_dependencies: ["jinja2"]
-      - id: helm-dep-update
+      - id: helm-dependency-update
         name: Ensure helm lock is up to date with requirements in Chart.yaml
         files: "Chart.yaml"
         language: system
-        entry: helm dep update
+        entry: helm dependency update
         pass_filenames: false
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v3.0.3"

--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: airflow
-  repository: https://github.com/astronomer/airflow/releases/download/oss-helm-chart/1.11.0-astro
-  version: 1.11.0-astro
-digest: sha256:278bdbbf08fc34309a300e82f14530c6ad2cf7666a4674597d7033a874051bcc
-generated: "2023-07-18T15:06:11.852405-04:00"
+  repository: https://github.com/astronomer/airflow/releases/download/oss-helm-chart/1.11.1-astro
+  version: 1.11.1-astro
+digest: sha256:6d7c55a8e643d3e50723187c70177ec8baa8610a4b27f430a28805afaaf7a05f
+generated: "2023-12-06T11:30:00.49718-05:00"


### PR DESCRIPTION
## Description

Add pre-commit hook that runs `helm dependency update` when Chart.yaml has changed.

## Related Issues

N/A

## Testing

No testing is needed. This is just a pre-commit change, and a lockfile change created by the new pre-commit hook. These changes don't alter anything that runs in customer environments. The only changes would be when we package the chart, and even that would be a no-op since the packaging scripts already run `helm dependency update`

## Merging

Merge everywhere.