### PR TITLE
add persistentVolumeClaimRetentionPolicy support in dag server

### DIFF
--- a/templates/dag-deploy/dag-server-statefulset.yaml
+++ b/templates/dag-deploy/dag-server-statefulset.yaml
@@ -16,6 +16,9 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if  .Values.dagDeploy.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.dagDeploy.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
+  {{ end }}
   serviceName: {{ include "airflow.fullname" . }}-dag-server
   replicas: 1
   selector:

--- a/templates/dag-deploy/dag-server-statefulset.yaml
+++ b/templates/dag-deploy/dag-server-statefulset.yaml
@@ -17,8 +17,8 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if and $persistenceEnabled .Values.dagDeploy.persistentVolumeClaimRetentionPolicy }}
-  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.dagDeploy.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
+  {{- if and $persistenceEnabled .Values.dagDeploy.persistence.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.dagDeploy.persistence.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
   {{ end }}
   serviceName: {{ include "airflow.fullname" . }}-dag-server
   replicas: 1

--- a/templates/dag-deploy/dag-server-statefulset.yaml
+++ b/templates/dag-deploy/dag-server-statefulset.yaml
@@ -2,7 +2,6 @@
 ## dag-server StatefulSet ##
 ############################
 {{- if .Values.dagDeploy.enabled }}
-{{- $persistenceEnabled := .Values.dagDeploy.persistence.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -17,7 +16,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if and $persistenceEnabled .Values.dagDeploy.persistence.persistentVolumeClaimRetentionPolicy }}
+  {{- if and .Values.dagDeploy.persistence.enabled .Values.dagDeploy.persistence.persistentVolumeClaimRetentionPolicy }}
   persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.dagDeploy.persistence.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
   {{ end }}
   serviceName: {{ include "airflow.fullname" . }}-dag-server

--- a/templates/dag-deploy/dag-server-statefulset.yaml
+++ b/templates/dag-deploy/dag-server-statefulset.yaml
@@ -2,6 +2,7 @@
 ## dag-server StatefulSet ##
 ############################
 {{- if .Values.dagDeploy.enabled }}
+{{- $persistenceEnabled := .Values.dagDeploy.persistence.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -16,7 +17,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if  .Values.dagDeploy.persistentVolumeClaimRetentionPolicy }}
+  {{- if and $persistenceEnabled .Values.dagDeploy.persistentVolumeClaimRetentionPolicy }}
   persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.dagDeploy.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
   {{ end }}
   serviceName: {{ include "airflow.fullname" . }}-dag-server

--- a/tests/chart/test_dag_server_statefulset.py
+++ b/tests/chart/test_dag_server_statefulset.py
@@ -61,6 +61,8 @@ class TestDagServerStatefulSet:
             == "http://-houston..svc.cluster.local.:8871/v1/"
         )
 
+        assert "persistentVolumeClaimRetentionPolicy" not in doc["spec"]
+
     def test_dag_server_statefulset_houston_service_endpoint_override(
         self, kube_version
     ):
@@ -156,3 +158,37 @@ class TestDagServerStatefulSet:
         assert [{"name": "gscsecret"}] == doc["spec"]["template"]["spec"][
             "imagePullSecrets"
         ]
+
+    def test_dag_server_statefulset_with_persistentVolumeClaimRetentionPolicy_overrides(
+        self, kube_version
+    ):
+        """Test that dag-server statefulset are configurable with persistentVolumeClaimRetentionPolicy."""
+        persistentVolumeClaimRetentionPolicy = {
+            "persistence": {
+                "persistentVolumeClaimRetentionPolicy": {
+                    "whenDeleted": "Retain",
+                    "whenScaled": "Delete",
+                }
+            }
+        }
+        values = {
+            "dagDeploy": {
+                "enabled": True,
+                "persistentVolumeClaimRetentionPolicy": persistentVolumeClaimRetentionPolicy,
+            }
+        }
+
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/dag-deploy/dag-server-statefulset.yaml",
+            values=values,
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+
+        common_default_tests(doc)
+
+        assert (
+            persistentVolumeClaimRetentionPolicy
+            == doc["spec"]["persistentVolumeClaimRetentionPolicy"]
+        )

--- a/tests/chart/test_dag_server_statefulset.py
+++ b/tests/chart/test_dag_server_statefulset.py
@@ -164,16 +164,17 @@ class TestDagServerStatefulSet:
     ):
         """Test that dag-server statefulset are configurable with persistentVolumeClaimRetentionPolicy."""
         persistentVolumeClaimRetentionPolicy = {
-                "persistentVolumeClaimRetentionPolicy": {
-                    "whenDeleted": "Retain",
-                    "whenScaled": "Delete",
-                }
+            "persistentVolumeClaimRetentionPolicy": {
+                "whenDeleted": "Retain",
+                "whenScaled": "Delete",
             }
+        }
         values = {
             "dagDeploy": {
                 "enabled": True,
                 "persistence": {
-                "persistentVolumeClaimRetentionPolicy": persistentVolumeClaimRetentionPolicy,}
+                    "persistentVolumeClaimRetentionPolicy": persistentVolumeClaimRetentionPolicy,
+                },
             }
         }
 

--- a/tests/chart/test_dag_server_statefulset.py
+++ b/tests/chart/test_dag_server_statefulset.py
@@ -164,17 +164,16 @@ class TestDagServerStatefulSet:
     ):
         """Test that dag-server statefulset are configurable with persistentVolumeClaimRetentionPolicy."""
         persistentVolumeClaimRetentionPolicy = {
-            "persistence": {
                 "persistentVolumeClaimRetentionPolicy": {
                     "whenDeleted": "Retain",
                     "whenScaled": "Delete",
                 }
             }
-        }
         values = {
             "dagDeploy": {
                 "enabled": True,
-                "persistentVolumeClaimRetentionPolicy": persistentVolumeClaimRetentionPolicy,
+                "persistence": {
+                "persistentVolumeClaimRetentionPolicy": persistentVolumeClaimRetentionPolicy,}
             }
         }
 

--- a/values.yaml
+++ b/values.yaml
@@ -549,12 +549,12 @@ dagDeploy:
     initialDelaySeconds: 30
     timeoutSeconds: 30
   terminationGracePeriodSeconds: 30
-  persistentVolumeClaimRetentionPolicy: ~
   podAnnotations: {}
   extraEnv: []
   extraContainers: []
   persistence:
     enabled: true
+    persistentVolumeClaimRetentionPolicy: ~
     size: 10Gi
     storageClassName: ~
     annotations: {}

--- a/values.yaml
+++ b/values.yaml
@@ -549,6 +549,7 @@ dagDeploy:
     initialDelaySeconds: 30
     timeoutSeconds: 30
   terminationGracePeriodSeconds: 30
+  persistentVolumeClaimRetentionPolicy: ~
   podAnnotations: {}
   extraEnv: []
   extraContainers: []


### PR DESCRIPTION
## Description

Add persistentVolumeClaimRetentionPolicy support for dag server stateful to enable auto cleanup of pvc 

## Related Issues

https://github.com/astronomer/issues/issues/6436

## Testing

refer issue ticket

## Merging

cherry-pick to release 1.10, 1.11
