### PR TITLE
unittest in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,6 +234,7 @@ jobs:
   unittest-charts:
     docker:
       - image: quay.io/astronomer/ci-helm-release:2024-02
+    parallelism: 8
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
@@ -242,6 +243,8 @@ jobs:
           name: unittest the Airflow chart
           command: |
             mkdir test-results
+            TEST_FILES=$(circleci tests glob "tests/chart_tests/test_*.py" | circleci tests split --split-by=timings)
+            venv/bin/python -m pytest -n auto -v --junitxml=test-results/junit.xml $TEST_FILES
             make unittest-chart
       - store_test_results:
           path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,7 +247,6 @@ jobs:
             make charts
             TEST_FILES=$(circleci tests glob "tests/chart_tests/test_*.py" | circleci tests split --split-by=timings)
             venv/bin/python -m pytest -n auto -v --junitxml=test-results/junit.xml $TEST_FILES
-            make unittest-chart
       - store_test_results:
           path: test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,6 +244,7 @@ jobs:
           command: |
             mkdir test-results
             make venv
+            make charts
             TEST_FILES=$(circleci tests glob "tests/chart_tests/test_*.py" | circleci tests split --split-by=timings)
             venv/bin/python -m pytest -n auto -v --junitxml=test-results/junit.xml $TEST_FILES
             make unittest-chart

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,6 +243,7 @@ jobs:
           name: unittest the Airflow chart
           command: |
             mkdir test-results
+            make venv
             TEST_FILES=$(circleci tests glob "tests/chart_tests/test_*.py" | circleci tests split --split-by=timings)
             venv/bin/python -m pytest -n auto -v --junitxml=test-results/junit.xml $TEST_FILES
             make unittest-chart

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -107,7 +107,6 @@ jobs:
             make charts
             TEST_FILES=$(circleci tests glob "tests/chart_tests/test_*.py" | circleci tests split --split-by=timings)
             venv/bin/python -m pytest -n auto -v --junitxml=test-results/junit.xml $TEST_FILES
-            make unittest-chart
       - store_test_results:
           path: test-results
 

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -103,6 +103,7 @@ jobs:
           name: unittest the Airflow chart
           command: |
             mkdir test-results
+            make venv
             TEST_FILES=$(circleci tests glob "tests/chart_tests/test_*.py" | circleci tests split --split-by=timings)
             venv/bin/python -m pytest -n auto -v --junitxml=test-results/junit.xml $TEST_FILES
             make unittest-chart

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -104,6 +104,7 @@ jobs:
           command: |
             mkdir test-results
             make venv
+            make charts
             TEST_FILES=$(circleci tests glob "tests/chart_tests/test_*.py" | circleci tests split --split-by=timings)
             venv/bin/python -m pytest -n auto -v --junitxml=test-results/junit.xml $TEST_FILES
             make unittest-chart

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -94,6 +94,7 @@ jobs:
   unittest-charts:
     docker:
       - image: quay.io/astronomer/ci-helm-release:{{ ci_runner_version }}
+    parallelism: 8
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
@@ -102,6 +103,8 @@ jobs:
           name: unittest the Airflow chart
           command: |
             mkdir test-results
+            TEST_FILES=$(circleci tests glob "tests/chart_tests/test_*.py" | circleci tests split --split-by=timings)
+            venv/bin/python -m pytest -n auto -v --junitxml=test-results/junit.xml $TEST_FILES
             make unittest-chart
       - store_test_results:
           path: test-results


### PR DESCRIPTION
## Description

This adds parallel unit testing in CircleCI, which is something we do in astronomer/astronomer. The unittest step takes 18m20s on average as it is. <https://app.circleci.com/insights/github/astronomer/airflow-chart/workflows/install-airflow-chart/jobs?branch=master&reporting-window=last-90-days> This PR cuts that 18m20s down to about 4m20s <https://app.circleci.com/pipelines/github/astronomer/airflow-chart/2126/workflows/ff7ab1a7-3067-4a78-9ecf-e4ab7d7701d3/jobs/23388>

## Related Issues

- https://github.com/astronomer/issues/issues/5199

## Testing

No QA testing is needed. These changes are only CircleCI related.

## Merging

Merge everywhere.