### PR TITLE
add authsidecar security context support for dag server

### DIFF
--- a/templates/dag-deploy/dag-server-statefulset.yaml
+++ b/templates/dag-deploy/dag-server-statefulset.yaml
@@ -85,6 +85,9 @@ spec:
           {{- if .Values.authSidecar.resources }}
           resources: {{- toYaml .Values.authSidecar.resources | nindent 12 }}
           {{- end }}
+          {{- if .Values.authSidecar.securityContext }}
+          securityContext: {{- toYaml .Values.authSidecar.securityContext | nindent 12 }}
+          {{- end }}
           ports:
           - containerPort: {{ .Values.authSidecar.port }}
             name: auth-proxy

--- a/tests/chart/test_auth_sidecar.py
+++ b/tests/chart/test_auth_sidecar.py
@@ -95,3 +95,28 @@ class TestAuthSidecar:
         assert docs[1]["apiVersion"] == "v1"
         assert docs[1]["metadata"]["name"] == "release-name-dag-server"
         assert authSidecarServicePorts in docs[1]["spec"]["ports"]
+
+    def test_auth_sidecar_security_context_with_dag_server_enabled(self, kube_version):
+        """Test logging sidecar config with defaults"""
+        securityContext = {
+            "allowPrivilegeEscalation": False,
+            "runAsNonRoot": True,
+        }
+
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "authSidecar": {"enabled": True, "securityContext": securityContext},
+                "dagDeploy": {"enabled": True},
+            },
+            show_only=[
+                "templates/dag-deploy/dag-server-statefulset.yaml",
+            ],
+        )
+
+        assert len(docs) == 1
+        assert docs[0]["kind"] == "StatefulSet"
+        assert docs[0]["apiVersion"] == "apps/v1"
+        assert docs[0]["metadata"]["name"] == "release-name-dag-server"
+        c_by_name = get_containers_by_name(docs[0])
+        assert c_by_name["auth-proxy"]["securityContext"] == securityContext

--- a/tests/chart/test_auth_sidecar.py
+++ b/tests/chart/test_auth_sidecar.py
@@ -6,6 +6,15 @@ from .. import supported_k8s_versions
 from . import get_containers_by_name
 
 
+def common_dagserver_sts_test_cases(docs, docs_length):
+    """Test some things that should apply to all cases."""
+    len(docs) == docs_length
+    doc = docs[0]
+    assert doc["kind"] == "StatefulSet"
+    assert doc["apiVersion"] == "apps/v1"
+    assert doc["metadata"]["name"] == "release-name-dag-server"
+
+
 @pytest.mark.parametrize("kube_version", supported_k8s_versions)
 class TestAuthSidecar:
     show_only = [
@@ -83,10 +92,7 @@ class TestAuthSidecar:
             ],
         )
 
-        assert len(docs) == 2
-        assert docs[0]["kind"] == "StatefulSet"
-        assert docs[0]["apiVersion"] == "apps/v1"
-        assert docs[0]["metadata"]["name"] == "release-name-dag-server"
+        common_dagserver_sts_test_cases(docs, 2)
         c_by_name = get_containers_by_name(docs[0])
         assert c_by_name["auth-proxy"]["resources"] == resources
         assert volumeMounts in c_by_name["auth-proxy"]["volumeMounts"]
@@ -114,9 +120,6 @@ class TestAuthSidecar:
             ],
         )
 
-        assert len(docs) == 1
-        assert docs[0]["kind"] == "StatefulSet"
-        assert docs[0]["apiVersion"] == "apps/v1"
-        assert docs[0]["metadata"]["name"] == "release-name-dag-server"
+        common_dagserver_sts_test_cases(docs, 1)
         c_by_name = get_containers_by_name(docs[0])
         assert c_by_name["auth-proxy"]["securityContext"] == securityContext

--- a/values.yaml
+++ b/values.yaml
@@ -478,6 +478,7 @@ authSidecar:
   tag: 1.25.2-2
   pullPolicy: IfNotPresent
   port: 8084
+  securityContext: {}
 
 loggingSidecar:
   enabled: false


### PR DESCRIPTION
## Description

This PR adds supports for dag server auth sidecar with securityContext support 
Note: for webserver and celery we pass securityContext from code reading from global astronomer authsidecar values, for dag-server authsidecar we have a slightly different approach to handle them with the chart itself


## Related Issues

https://github.com/astronomer/issues/issues/6325
https://github.com/astronomer/issues/issues/6328
## Testing

QA should see globally passed valid securityContext to dag server auth sidecar container

## Merging

cherry-pick to release-1.10 and other upcomming releases
