### PR TITLE
dag deploy 0.4.0

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -540,7 +540,7 @@ dagDeploy:
   images:
     dagServer:
       repository: quay.io/astronomer/ap-dag-deploy
-      tag: 0.3.2
+      tag: 0.4.0
       imagePullPolicy: IfNotPresent
   livenessProbe:
     initialDelaySeconds: 30


### PR DESCRIPTION
## Description

- Use ap-dag-deploy 0.4.0 with rollbacks support

## Related Issues

- astronomer/issues#6233

## Testing

This can be tested with normal QA testing for the 0.35.0 release

## Merging

Merge only into whatever version is going into astronomer/astronomer 0.35.0