### PR TITLE
add authsidecar resource section to default values

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -479,6 +479,7 @@ authSidecar:
   pullPolicy: IfNotPresent
   port: 8084
   securityContext: {}
+  resources: {}
 
 loggingSidecar:
   enabled: false


### PR DESCRIPTION
## Description

This PR has a minor imporvement over dag server auth sidecar. resource overrides support is already added for dag server authsidecar but key was missing in values.yaml this gives an initial impression of whether authsidecar supports resource overrides or not, this PR corrects the behaviour to show supported values in values.yaml

## Related Issues

https://github.com/astronomer/issues/issues/6123

## Testing

NA

## Merging

cherry-pick to release-1.10 and upcomming releases
