### PR TITLE
remove auth headers for dag server auth sidecar

### DIFF
--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -129,6 +129,32 @@ proxy_ssl_server_name       on;
 proxy_pass_request_headers  on;
 {{ end }}
 
+{{ define "default_dag_server_nginx_settings_location" }}
+auth_request     /auth;
+auth_request_set $auth_status $upstream_status;
+auth_request_set $auth_cookie $upstream_http_set_cookie;
+add_header       Set-Cookie $auth_cookie;
+error_page 401 = @401_auth_error;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Connection 'connection_upgrade';
+proxy_set_header X-Real-IP              $remote_addr;
+proxy_set_header X-Forwarded-For        $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_cache_bypass $http_upgrade;
+proxy_set_header X-Original-Forwarded-For $http_x_forwarded_for;
+proxy_connect_timeout                   15s;
+proxy_send_timeout                      600s;
+proxy_read_timeout                      600s;
+proxy_buffering                         off;
+proxy_buffer_size                       4k;
+proxy_buffers                           4 4k;
+proxy_max_temp_file_size                1024m;
+proxy_request_buffering                 on;
+proxy_http_version                      1.1;
+proxy_cookie_domain                     off;
+proxy_redirect                          off;
+{{ end }}
+
 {{ define "default_nginx_settings_location" }}
 auth_request     /auth;
 auth_request_set $auth_status $upstream_status;

--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -129,30 +129,13 @@ proxy_ssl_server_name       on;
 proxy_pass_request_headers  on;
 {{ end }}
 
-{{ define "default_dag_server_nginx_settings_location" }}
-auth_request     /auth;
-auth_request_set $auth_status $upstream_status;
-auth_request_set $auth_cookie $upstream_http_set_cookie;
-add_header       Set-Cookie $auth_cookie;
-error_page 401 = @401_auth_error;
-proxy_set_header Upgrade $http_upgrade;
-proxy_set_header Connection 'connection_upgrade';
-proxy_set_header X-Real-IP              $remote_addr;
-proxy_set_header X-Forwarded-For        $remote_addr;
-proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-proxy_cache_bypass $http_upgrade;
-proxy_set_header X-Original-Forwarded-For $http_x_forwarded_for;
-proxy_connect_timeout                   15s;
-proxy_send_timeout                      600s;
-proxy_read_timeout                      600s;
-proxy_buffering                         off;
-proxy_buffer_size                       4k;
-proxy_buffers                           4 4k;
-proxy_max_temp_file_size                1024m;
-proxy_request_buffering                 on;
-proxy_http_version                      1.1;
-proxy_cookie_domain                     off;
-proxy_redirect                          off;
+{{ define "default_nginx_auth_headers" }}
+auth_request_set $authHeader0 $upstream_http_authorization;
+proxy_set_header 'authorization' $authHeader0;
+auth_request_set $authHeader1 $upstream_http_username;
+proxy_set_header 'username' $authHeader1;
+auth_request_set $authHeader2 $upstream_http_email;
+proxy_set_header 'email' $authHeader2;
 {{ end }}
 
 {{ define "default_nginx_settings_location" }}
@@ -160,12 +143,6 @@ auth_request     /auth;
 auth_request_set $auth_status $upstream_status;
 auth_request_set $auth_cookie $upstream_http_set_cookie;
 add_header       Set-Cookie $auth_cookie;
-auth_request_set $authHeader0 $upstream_http_authorization;
-proxy_set_header 'authorization' $authHeader0;
-auth_request_set $authHeader1 $upstream_http_username;
-proxy_set_header 'username' $authHeader1;
-auth_request_set $authHeader2 $upstream_http_email;
-proxy_set_header 'email' $authHeader2;
 error_page 401 = @401_auth_error;
 proxy_set_header Upgrade $http_upgrade;
 proxy_set_header Connection 'connection_upgrade';

--- a/templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml
+++ b/templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml
@@ -42,7 +42,7 @@ data:
         }
 
         location ~ ^/{{ .Release.Name }}/dags/(upload|download) {
-{{ include "default_nginx_settings_location" . | indent 8 }}
+{{ include "default_dag_server_nginx_settings_location" . | indent 8 }}
 
 
           #proxy_set_header X-Original-URI        $request_uri;

--- a/templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml
+++ b/templates/dag-deploy/dag-server-auth-sidecar-configmap.yaml
@@ -42,7 +42,7 @@ data:
         }
 
         location ~ ^/{{ .Release.Name }}/dags/(upload|download) {
-{{ include "default_dag_server_nginx_settings_location" . | indent 8 }}
+{{ include "default_nginx_settings_location" . | indent 8 }}
 
 
           #proxy_set_header X-Original-URI        $request_uri;

--- a/templates/flower/flower-auth-sidecar-configmap.yaml
+++ b/templates/flower/flower-auth-sidecar-configmap.yaml
@@ -43,6 +43,7 @@ data:
 
         location ~* "^/{{ .Release.Name }}/flower(/|$)(.*)"  {
 {{ include "default_nginx_settings_location" . | indent 8  }}
+{{ include "default_nginx_auth_headers" . | indent 8 }}
 
           if ($host = '{{ .Values.platform.release }}-flower.{{ .Values.ingress.baseDomain }}' ) {
             rewrite ^ https://deployments.{{ .Values.ingress.baseDomain }}/{{ .Release.Name }}/flower permanent;

--- a/templates/webserver/webserver-auth-sidecar-configmap.yaml
+++ b/templates/webserver/webserver-auth-sidecar-configmap.yaml
@@ -49,7 +49,7 @@ data:
 
         location / {
 {{ include "default_nginx_settings_location" . | indent 8  }}
-
+{{ include "default_nginx_auth_headers" . | indent 8 }}
 
           #proxy_set_header X-Original-URI        $request_uri;
           if ($host = '{{ .Values.platform.release }}-airflow.{{ .Values.ingress.baseDomain }}' ) {

--- a/tests/chart/test_data/dag-server-authsidecar-nginx.conf
+++ b/tests/chart/test_data/dag-server-authsidecar-nginx.conf
@@ -52,12 +52,6 @@ http {
     auth_request_set $auth_status $upstream_status;
     auth_request_set $auth_cookie $upstream_http_set_cookie;
     add_header       Set-Cookie $auth_cookie;
-    auth_request_set $authHeader0 $upstream_http_authorization;
-    proxy_set_header 'authorization' $authHeader0;
-    auth_request_set $authHeader1 $upstream_http_username;
-    proxy_set_header 'username' $authHeader1;
-    auth_request_set $authHeader2 $upstream_http_email;
-    proxy_set_header 'email' $authHeader2;
     error_page 401 = @401_auth_error;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection 'connection_upgrade';


### PR DESCRIPTION
## Description

remove auth response headers from dag server auth sidecar nginx conf

## Related Issues

https://github.com/astronomer/issues/issues/6383

## Testing

QA should able to upload dags when auth-sidecar is enabled

## Merging

cherry-pick to 1.11
