### PR TITLE
initial authsidecar config for dag-server

### DIFF
--- a/templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml
+++ b/templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml
@@ -1,0 +1,74 @@
+######################################
+## WebServer auth sidecar ConfigMap ##
+######################################
+{{- if and .Values.dagDeploy.enabled .Values.authSidecar.enabled  }}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ .Release.Name }}-dag-server-nginx-conf
+  labels:
+    tier: airflow
+    component: dag-server
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+data:
+  nginx.conf: |
+    pid /tmp/nginx.pid;
+    worker_processes auto;
+    events {
+      multi_accept        on;
+      worker_connections  16384;
+      use                 epoll;
+      }
+    http {
+      upstream astro-webserver {
+        server localhost:{{ .Values.dagDeploy.ports.dagServerHttp }} ;
+      }
+      server {
+        server_name {{ .Release.Name }}.{{ .Values.ingress.baseDomain }} ;
+        listen {{ .Values.authSidecar.port }}  ;
+        # Disable Nginx Server version
+        server_tokens off;
+        location ^~ /api/ {
+          if ($host = 'deployments.{{ .Values.ingress.baseDomain }}' ) {
+            return 404;
+            }
+            proxy_pass https://deployments.{{ .Values.ingress.baseDomain }}/{{ .Release.Name }}/airflow/$request_uri;
+          }
+        location  = /auth {
+{{ include "default_nginx_settings" . | indent 8  }}
+          proxy_set_header            Host                    houston.{{ .Values.ingress.baseDomain }};
+          proxy_pass  https://houston.{{ .Values.ingress.baseDomain }}/v1/authorization;
+        }
+
+        location @401_auth_error {
+          internal;
+          add_header Set-Cookie $auth_cookie;
+          return 302 https://app.{{ .Values.ingress.baseDomain }}/login?rd=https://$http_host$request_uri;
+        }
+
+        location / {
+{{ include "default_nginx_settings_location" . | indent 8  }}
+
+
+          #proxy_set_header X-Original-URI        $request_uri;
+          if ($host = '{{ .Values.platform.release }}-airflow.{{ .Values.ingress.baseDomain }}' ) {
+            return 308 https://deployments.{{ .Values.ingress.baseDomain }}/{{ .Release.Name }}/airflow/$request_uri;
+          }
+
+          # Custom headers to proxied server
+          proxy_set_header  Host  deployments.{{ .Values.ingress.baseDomain}};
+          #proxy_set_header  X-Forwarded-Proto https;
+          proxy_cookie_path                       off;
+          proxy_pass http://astro-dag-server;
+
+        }
+
+        location /healthz {
+          return 200;
+        }
+
+      }
+    }
+{{- end }}

--- a/templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml
+++ b/templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml
@@ -1,6 +1,6 @@
-######################################
-## WebServer auth sidecar ConfigMap ##
-######################################
+#######################################
+## Dag Server auth sidecar ConfigMap ##
+#######################################
 {{- if and .Values.dagDeploy.enabled .Values.authSidecar.enabled  }}
 kind: ConfigMap
 apiVersion: v1
@@ -42,7 +42,7 @@ data:
           return 302 https://app.{{ .Values.ingress.baseDomain }}/login?rd=https://$http_host$request_uri;
         }
 
-        location ~ ^/{{ .Release.Name }}/dags/(upload|download) { {
+        location ~ ^/{{ .Release.Name }}/dags/(upload|download) {
 {{ include "default_nginx_settings_location" . | indent 8  }}
 
 

--- a/templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml
+++ b/templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml
@@ -22,7 +22,7 @@ data:
       use                 epoll;
       }
     http {
-      upstream astro-webserver {
+      upstream astro-dag-server {
         server localhost:{{ .Values.dagDeploy.ports.dagServerHttp }} ;
       }
       server {
@@ -30,11 +30,11 @@ data:
         listen {{ .Values.authSidecar.port }}  ;
         # Disable Nginx Server version
         server_tokens off;
-        location ^~ /api/ {
+        location ^~ /dags/(upload|download)(/.*)? {
           if ($host = 'deployments.{{ .Values.ingress.baseDomain }}' ) {
             return 404;
             }
-            proxy_pass https://deployments.{{ .Values.ingress.baseDomain }}/{{ .Release.Name }}/airflow/$request_uri;
+            proxy_pass https://deployments.{{ .Values.ingress.baseDomain }}/{{ .Release.Name }}/dags/$request_uri;
           }
         location  = /auth {
 {{ include "default_nginx_settings" . | indent 8  }}
@@ -54,7 +54,7 @@ data:
 
           #proxy_set_header X-Original-URI        $request_uri;
           if ($host = '{{ .Values.platform.release }}-airflow.{{ .Values.ingress.baseDomain }}' ) {
-            return 308 https://deployments.{{ .Values.ingress.baseDomain }}/{{ .Release.Name }}/airflow/$request_uri;
+            return 308 https://deployments.{{ .Values.ingress.baseDomain }}/{{ .Release.Name }}/dags/$request_uri;
           }
 
           # Custom headers to proxied server

--- a/templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml
+++ b/templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml
@@ -30,12 +30,6 @@ data:
         listen {{ .Values.authSidecar.port }}  ;
         # Disable Nginx Server version
         server_tokens off;
-        location ^~ /dags/(upload|download)(/.*)? {
-          if ($host = 'deployments.{{ .Values.ingress.baseDomain }}' ) {
-            return 404;
-            }
-            proxy_pass https://deployments.{{ .Values.ingress.baseDomain }}/{{ .Release.Name }}/dags/$request_uri;
-          }
         location  = /auth {
 {{ include "default_nginx_settings" . | indent 8  }}
           proxy_set_header            Host                    houston.{{ .Values.ingress.baseDomain }};
@@ -48,7 +42,7 @@ data:
           return 302 https://app.{{ .Values.ingress.baseDomain }}/login?rd=https://$http_host$request_uri;
         }
 
-        location / {
+        location ~ ^/{{ .Release.Name }}/dags/(upload|download) { {
 {{ include "default_nginx_settings_location" . | indent 8  }}
 
 
@@ -61,6 +55,7 @@ data:
           proxy_set_header  Host  deployments.{{ .Values.ingress.baseDomain}};
           #proxy_set_header  X-Forwarded-Proto https;
           proxy_cookie_path                       off;
+          rewrite ^/{{ .Release.Name }}/dags(.*)$ $1 break;
           proxy_pass http://astro-dag-server;
 
         }

--- a/templates/dag-deploy/dag-server-service.yaml
+++ b/templates/dag-deploy/dag-server-service.yaml
@@ -14,10 +14,17 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   ports:
+{{- if .Values.authSidecar.enabled }}
+    - name: auth-proxy
+      port: {{ .Values.authSidecar.port }}
+      protocol: TCP
+      targetPort: {{ .Values.authSidecar.port }}
+{{- else }}
     - name: http
       port: {{ .Values.dagDeploy.ports.dagServerHttp }}
       protocol: TCP
       targetPort: 8000
+{{- end }}
   selector:
     component: dag-server
     tier: airflow

--- a/templates/dag-deploy/dag-server-service.yaml
+++ b/templates/dag-deploy/dag-server-service.yaml
@@ -14,16 +14,15 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   ports:
+    - name: http
+      port: {{ .Values.dagDeploy.ports.dagServerHttp }}
+      protocol: TCP
+      targetPort: 8000
 {{- if .Values.authSidecar.enabled }}
     - name: auth-proxy
       port: {{ .Values.authSidecar.port }}
       protocol: TCP
       targetPort: {{ .Values.authSidecar.port }}
-{{- else }}
-    - name: http
-      port: {{ .Values.dagDeploy.ports.dagServerHttp }}
-      protocol: TCP
-      targetPort: 8000
 {{- end }}
   selector:
     component: dag-server

--- a/templates/dag-deploy/dag-server-statefulset.yaml
+++ b/templates/dag-deploy/dag-server-statefulset.yaml
@@ -113,7 +113,7 @@ spec:
       volumes:
       - name: nginx-sidecar-conf
         configMap:
-          name: {{ .Release.Name }}-nginx-conf
+          name: {{ .Release.Name }}-dag-server-nginx-conf
 {{- end }}
   volumeClaimTemplates:
   - metadata:

--- a/templates/dag-deploy/dag-server-statefulset.yaml
+++ b/templates/dag-deploy/dag-server-statefulset.yaml
@@ -76,8 +76,44 @@ spec:
           - name: data
             mountPath: /data
             readOnly: false
+{{- if .Values.authSidecar.enabled }}
+        - name: auth-proxy
+          image: "{{ .Values.authSidecar.repository }}:{{ .Values.authSidecar.tag }}"
+          imagePullPolicy: {{ .Values.authSidecar.pullPolicy }}
+          {{- if .Values.authSidecar.resources }}
+          resources: {{- toYaml .Values.authSidecar.resources | nindent 12 }}
+          {{- end }}
+          ports:
+          - containerPort: {{ .Values.authSidecar.port }}
+            name: auth-proxy
+            protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.authSidecar.port }}
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.authSidecar.port }}
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          volumeMounts:
+          - mountPath: /etc/nginx/nginx.conf
+            name: nginx-sidecar-conf
+            subPath: nginx.conf
+{{- end }}
 {{- if .Values.dagDeploy.extraContainers }}
 {{- toYaml .Values.dagDeploy.extraContainers | nindent 8 }}
+{{- end }}
+{{- if .Values.authSidecar.enabled }}
+      volumes:
+      - name: nginx-sidecar-conf
+        configMap:
+          name: {{ .Release.Name }}-nginx-conf
 {{- end }}
   volumeClaimTemplates:
   - metadata:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -190,7 +190,11 @@ spec:
     - host: {{- include "deployments_subdomain" . | indent 1 }}
       http:
         paths:
+          {{- if .Values.authSidecar.enabled  }}
+          - path: /{{ .Release.Name }}/dags
+          {{- else }}
           - path: /{{ .Release.Name }}/dags/(upload|download)(/.*)?
+          {{- end }}
             pathType: Prefix
             backend:
               service:

--- a/tests/chart_tests/test_auth_sidecar.py
+++ b/tests/chart_tests/test_auth_sidecar.py
@@ -8,17 +8,15 @@ from . import get_containers_by_name
 
 @pytest.mark.parametrize("kube_version", supported_k8s_versions)
 class TestAuthSidecar:
+    show_only = [
+        "templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml",
+        "templates/flower/flower-auth-sidecar-configmap.yaml",
+        "templates/webserver/webserver-auth-sidecar-configmap.yaml",
+    ]
+
     def test_auth_sidecar_config_defaults(self, kube_version):
         """Test logging sidecar config with defaults"""
-        docs = render_chart(
-            kube_version=kube_version,
-            values={},
-            show_only=[
-                "templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml",
-                "templates/flower/flower-auth-sidecar-configmap.yaml",
-                "templates/webserver/webserver-auth-sidecar-configmap.yaml",
-            ],
-        )
+        docs = render_chart(kube_version=kube_version, values={}, show_only=self.show_only)
         assert len(docs) == 0
 
     def test_auth_sidecar_config_enabled_with_celeryexecutor(self, kube_version):

--- a/tests/chart_tests/test_auth_sidecar.py
+++ b/tests/chart_tests/test_auth_sidecar.py
@@ -1,0 +1,34 @@
+
+import pytest
+import yaml
+
+from tests.chart_tests.helm_template_generator import render_chart
+
+from .. import supported_k8s_versions
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+class TestAuthSidecar:
+    def test_auth_sidecar_config_defaults(self, kube_version):
+        """Test logging sidecar config with defaults"""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={},
+            show_only=["templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml",
+                       "templates/flower/flower-auth-sidecar-configmap.yaml",
+                       "templates/webserver/webserver-auth-sidecar-configmap.yaml"],
+        )
+        assert len(docs) == 0
+        
+    def test_auth_sidecar_config_enabled(self, kube_version):
+        """Test logging sidecar config with defaults"""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"authSidecar": {"enabled": True},
+                    "dagDeploy": {"enabled": True}},
+            show_only=["templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml",
+                       "templates/flower/flower-auth-sidecar-configmap.yaml",
+                       "templates/webserver/webserver-auth-sidecar-configmap.yaml",
+                       "templates/dag-deploy/dag-server-statefulset.yaml"],
+        )
+        assert len(docs) == 3

--- a/tests/chart_tests/test_auth_sidecar.py
+++ b/tests/chart_tests/test_auth_sidecar.py
@@ -3,6 +3,7 @@ import pytest
 from tests.chart_tests.helm_template_generator import render_chart
 
 from .. import supported_k8s_versions
+from . import get_containers_by_name
 
 
 @pytest.mark.parametrize("kube_version", supported_k8s_versions)
@@ -29,7 +30,49 @@ class TestAuthSidecar:
                 "templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml",
                 "templates/flower/flower-auth-sidecar-configmap.yaml",
                 "templates/webserver/webserver-auth-sidecar-configmap.yaml",
-                "templates/dag-deploy/dag-server-statefulset.yaml",
             ],
         )
         assert len(docs) == 3
+
+    def test_auth_sidecar_config_with_dag_server_enabled(self, kube_version):
+        """Test logging sidecar config with defaults"""
+        resources = {
+            "requests": {"cpu": 99.9, "memory": "777Mi"},
+            "limits": {"cpu": 66.6, "memory": "888Mi"},
+        }
+        volumeMounts = {
+            "mountPath": "/etc/nginx/nginx.conf",
+            "name": "nginx-sidecar-conf",
+            "subPath": "nginx.conf",
+        }
+
+        authSidecarServicePorts = {
+            "name": "auth-proxy",
+            "port": 8084,
+            "protocol": "TCP",
+            "targetPort": 8084,
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "authSidecar": {"enabled": True, "resources": resources},
+                "dagDeploy": {"enabled": True},
+            },
+            show_only=[
+                "templates/dag-deploy/dag-server-statefulset.yaml",
+                "templates/dag-deploy/dag-server-service.yaml",
+            ],
+        )
+
+        assert len(docs) == 2
+        assert docs[0]["kind"] == "StatefulSet"
+        assert docs[0]["apiVersion"] == "apps/v1"
+        assert docs[0]["metadata"]["name"] == "release-name-dag-server"
+        c_by_name = get_containers_by_name(docs[0])
+        assert c_by_name["auth-proxy"]["resources"] == resources
+        assert volumeMounts in c_by_name["auth-proxy"]["volumeMounts"]
+
+        assert docs[1]["kind"] == "Service"
+        assert docs[1]["apiVersion"] == "v1"
+        assert docs[1]["metadata"]["name"] == "release-name-dag-server"
+        assert authSidecarServicePorts in docs[1]["spec"]["ports"]

--- a/tests/chart_tests/test_auth_sidecar.py
+++ b/tests/chart_tests/test_auth_sidecar.py
@@ -57,6 +57,7 @@ class TestAuthSidecar:
             "requests": {"cpu": 99.9, "memory": "777Mi"},
             "limits": {"cpu": 66.6, "memory": "888Mi"},
         }
+
         volumeMounts = {
             "mountPath": "/etc/nginx/nginx.conf",
             "name": "nginx-sidecar-conf",

--- a/tests/chart_tests/test_auth_sidecar.py
+++ b/tests/chart_tests/test_auth_sidecar.py
@@ -1,6 +1,4 @@
-
 import pytest
-import yaml
 
 from tests.chart_tests.helm_template_generator import render_chart
 
@@ -14,21 +12,24 @@ class TestAuthSidecar:
         docs = render_chart(
             kube_version=kube_version,
             values={},
-            show_only=["templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml",
-                       "templates/flower/flower-auth-sidecar-configmap.yaml",
-                       "templates/webserver/webserver-auth-sidecar-configmap.yaml"],
+            show_only=[
+                "templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml",
+                "templates/flower/flower-auth-sidecar-configmap.yaml",
+                "templates/webserver/webserver-auth-sidecar-configmap.yaml",
+            ],
         )
         assert len(docs) == 0
-        
+
     def test_auth_sidecar_config_enabled(self, kube_version):
         """Test logging sidecar config with defaults"""
         docs = render_chart(
             kube_version=kube_version,
-            values={"authSidecar": {"enabled": True},
-                    "dagDeploy": {"enabled": True}},
-            show_only=["templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml",
-                       "templates/flower/flower-auth-sidecar-configmap.yaml",
-                       "templates/webserver/webserver-auth-sidecar-configmap.yaml",
-                       "templates/dag-deploy/dag-server-statefulset.yaml"],
+            values={"authSidecar": {"enabled": True}, "dagDeploy": {"enabled": True}},
+            show_only=[
+                "templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml",
+                "templates/flower/flower-auth-sidecar-configmap.yaml",
+                "templates/webserver/webserver-auth-sidecar-configmap.yaml",
+                "templates/dag-deploy/dag-server-statefulset.yaml",
+            ],
         )
         assert len(docs) == 3

--- a/tests/chart_tests/test_auth_sidecar.py
+++ b/tests/chart_tests/test_auth_sidecar.py
@@ -16,7 +16,9 @@ class TestAuthSidecar:
 
     def test_auth_sidecar_config_defaults(self, kube_version):
         """Test logging sidecar config with defaults"""
-        docs = render_chart(kube_version=kube_version, values={}, show_only=self.show_only)
+        docs = render_chart(
+            kube_version=kube_version, values={}, show_only=self.show_only
+        )
         assert len(docs) == 0
 
     def test_auth_sidecar_config_enabled_with_celeryexecutor(self, kube_version):

--- a/tests/chart_tests/test_auth_sidecar.py
+++ b/tests/chart_tests/test_auth_sidecar.py
@@ -69,6 +69,7 @@ class TestAuthSidecar:
             "protocol": "TCP",
             "targetPort": 8084,
         }
+
         docs = render_chart(
             kube_version=kube_version,
             values={

--- a/tests/chart_tests/test_auth_sidecar.py
+++ b/tests/chart_tests/test_auth_sidecar.py
@@ -21,18 +21,35 @@ class TestAuthSidecar:
         )
         assert len(docs) == 0
 
-    def test_auth_sidecar_config_enabled(self, kube_version):
+    def test_auth_sidecar_config_enabled_with_celeryexecutor(self, kube_version):
+        """Test logging sidecar config with defaults"""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "authSidecar": {"enabled": True},
+                "dagDeploy": {"enabled": True},
+                "airflow": {"executor": "CeleryExecutor"},
+            },
+            show_only=[
+                "templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml",
+                "templates/webserver/webserver-auth-sidecar-configmap.yaml",
+                "templates/flower/flower-auth-sidecar-configmap.yaml",
+            ],
+        )
+        assert len(docs) == 3
+
+    def test_auth_sidecar_config_enabled_with_kubernetesexecutor(self, kube_version):
         """Test logging sidecar config with defaults"""
         docs = render_chart(
             kube_version=kube_version,
             values={"authSidecar": {"enabled": True}, "dagDeploy": {"enabled": True}},
             show_only=[
                 "templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml",
-                "templates/flower/flower-auth-sidecar-configmap.yaml",
                 "templates/webserver/webserver-auth-sidecar-configmap.yaml",
+                "templates/flower/flower-auth-sidecar-configmap.yaml",
             ],
         )
-        assert len(docs) == 3
+        assert len(docs) == 2
 
     def test_auth_sidecar_config_with_dag_server_enabled(self, kube_version):
         """Test logging sidecar config with defaults"""


### PR DESCRIPTION
## Description

This PR adds support for authsidecar configuration in airflow chart in order to support external ingress controller

## Related Issues

https://github.com/astronomer/issues/issues/6123

## Testing

QA should able to access when external ingress controller is used

## Merging

release-0.34
