### PR TITLE
enhance nginx auth sidecar config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ---
-exclude: '^(venv|\.vscode|tests/k8s_schema)' # regex
+exclude: '^(venv|\.vscode|tests/k8s_schema|tests/chart/test_data)' # regex
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: "v0.4.4"

--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -104,6 +104,12 @@
 {{ .Release.Name }}-flower.{{ .Values.ingress.baseDomain }}
 {{- end }}
 
+{{ define "default_nginx_server_settings" }}
+# Disable Nginx Server version
+server_tokens off;
+client_max_body_size        1024m;
+{{ end }}
+
 {{ define "default_nginx_settings" }}
 internal;
 proxy_pass_request_body     off;
@@ -121,7 +127,6 @@ proxy_request_buffering     on;
 proxy_http_version          1.1;
 proxy_ssl_server_name       on;
 proxy_pass_request_headers  on;
-client_max_body_size        1024m;
 {{ end }}
 
 {{ define "default_nginx_settings_location" }}

--- a/templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml
+++ b/templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml
@@ -28,7 +28,7 @@ data:
       server {
         server_name {{ .Release.Name }}.{{ .Values.ingress.baseDomain }} ;
         listen {{ .Values.authSidecar.port }}  ;
-{{ include "default_nginx_server_settings" . | indent 8 }}
+        {{ include "default_nginx_server_settings" . }}
         location  = /auth {
 {{ include "default_nginx_settings" . | indent 8 }}
           proxy_set_header            Host                    houston.{{ .Values.ingress.baseDomain }};

--- a/templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml
+++ b/templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml
@@ -23,7 +23,7 @@ data:
       }
     http {
       upstream astro-dag-server {
-        server localhost:{{ .Values.dagDeploy.ports.dagServerHttp }} ;
+        server 127.0.0.1:{{ .Values.dagDeploy.ports.dagServerHttp }} ;
       }
       server {
         server_name {{ .Release.Name }}.{{ .Values.ingress.baseDomain }} ;

--- a/templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml
+++ b/templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml
@@ -28,7 +28,7 @@ data:
       server {
         server_name {{ .Release.Name }}.{{ .Values.ingress.baseDomain }} ;
         listen {{ .Values.authSidecar.port }}  ;
-        {{ include "default_nginx_server_settings" . }}
+{{ include "default_nginx_server_settings" . | indent 8 }}
         location  = /auth {
 {{ include "default_nginx_settings" . | indent 8 }}
           proxy_set_header            Host                    houston.{{ .Values.ingress.baseDomain }};

--- a/templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml
+++ b/templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml
@@ -28,10 +28,9 @@ data:
       server {
         server_name {{ .Release.Name }}.{{ .Values.ingress.baseDomain }} ;
         listen {{ .Values.authSidecar.port }}  ;
-        # Disable Nginx Server version
-        server_tokens off;
-{{ include "default_nginx_settings" . | indent 6 }}
+{{ include "default_nginx_server_settings" . | indent 8 }}
         location  = /auth {
+{{ include "default_nginx_settings" . | indent 8 }}
           proxy_set_header            Host                    houston.{{ .Values.ingress.baseDomain }};
           proxy_pass  https://houston.{{ .Values.ingress.baseDomain }}/v1/authorization;
         }

--- a/templates/flower/flower-auth-sidecar-configmap.yaml
+++ b/templates/flower/flower-auth-sidecar-configmap.yaml
@@ -28,7 +28,7 @@ data:
       server {
         server_name {{ .Release.Name }}-flower.{{ .Values.ingress.baseDomain }} ;
         listen {{ .Values.authSidecar.port }}  ;
-        {{ include "default_nginx_server_settings" . }}
+{{ include "default_nginx_server_settings" . | indent 8 }}
         location  = /auth {
 {{ include "default_nginx_settings" . | indent 8  }}
           proxy_set_header            Host                    houston.{{ .Values.ingress.baseDomain }};

--- a/templates/flower/flower-auth-sidecar-configmap.yaml
+++ b/templates/flower/flower-auth-sidecar-configmap.yaml
@@ -28,8 +28,7 @@ data:
       server {
         server_name {{ .Release.Name }}-flower.{{ .Values.ingress.baseDomain }} ;
         listen {{ .Values.authSidecar.port }}  ;
-        # Disable Nginx Server version
-        server_tokens off;
+{{ include "default_nginx_server_settings" . | indent 8 }}
         location  = /auth {
 {{ include "default_nginx_settings" . | indent 8  }}
           proxy_set_header            Host                    houston.{{ .Values.ingress.baseDomain }};

--- a/templates/flower/flower-auth-sidecar-configmap.yaml
+++ b/templates/flower/flower-auth-sidecar-configmap.yaml
@@ -28,7 +28,7 @@ data:
       server {
         server_name {{ .Release.Name }}-flower.{{ .Values.ingress.baseDomain }} ;
         listen {{ .Values.authSidecar.port }}  ;
-{{ include "default_nginx_server_settings" . | indent 8 }}
+        {{ include "default_nginx_server_settings" . }}
         location  = /auth {
 {{ include "default_nginx_settings" . | indent 8  }}
           proxy_set_header            Host                    houston.{{ .Values.ingress.baseDomain }};

--- a/templates/webserver/webserver-auth-sidecar-configmap.yaml
+++ b/templates/webserver/webserver-auth-sidecar-configmap.yaml
@@ -28,8 +28,7 @@ data:
       server {
         server_name {{ .Release.Name }}.{{ .Values.ingress.baseDomain }} ;
         listen {{ .Values.authSidecar.port }}  ;
-        # Disable Nginx Server version
-        server_tokens off;
+{{ include "default_nginx_server_settings" . | indent 8 }}
         location ^~ /api/ {
           if ($host = 'deployments.{{ .Values.ingress.baseDomain }}' ) {
             return 404;

--- a/templates/webserver/webserver-auth-sidecar-configmap.yaml
+++ b/templates/webserver/webserver-auth-sidecar-configmap.yaml
@@ -28,7 +28,7 @@ data:
       server {
         server_name {{ .Release.Name }}.{{ .Values.ingress.baseDomain }} ;
         listen {{ .Values.authSidecar.port }}  ;
-{{ include "default_nginx_server_settings" . | indent 8 }}
+        {{ include "default_nginx_server_settings" . }}
         location ^~ /api/ {
           if ($host = 'deployments.{{ .Values.ingress.baseDomain }}' ) {
             return 404;

--- a/templates/webserver/webserver-auth-sidecar-configmap.yaml
+++ b/templates/webserver/webserver-auth-sidecar-configmap.yaml
@@ -28,7 +28,7 @@ data:
       server {
         server_name {{ .Release.Name }}.{{ .Values.ingress.baseDomain }} ;
         listen {{ .Values.authSidecar.port }}  ;
-        {{ include "default_nginx_server_settings" . }}
+{{ include "default_nginx_server_settings" . | indent 8 }}
         location ^~ /api/ {
           if ($host = 'deployments.{{ .Values.ingress.baseDomain }}' ) {
             return 404;

--- a/tests/chart/test_data/dag-server-authsidecar-nginx.conf
+++ b/tests/chart/test_data/dag-server-authsidecar-nginx.conf
@@ -1,0 +1,102 @@
+pid /tmp/nginx.pid;
+worker_processes auto;
+events {
+  multi_accept        on;
+  worker_connections  16384;
+  use                 epoll;
+  }
+http {
+  upstream astro-dag-server {
+    server 127.0.0.1:8000 ;
+  }
+  server {
+    server_name release-name. ;
+    listen 8084  ;
+    
+    # Disable Nginx Server version
+    server_tokens off;
+    client_max_body_size        1024m;
+    
+    location  = /auth {
+    
+    internal;
+    proxy_pass_request_body     off;
+    proxy_set_header            Content-Length          "";
+    proxy_set_header            X-Forwarded-Proto       "";
+    proxy_set_header            X-Original-URL          https://$http_host$request_uri;
+    proxy_set_header            X-Original-Method       $request_method;
+    proxy_set_header            X-Real-IP               $remote_addr;
+    proxy_set_header            X-Forwarded-For         $remote_addr;
+    proxy_set_header            X-Auth-Request-Redirect $request_uri;
+    proxy_buffering             off;
+    proxy_buffer_size           4k;
+    proxy_buffers               4 4k;
+    proxy_request_buffering     on;
+    proxy_http_version          1.1;
+    proxy_ssl_server_name       on;
+    proxy_pass_request_headers  on;
+    
+      proxy_set_header            Host                    houston.;
+      proxy_pass  https://houston./v1/authorization;
+    }
+
+    location @401_auth_error {
+      internal;
+      add_header Set-Cookie $auth_cookie;
+      return 302 https://app./login?rd=https://$http_host$request_uri;
+    }
+
+    location ~ ^/release-name/dags/(upload|download) {
+    
+    auth_request     /auth;
+    auth_request_set $auth_status $upstream_status;
+    auth_request_set $auth_cookie $upstream_http_set_cookie;
+    add_header       Set-Cookie $auth_cookie;
+    auth_request_set $authHeader0 $upstream_http_authorization;
+    proxy_set_header 'authorization' $authHeader0;
+    auth_request_set $authHeader1 $upstream_http_username;
+    proxy_set_header 'username' $authHeader1;
+    auth_request_set $authHeader2 $upstream_http_email;
+    proxy_set_header 'email' $authHeader2;
+    error_page 401 = @401_auth_error;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection 'connection_upgrade';
+    proxy_set_header X-Real-IP              $remote_addr;
+    proxy_set_header X-Forwarded-For        $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_cache_bypass $http_upgrade;
+    proxy_set_header X-Original-Forwarded-For $http_x_forwarded_for;
+    proxy_connect_timeout                   15s;
+    proxy_send_timeout                      600s;
+    proxy_read_timeout                      600s;
+    proxy_buffering                         off;
+    proxy_buffer_size                       4k;
+    proxy_buffers                           4 4k;
+    proxy_max_temp_file_size                1024m;
+    proxy_request_buffering                 on;
+    proxy_http_version                      1.1;
+    proxy_cookie_domain                     off;
+    proxy_redirect                          off;
+    
+
+
+      #proxy_set_header X-Original-URI        $request_uri;
+      if ($host = '-airflow.' ) {
+        return 308 https://deployments./release-name/dags/$request_uri;
+      }
+
+      # Custom headers to proxied server
+      proxy_set_header  Host  deployments.;
+      #proxy_set_header  X-Forwarded-Proto https;
+      proxy_cookie_path                       off;
+      rewrite ^/release-name/dags(.*)$ $1 break;
+      proxy_pass http://astro-dag-server;
+
+    }
+
+    location /healthz {
+      return 200;
+    }
+
+  }
+}


### PR DESCRIPTION
## Description

This PR enhances existing authsidecar config and fixes code duplication.
change 1: client_max_body_size initially nested inside auth block its now moved to server block to get applied for all location

change 2: server_tokens is added  every where in auth-sidecar nginx block  now its moved to common location and called every to reduce code duplication

change 3:  localhost in upstream block connects ipv6 by default and falls back to ipv4 this was causing error in first try and fallbacks to ipv4 and call passed sucessfully - we have changed to 127.0.0.1 to connect ipv4 by default
 

## Related Issues

https://github.com/astronomer/issues/issues/6141

## Testing

QA should validate webserver, flower and dag-server to see services comes up without any issues.
This also now enhances our upload limit for all auth proxy components 

## Merging

cherry-pick to release-1.10, master and 1.11
