### PR TITLE
update vendor packages for airflow chart

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -29,16 +29,16 @@ airflow:
       tag: ~
     statsd:
       repository: quay.io/astronomer/ap-statsd-exporter
-      tag: 0.26.0
+      tag: 0.26.1
     redis:
       repository: quay.io/astronomer/ap-redis
       tag: 6.2.14
     pgbouncer:
       repository: quay.io/astronomer/ap-pgbouncer
-      tag: 1.20.1-3
+      tag: 1.21.0
     pgbouncerExporter:
       repository: quay.io/astronomer/ap-pgbouncer-exporter
-      tag: 0.15.0-5
+      tag: 0.15.0-9
     gitSync:
       repository: quay.io/astronomer/ap-git-sync
       tag: 3.6.9
@@ -475,7 +475,7 @@ extraObjects: []
 authSidecar:
   enabled: false
   repository: quay.io/astronomer/ap-auth-sidecar
-  tag: 1.25.2-2
+  tag: 1.25.5
   pullPolicy: IfNotPresent
   port: 8084
   securityContext: {}
@@ -588,10 +588,10 @@ gitSyncRelay:
   images:
     gitDaemon:
       repository: "quay.io/astronomer/ap-git-daemon"
-      tag: "3.18.5"
+      tag: "3.18.7-1"
     gitSync:
       repository: "quay.io/astronomer/ap-git-sync-relay"
-      tag: "0.0.3-1"
+      tag: "0.0.3-4"
   repo:
     url: ~
     branch: main


### PR DESCRIPTION
## Description

Do not merge this PR until this description is replaced with relevant info.

## Related Issues

| Header | Header | Header |
|--------|--------|--------|
| ap-statsd-exporter | 0.26.0 | 0.26.1 |
| ap-pgbouncer | 1.20.1-3 | 1.21.0 |
| ap-pgbouncer-exporter | 0.15.0-5 | 0.15.0-9 |
| ap-auth-sidecar | 1.25.2-2 | 1.25.5 | 
| ap-git-daemon | 3.18.5 | 3.18.7-1 | 
|ap-git-sync-relay| 0.0.3-1 | 0.0.3-4|
## Testing

https://github.com/astronomer/issues/issues/6305
https://github.com/astronomer/issues/issues/6462

## Merging

cherry-pick to release-1.11
