### PR TITLE
dag-deploy 0.5.1

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -543,7 +543,7 @@ dagDeploy:
   images:
     dagServer:
       repository: quay.io/astronomer/ap-dag-deploy
-      tag: 0.5.0
+      tag: 0.5.1
       imagePullPolicy: IfNotPresent
   livenessProbe:
     initialDelaySeconds: 30


### PR DESCRIPTION
## Description

dag-deploy version 0.5.1

## Related Issues

- https://github.com/astronomer/issues/issues/6522
- https://github.com/astronomer/dag-deploy/pull/31

## Testing

None needed. This value is actually passed in from houston, and we should consider removing this default. Maybe we can do that as part of https://github.com/astronomer/issues/issues/6481

## Merging

Merge to 0.35, 0.36