### PR TITLE
Move codeowners to an org team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @danielhoherd @aliotta @jedcunningham @pgvishnuram
+* @astronomer/maintainers-airflow-chart


### PR DESCRIPTION
## Description

Move the CODEOWNERS folks out of the file and into a GH org team.

## Related Issues

N/A

## Testing

N/A, this is just repo maintenance

## Merging

Only the main branch is used for the CODEOWNERS feature. We might as well merge everywhere though.