### PR TITLE
add airflow downgrade config to vector sidecar configuration list

### DIFF
--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -74,6 +74,14 @@ data:
           type: "vrl"
           source: 'includes(["dag-server"], .component)'
 
+      filter_airflow_downgrade_logs:
+        type: filter
+        inputs:
+          - transform_airflow_logs
+        condition:
+          type: "vrl"
+          source: 'includes(["airflow-downgrade"], .component)'
+
       transform_task_log:
         type: remap
         inputs:
@@ -105,6 +113,7 @@ data:
           - filter_common_logs
           - filter_gitsyncrelay_logs
           - filter_dagserver_logs
+          - filter_airflow_downgrade_logs
         source: |
           del(.host)
           del(.file)


### PR DESCRIPTION
## Description

This PR adds support for airflow downgrade pod logs to logging server from our sidecar based mechanism

## Related Issues

https://github.com/astronomer/issues/issues/6401

## Testing

QA should able to view logs in astro-ui 

## Merging

cherry-pick to release-1.11
