### PR TITLE
update exposed route paths for dag server

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -193,7 +193,7 @@ spec:
           {{- if .Values.authSidecar.enabled  }}
           - path: /{{ .Release.Name }}/dags
           {{- else }}
-          - path: /{{ .Release.Name }}/dags/(upload|download)(/.*)?
+          - path: /{{ .Release.Name }}/dags/(upload|downloads|healthz)(/.*)?
           {{- end }}
             pathType: Prefix
             backend:

--- a/tests/chart/test_ingress.py
+++ b/tests/chart/test_ingress.py
@@ -94,7 +94,7 @@ class TestIngress:
         rule_0 = docs[1]["spec"]["rules"][0]
         assert (
             rule_0["http"]["paths"][0]["path"]
-            == "/release-name/dags/(upload|download)(/.*)?"
+            == "/release-name/dags/(upload|downloads|healthz)(/.*)?"
         )
         assert rule_0["host"] == "deployments.example.com"
 

--- a/tests/chart/test_ingress.py
+++ b/tests/chart/test_ingress.py
@@ -67,7 +67,7 @@ class TestIngress:
         rule_0 = docs[0]["spec"]["rules"][0]
         assert (
             rule_0["http"]["paths"][0]["path"]
-            == "/release-name/dags/(upload|download)(/.*)?"
+            == "/release-name/dags/(upload|downloads|healthz)(/.*)?"
         )
         assert rule_0["host"] == "deployments.example.com"
 


### PR DESCRIPTION
## Description

update exposed route paths for dag server


PS: we already have a auth setup protecting these endpoints so we are safe here to expose them

## Related Issues

https://github.com/astronomer/issues/issues/6518

## Testing

QA should able to acess downloads and healthz endpoint 

## Merging

cherry-pick to release-1.11
