### PR TITLE
Use 'rolebinding' and forbid 'role-binding'

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,12 @@
 exclude: '^(venv|\.vscode|tests/k8s_schema)' # regex
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.3.7"
+    rev: "v0.4.4"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --ignore, E501]
   - repo: https://github.com/psf/black
-    rev: 24.4.0
+    rev: 24.4.2
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -59,6 +59,12 @@ repos:
       - id: remove-unicode-zero-width-space
   - repo: local
     hooks:
+      - id: ensure-rolebinding-without-dash
+        language: pygrep
+        name: "Ensure we're using 'rolebinding' and not 'role-binding'"
+        entry: "role-binding"
+        pass_filenames: true
+        exclude: "^.pre-commit-config.yaml$"
       - id: circle-config-yaml
         name: Ensure .circleci/config.yml is up to date
         language: python

--- a/templates/dag-deploy/dag-deploy-rolebinding.yaml
+++ b/templates/dag-deploy/dag-deploy-rolebinding.yaml
@@ -1,12 +1,12 @@
 #################################
-# dag-deploy-role-binding
+# dag-deploy-rolebinding
 #################################
 {{- if .Values.dagDeploy.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: "{{ .Release.Namespace }}"
-  name: {{ .Release.Name }}-dag-server-role-binding
+  name: {{ .Release.Name }}-dag-server-rolebinding
 subjects:
 - kind: ServiceAccount
   name: {{ .Release.Name }}-dag-server

--- a/templates/generate-ssl.yaml
+++ b/templates/generate-ssl.yaml
@@ -21,7 +21,7 @@ metadata:
   annotations:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-weight": "-2"
-  name: {{ .Release.Name }}-create-secret-role-binding
+  name: {{ .Release.Name }}-create-secret-rolebinding
 subjects:
 - kind: ServiceAccount
   name: {{ .Release.Name }}-pgbouncer-ssl

--- a/tests/chart/test_dag_deploy_rolebinding.py
+++ b/tests/chart/test_dag_deploy_rolebinding.py
@@ -27,4 +27,4 @@ class TestDagServerRoleBinding:
         doc = docs[0]
         assert doc["kind"] == "RoleBinding"
         assert doc["apiVersion"] == "rbac.authorization.k8s.io/v1"
-        assert doc["metadata"]["name"] == "release-name-dag-server-role-binding"
+        assert doc["metadata"]["name"] == "release-name-dag-server-rolebinding"


### PR DESCRIPTION
## Description

- Update pre-commit hooks
- Add a pygrep pre-commit hook that forbids the string `role-binding`
- `s/role-binding/rolebinding/g/`

## Related Issues

https://github.com/astronomer/issues/issues/6362

## Testing

Tests were modified. It's possible this will break stuff though, so we should look out for anywhere that complains about `role-binding`.

## Merging

We should merge this everywhere if possible.