### PR TITLE
update localhost upstream host to default ipv4

### DIFF
--- a/templates/flower/flower-auth-sidecar-configmap.yaml
+++ b/templates/flower/flower-auth-sidecar-configmap.yaml
@@ -23,7 +23,7 @@ data:
       }
     http {
       upstream astro-flower {
-        server localhost:{{ .Values.airflow.ports.flowerUI }} ;
+        server 127.0.0.1:{{ .Values.airflow.ports.flowerUI }} ;
       }
       server {
         server_name {{ .Release.Name }}-flower.{{ .Values.ingress.baseDomain }} ;

--- a/templates/webserver/webserver-auth-sidecar-configmap.yaml
+++ b/templates/webserver/webserver-auth-sidecar-configmap.yaml
@@ -23,7 +23,7 @@ data:
       }
     http {
       upstream astro-webserver {
-        server localhost:{{ .Values.airflow.ports.airflowUI }} ;
+        server 127.0.0.1:{{ .Values.airflow.ports.airflowUI }} ;
       }
       server {
         server_name {{ .Release.Name }}.{{ .Values.ingress.baseDomain }} ;


### PR DESCRIPTION
## Description

update localhost upstream host to default ipv4 for authsidecar 

## Related Issues

https://github.com/astronomer/issues/issues/6547

## Testing

QA should not see any connection error stating ipv6 config

## Merging

cherry-pick to release-1.10, release-1.11
