### PR TITLE
update upstream airflow helm chart

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: airflow
-  repository: https://github.com/astronomer/airflow/releases/download/oss-helm-chart/1.11.1-astro
-  version: 1.11.1-astro
-digest: sha256:6d7c55a8e643d3e50723187c70177ec8baa8610a4b27f430a28805afaaf7a05f
-generated: "2023-12-06T11:30:00.49718-05:00"
+  repository: https://airflow.apache.org
+  version: 1.11.0
+digest: sha256:53b083811a0d9129833f7f6a5047b4fe73084611850c1327063ebd93fa54b7ba
+generated: "2024-09-05T13:28:33.996621+05:30"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -9,5 +9,5 @@ keywords:
   - airflow
 dependencies:
   - name: airflow
-    version: 1.11.1-astro
-    repository: https://github.com/astronomer/airflow/releases/download/oss-helm-chart/1.11.1-astro
+    version: 1.11.0
+    repository: https://airflow.apache.org

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v2 is Helm 3
 apiVersion: v2
 name: airflow
-version: 1.11.5
+version: 1.11.6
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:


### PR DESCRIPTION
## Description

sync astronomer airflow chart to upstream oss chart 1.11.0 to bring new features 
fore more feature info check below link
https://airflow.apache.org/docs/helm-chart/stable/release_notes.html#airflow-helm-chart-1-11-0-2023-10-02

## Related Issues

https://github.com/astronomer/issues/issues/6593

## Testing

QA should validate all regular chart features

## Merging

cherry-pick to 1.10 and 1.11
