### PR TITLE
Update ap-vendor packages 

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -32,13 +32,13 @@ airflow:
       tag: 0.26.1
     redis:
       repository: quay.io/astronomer/ap-redis
-      tag: 6.2.14
+      tag: 7.2.5
     pgbouncer:
       repository: quay.io/astronomer/ap-pgbouncer
-      tag: 1.21.0
+      tag: 1.23.1-1
     pgbouncerExporter:
       repository: quay.io/astronomer/ap-pgbouncer-exporter
-      tag: 0.15.0-9
+      tag: 0.15.0-10
     gitSync:
       repository: quay.io/astronomer/ap-git-sync
       tag: 3.6.9
@@ -589,10 +589,10 @@ gitSyncRelay:
   images:
     gitDaemon:
       repository: "quay.io/astronomer/ap-git-daemon"
-      tag: "3.18.7-1"
+      tag: "3.18.8"
     gitSync:
       repository: "quay.io/astronomer/ap-git-sync-relay"
-      tag: "0.0.3-4"
+      tag: "0.0.3-5"
   repo:
     url: ~
     branch: main


### PR DESCRIPTION
## Description

Image Name |  Old-tag|  New-tag 
-- | -- | -- 
ap-redis | 6.2.14 | 7.2.5
ap-pgbouncer | 1.21.0 | 1.23.1-1
ap-pgbouncer-exporter|  0.15.0-9 | 0.15.0-10
ap-git-daemon |3.18.7-1 | 3.18.8
ap-git-sync-relay | 0.0.3-4 |0.0.3-5

## Related Issues
https://github.com/astronomer/issues/issues/6557

## Testing



## Merging

