### PR TITLE
6233 dag rollback env

### DIFF
--- a/templates/dag-deploy/dag-server-statefulset.yaml
+++ b/templates/dag-deploy/dag-server-statefulset.yaml
@@ -54,7 +54,7 @@ spec:
             {{- toYaml .Values.dagDeploy.resources | nindent 12 }}
           env:
           - name: HOUSTON_SERVICE_ENDPOINT
-            value: "https://{{ .Values.platform.release }}-houston.{{ .Values.platform.namespace }}.svc.cluster.local.:8871/v1/"
+            value: "http://{{ .Values.platform.release }}-houston.{{ .Values.platform.namespace }}.svc.cluster.local.:8871/v1/"
 {{- if .Values.dagDeploy.extraEnv }}
 {{ toYaml .Values.dagDeploy.extraEnv | indent 10 }}
 {{- end }}

--- a/templates/dag-deploy/dag-server-statefulset.yaml
+++ b/templates/dag-deploy/dag-server-statefulset.yaml
@@ -47,6 +47,9 @@ spec:
           image: "{{ .Values.dagDeploy.images.dagServer.repository }}:{{ .Values.dagDeploy.images.dagServer.tag }}"
           imagePullPolicy: {{ .Values.dagDeploy.images.dagServer.pullPolicy }}
           command: ["sanic", "dag_deploy.server.app", "-H", "0.0.0.0"]
+          env:
+          - name: HOUSTON_SERVICE_ENDPOINT
+            value: "https://{{ .Values.platform.release }}-houston.{{ .Values.platform.namespace }}.svc.cluster.local.:8871/v1/"
           ports:
           - name: server
             containerPort: {{ .Values.dagDeploy.ports.dagServerHttp }}

--- a/templates/dag-deploy/dag-server-statefulset.yaml
+++ b/templates/dag-deploy/dag-server-statefulset.yaml
@@ -47,15 +47,14 @@ spec:
           image: "{{ .Values.dagDeploy.images.dagServer.repository }}:{{ .Values.dagDeploy.images.dagServer.tag }}"
           imagePullPolicy: {{ .Values.dagDeploy.images.dagServer.pullPolicy }}
           command: ["sanic", "dag_deploy.server.app", "-H", "0.0.0.0"]
-          env:
-          - name: HOUSTON_SERVICE_ENDPOINT
-            value: "https://{{ .Values.platform.release }}-houston.{{ .Values.platform.namespace }}.svc.cluster.local.:8871/v1/"
           ports:
           - name: server
             containerPort: {{ .Values.dagDeploy.ports.dagServerHttp }}
           resources:
             {{- toYaml .Values.dagDeploy.resources | nindent 12 }}
           env:
+          - name: HOUSTON_SERVICE_ENDPOINT
+            value: "https://{{ .Values.platform.release }}-houston.{{ .Values.platform.namespace }}.svc.cluster.local.:8871/v1/"
 {{- if .Values.dagDeploy.extraEnv }}
 {{ toYaml .Values.dagDeploy.extraEnv | indent 10 }}
 {{- end }}

--- a/tests/chart/test_dag_server_statefulset.py
+++ b/tests/chart/test_dag_server_statefulset.py
@@ -58,7 +58,7 @@ class TestDagServerStatefulSet:
         env_vars = {x["name"]: x["value"] for x in c_by_name["dag-server"]["env"]}
         assert (
             env_vars["HOUSTON_SERVICE_ENDPOINT"]
-            == "https://-houston..svc.cluster.local.:8871/v1/"
+            == "http://-houston..svc.cluster.local.:8871/v1/"
         )
 
     def test_dag_server_statefulset_houston_service_endpoint_override(
@@ -85,7 +85,7 @@ class TestDagServerStatefulSet:
         env_vars = {x["name"]: x["value"] for x in c_by_name["dag-server"]["env"]}
         assert (
             env_vars["HOUSTON_SERVICE_ENDPOINT"]
-            == "https://test-release-houston.test-namespace.svc.cluster.local.:8871/v1/"
+            == "http://test-release-houston.test-namespace.svc.cluster.local.:8871/v1/"
         )
 
     def test_dag_server_statefulset_with_resource_overrides(self, kube_version):

--- a/tests/chart/test_dag_server_statefulset.py
+++ b/tests/chart/test_dag_server_statefulset.py
@@ -6,6 +6,29 @@ from .. import supported_k8s_versions
 from . import get_containers_by_name
 
 
+def common_default_tests(doc):
+    """Test cases for default dag-server sts enabled"""
+
+    assert doc["kind"] == "StatefulSet"
+    assert doc["apiVersion"] == "apps/v1"
+    assert doc["metadata"]["name"] == "release-name-dag-server"
+    c_by_name = get_containers_by_name(doc)
+    assert len(c_by_name) == 1
+    assert c_by_name["dag-server"]["command"] == [
+        "sanic",
+        "dag_deploy.server.app",
+        "-H",
+        "0.0.0.0",
+    ]
+    assert c_by_name["dag-server"]["image"].startswith(
+        "quay.io/astronomer/ap-dag-deploy:"
+    )
+    assert c_by_name["dag-server"]["image"].startswith(
+        "quay.io/astronomer/ap-dag-deploy:"
+    )
+    assert c_by_name["dag-server"]["livenessProbe"]
+
+
 @pytest.mark.parametrize("kube_version", supported_k8s_versions)
 class TestDagServerStatefulSet:
     def test_dag_server_statefulset_default(self, kube_version):
@@ -27,24 +50,43 @@ class TestDagServerStatefulSet:
         )
         assert len(docs) == 1
         doc = docs[0]
-        assert doc["kind"] == "StatefulSet"
-        assert doc["apiVersion"] == "apps/v1"
-        assert doc["metadata"]["name"] == "release-name-dag-server"
+
+        common_default_tests(doc)
+
         c_by_name = get_containers_by_name(doc)
-        assert len(c_by_name) == 1
-        assert c_by_name["dag-server"]["command"] == [
-            "sanic",
-            "dag_deploy.server.app",
-            "-H",
-            "0.0.0.0",
-        ]
-        assert c_by_name["dag-server"]["image"].startswith(
-            "quay.io/astronomer/ap-dag-deploy:"
+
+        env_vars = {x["name"]: x["value"] for x in c_by_name["dag-server"]["env"]}
+        assert (
+            env_vars["HOUSTON_SERVICE_ENDPOINT"]
+            == "https://-houston..svc.cluster.local.:8871/v1/"
         )
-        assert c_by_name["dag-server"]["image"].startswith(
-            "quay.io/astronomer/ap-dag-deploy:"
+
+    def test_dag_server_statefulset_houston_service_endpoint_override(
+        self, kube_version
+    ):
+        """Test that we see the right HOUSTON_SERVICE_ENDPOINT value when the relevant variables are set."""
+        values = {
+            "dagDeploy": {"enabled": True},
+            "platform": {"release": "test-release", "namespace": "test-namespace"},
+        }
+
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/dag-deploy/dag-server-statefulset.yaml",
+            values=values,
         )
-        assert c_by_name["dag-server"]["livenessProbe"]
+        assert len(docs) == 1
+        doc = docs[0]
+
+        common_default_tests(doc)
+
+        c_by_name = get_containers_by_name(doc)
+
+        env_vars = {x["name"]: x["value"] for x in c_by_name["dag-server"]["env"]}
+        assert (
+            env_vars["HOUSTON_SERVICE_ENDPOINT"]
+            == "https://test-release-houston.test-namespace.svc.cluster.local.:8871/v1/"
+        )
 
     def test_dag_server_statefulset_with_resource_overrides(self, kube_version):
         """Test that Dag Server statefulset are configurable with custom resource limits."""
@@ -66,9 +108,9 @@ class TestDagServerStatefulSet:
         )
         assert len(docs) == 1
         doc = docs[0]
-        assert doc["kind"] == "StatefulSet"
-        assert doc["apiVersion"] == "apps/v1"
-        assert doc["metadata"]["name"] == "release-name-dag-server"
+
+        common_default_tests(doc)
+
         c_by_name = get_containers_by_name(doc)
         assert c_by_name["dag-server"]["resources"] == resources
 
@@ -86,9 +128,9 @@ class TestDagServerStatefulSet:
         )
         assert len(docs) == 1
         doc = docs[0]
-        assert doc["kind"] == "StatefulSet"
-        assert doc["apiVersion"] == "apps/v1"
-        assert doc["metadata"]["name"] == "release-name-dag-server"
+
+        common_default_tests(doc)
+
         assert (
             dag_serversecuritycontext
             == doc["spec"]["template"]["spec"]["securityContext"]
@@ -108,9 +150,9 @@ class TestDagServerStatefulSet:
         )
         assert len(docs) == 1
         doc = docs[0]
-        assert doc["kind"] == "StatefulSet"
-        assert doc["apiVersion"] == "apps/v1"
-        assert doc["metadata"]["name"] == "release-name-dag-server"
+
+        common_default_tests(doc)
+
         assert [{"name": "gscsecret"}] == doc["spec"]["template"]["spec"][
             "imagePullSecrets"
         ]

--- a/values.yaml
+++ b/values.yaml
@@ -525,6 +525,7 @@ ingress:
 
 platform:
   release: ~
+  namespace: ~
 
 astronomer:
   images:


### PR DESCRIPTION
## Description

- Add `HOUSTON_SERVICE_ENDPOINT` env var
- Improve dag-server sts test cases

## Related Issues

- https://github.com/astronomer/issues/issues/6374
- https://github.com/astronomer/issues/issues/5623

## Testing

All of this code hasn't been in prod before and dag-deploy isn't going to work without it, so this can be tested during tests of dag-deploy rollback feature.

## Merging

Merge only into whatever release-0.35 is going to use.