### PR TITLE
Add dag-deploy networkPolicy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test: unittest-chart ## Run all tests
 
 .PHONY: unittest-chart
 unittest-chart: charts venv ## Unittest the helm chart
-	# Protip: you can modify pytest behavior like: make unittest-chart PYTEST_ADDOPTS='-v --maxfail=1 --pdb -k 1.20'
+	# Protip: you can modify pytest behavior like: make unittest-chart PYTEST_ADDOPTS='-v --maxfail=1 --pdb -k "1.30 and git-sync"'
 	venv/bin/python -m pytest -n auto -v --junitxml=test-results/junit.xml tests/chart
 
 .PHONY: clean

--- a/templates/dag-deploy/dag-deploy-networkpolicy.yaml
+++ b/templates/dag-deploy/dag-deploy-networkpolicy.yaml
@@ -57,6 +57,6 @@ spec:
       port: 8000
     {{ if .Values.authSidecar.enabled }}
     - protocol: TCP
-      port: 8084
+      port: {{ .Values.authSidecar.port }}
     {{- end -}}
 {{- end -}}

--- a/templates/dag-deploy/dag-deploy-networkpolicy.yaml
+++ b/templates/dag-deploy/dag-deploy-networkpolicy.yaml
@@ -38,6 +38,9 @@ spec:
           app: houston
           component: houston
           release: {{ .Values.platform.release }}
+    - namespaceSelector:
+        matchLabels:
+          "kubernetes.io/metadata.name": {{ .Values.platform.namespace }}
       podSelector:
         matchLabels:
           component: ingress-controller

--- a/templates/dag-deploy/dag-deploy-networkpolicy.yaml
+++ b/templates/dag-deploy/dag-deploy-networkpolicy.yaml
@@ -16,7 +16,7 @@ spec:
   podSelector:
     matchLabels:
       tier: airflow
-      component: dag-deploy
+      component: dag-server
       release: {{ .Release.Name }}
   policyTypes:
   - Ingress
@@ -32,13 +32,12 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          name: {{ .Values.platform.namespace }}
+          "kubernetes.io/metadata.name": {{ .Values.platform.namespace }}
       podSelector:
         matchLabels:
-          release: {{ .Values.platform.release }}
           app: houston
           component: houston
-          tier: astronomer
+          release: {{ .Values.platform.release }}
     ports:
     - protocol: TCP
       port: 8000

--- a/templates/dag-deploy/dag-deploy-networkpolicy.yaml
+++ b/templates/dag-deploy/dag-deploy-networkpolicy.yaml
@@ -38,6 +38,11 @@ spec:
           app: houston
           component: houston
           release: {{ .Values.platform.release }}
+    {{ if .Values.authSidecar.enabled }}
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: ingress
+    {{ else }}
     - namespaceSelector:
         matchLabels:
           "kubernetes.io/metadata.name": {{ .Values.platform.namespace }}
@@ -46,7 +51,12 @@ spec:
           component: ingress-controller
           release: {{ .Values.platform.release }}
           tier: nginx
+    {{ end }}
     ports:
     - protocol: TCP
       port: 8000
+    {{ if .Values.authSidecar.enabled }}
+    - protocol: TCP
+      port: 8084
+    {{- end -}}
 {{- end -}}

--- a/templates/dag-deploy/dag-deploy-networkpolicy.yaml
+++ b/templates/dag-deploy/dag-deploy-networkpolicy.yaml
@@ -38,6 +38,11 @@ spec:
           app: houston
           component: houston
           release: {{ .Values.platform.release }}
+      podSelector:
+        matchLabels:
+          component: ingress-controller
+          release: {{ .Values.platform.release }}
+          tier: nginx
     ports:
     - protocol: TCP
       port: 8000

--- a/templates/dag-deploy/dag-deploy-networkpolicy.yaml
+++ b/templates/dag-deploy/dag-deploy-networkpolicy.yaml
@@ -1,0 +1,45 @@
+##################################
+## dag-deploy NetworkPolicy ##
+##################################
+{{- if .Values.dagDeploy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-dag-deploy
+  labels:
+    component: dag-deploy
+    tier: airflow
+    release: {{ .Release.Name }}
+    chart: "{{ .Release.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+spec:
+  podSelector:
+    matchLabels:
+      tier: airflow
+      component: dag-deploy
+      release: {{ .Release.Name }}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          release: {{ .Release.Name }}
+          tier: airflow
+    ports:
+    - protocol: TCP
+      port: 8000
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: {{ .Values.platform.namespace }}
+      podSelector:
+        matchLabels:
+          release: {{ .Values.platform.release }}
+          app: houston
+          component: houston
+          tier: astronomer
+    ports:
+    - protocol: TCP
+      port: 8000
+{{- end -}}

--- a/templates/dag-deploy/dag-deploy-networkpolicy.yaml
+++ b/templates/dag-deploy/dag-deploy-networkpolicy.yaml
@@ -1,6 +1,6 @@
-##################################
+##############################
 ## dag-deploy NetworkPolicy ##
-##################################
+##############################
 {{- if .Values.dagDeploy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/tests/chart/test_dag_deploy_networkpolicy.py
+++ b/tests/chart/test_dag_deploy_networkpolicy.py
@@ -18,7 +18,10 @@ class TestDagDeployNetworkPolicy:
     def test_dag_deploy_networkpolicy_dag_deploy_enabled(self, kube_version):
         """Test that a valid networkPolicy are rendered when dag-deploy is enabled."""
 
-        values = {"dagDeploy": {"enabled": True}}
+        values = {
+            "dagDeploy": {"enabled": True},
+            "platform": {"namespace": "test-ns-99", "release": "test-release-42"},
+        }
 
         docs = render_chart(
             kube_version=kube_version,
@@ -26,3 +29,37 @@ class TestDagDeployNetworkPolicy:
             values=values,
         )
         assert len(docs) == 1
+        spec = docs[0]["spec"]
+
+        assert list(spec["podSelector"].keys()) == ["matchLabels"]
+        assert spec["policyTypes"] == ["Ingress"]
+        assert spec["podSelector"]["matchLabels"] == {
+            "tier": "airflow",
+            "component": "dag-server",
+            "release": "release-name",
+        }
+
+        assert all(
+            [x["ports"] == [{"protocol": "TCP", "port": 8000}] for x in spec["ingress"]]
+        )
+
+        assert spec["ingress"][0]["from"] == [
+            {
+                "podSelector": {
+                    "matchLabels": {"release": "release-name", "tier": "airflow"}
+                }
+            }
+        ]
+
+        assert len(spec["ingress"][1]["from"]) == 1
+        assert (
+            spec["ingress"][1]["from"][0]["namespaceSelector"]["matchLabels"][
+                "kubernetes.io/metadata.name"
+            ]
+            == "test-ns-99"
+        )
+        assert spec["ingress"][1]["from"][0]["podSelector"]["matchLabels"] == {
+            "app": "houston",
+            "component": "houston",
+            "release": "test-release-42",
+        }

--- a/tests/chart/test_dag_deploy_networkpolicy.py
+++ b/tests/chart/test_dag_deploy_networkpolicy.py
@@ -51,20 +51,29 @@ class TestDagDeployNetworkPolicy:
             }
         ]
 
-        assert len(spec["ingress"][1]["from"]) == 1
-        assert (
-            spec["ingress"][1]["from"][0]["namespaceSelector"]["matchLabels"][
-                "kubernetes.io/metadata.name"
-            ]
-            == "test-ns-99"
-        )
-        assert spec["ingress"][1]["from"][0]["podSelector"]["matchLabels"] == {
-            "app": "houston",
-            "component": "houston",
-            "release": "test-release-42",
-        }
-        assert spec["ingress"][1]["from"][1]["podSelector"]["matchLabels"] == {
-            "app": "ingress-controller",
-            "release": "test-release-42",
-            "tier" : "nginx"
-        }
+        assert len(spec["ingress"][1]["from"]) == 2
+
+        assert {
+            "namespaceSelector": {
+                "matchLabels": {"kubernetes.io/metadata.name": "test-ns-99"}
+            },
+            "podSelector": {
+                "matchLabels": {
+                    "app": "houston",
+                    "component": "houston",
+                    "release": "test-release-42",
+                }
+            },
+        } == spec["ingress"][1]["from"][0]
+        assert {
+            "namespaceSelector": {
+                "matchLabels": {"kubernetes.io/metadata.name": "test-ns-99"}
+            },
+            "podSelector": {
+                "matchLabels": {
+                    "tier": "nginx",
+                    "component": "ingress-controller",
+                    "release": "test-release-42",
+                }
+            },
+        } == spec["ingress"][1]["from"][1]

--- a/tests/chart/test_dag_deploy_networkpolicy.py
+++ b/tests/chart/test_dag_deploy_networkpolicy.py
@@ -1,0 +1,28 @@
+import pytest
+
+from tests.chart.helm_template_generator import render_chart
+
+from .. import supported_k8s_versions
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+class TestDagDeployNetworkPolicy:
+    def test_dag_deploy_networkpolicy_default(self, kube_version):
+        """Test that no dag-deploy templates are rendered by default."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/dag-deploy/dag-deploy-networkpolicy.yaml",
+        )
+        assert len(docs) == 0
+
+    def test_dag_deploy_networkpolicy_dag_deploy_enabled(self, kube_version):
+        """Test that a valid networkPolicy are rendered when dag-deploy is enabled."""
+
+        values = {"dagDeploy": {"enabled": True}}
+
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/dag-deploy/dag-deploy-networkpolicy.yaml",
+            values=values,
+        )
+        assert len(docs) == 1

--- a/tests/chart/test_dag_deploy_networkpolicy.py
+++ b/tests/chart/test_dag_deploy_networkpolicy.py
@@ -63,3 +63,8 @@ class TestDagDeployNetworkPolicy:
             "component": "houston",
             "release": "test-release-42",
         }
+        assert spec["ingress"][1]["from"][1]["podSelector"]["matchLabels"] == {
+            "app": "ingress-controller",
+            "release": "test-release-42",
+            "tier" : "nginx"
+        }

--- a/tests/chart/test_dag_deploy_networkpolicy.py
+++ b/tests/chart/test_dag_deploy_networkpolicy.py
@@ -78,6 +78,8 @@ class TestDagDeployNetworkPolicy:
             },
         } == spec["ingress"][1]["from"][1]
 
+        assert [{"protocol": "TCP", "port": 8000}] == spec["ingress"][1]["ports"]
+
     def test_dag_deploy_networkpolicy_with_authsidecar_enabled(self, kube_version):
         """Test that a valid networkPolicy are rendered when dag-deploy is enabled."""
 
@@ -131,3 +133,8 @@ class TestDagDeployNetworkPolicy:
                 "matchLabels": {"network.openshift.io/policy-group": "ingress"}
             }
         } == spec["ingress"][1]["from"][1]
+
+        assert [
+            {"protocol": "TCP", "port": 8000},
+            {"protocol": "TCP", "port": 8084},
+        ] == spec["ingress"][1]["ports"]

--- a/values.yaml
+++ b/values.yaml
@@ -525,6 +525,9 @@ ingress:
 #    enabled: true
 #    # TODO: Originated from https://github.com/astronomer/issues/issues/2516
 
+# This section describes the astronomer platform, and is used to share values
+# from astronomer that are useful here, like networkPolicies that need to know
+# what namespace astronomer is running in.
 platform:
   release: ~
   namespace: ~


### PR DESCRIPTION
## Description

Add dag-deploy networkPolicy that prevents dag-deploy from being accessed from other namespaces except houston pod in astronomer namespace.
add support for BYO ingress with inbound auth sidecar 

## Related Issues

- <https://github.com/astronomer/issues/issues/6479>

## Testing

I manually tested this in an AWS cluster by confirming that when the policy was absent, dag-deploy server could be accessed from any namespace, and when this policy was in place, only the current namespace could access it, and also the houston pod in the astronomer deployed namespace.

## Merging

This should be merged into releases >= 0.34