### PR TITLE
Add Beyoncé Rule tests for OSS airflow chart strategy

### DIFF
--- a/tests/chart/test_airflow_scheduler.py
+++ b/tests/chart/test_airflow_scheduler.py
@@ -1,0 +1,31 @@
+# Beyoncé Rule tests for OSS airflow scheduler behaviors
+
+import pytest
+
+from tests.chart.helm_template_generator import render_chart
+
+from .. import supported_k8s_versions
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+class TestAirflowScheduler:
+    def test_scheduler_defaults(self, kube_version):
+        """Test default behaviors of the scheduler that we rely on."""
+        docs = render_chart(kube_version=kube_version, show_only=["charts/airflow/templates/scheduler/scheduler-deployment.yaml"])
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "Deployment"
+        assert doc["spec"]["strategy"] == {"type": "Recreate"}
+
+    def test_scheduler_customizations(self, kube_version):
+        """Test custom behaviors of the scheduler that we rely on."""
+        values = {"airflow": {"scheduler": {"strategy": {"type": "RollingUpdate"}}}}
+        docs = render_chart(
+            kube_version=kube_version, show_only=["charts/airflow/templates/scheduler/scheduler-deployment.yaml"], values=values
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "Deployment"
+        assert doc["spec"]["strategy"] == {"type": "RollingUpdate"}


### PR DESCRIPTION
## Description

Add some Beyoncé Rule tests for the OSS airflow chart's scheduler.

## Related Issues

https://github.com/astronomer/issues/issues/6628

## Testing

No testing needed. These are just test additions to ensure that this behavior works as expected now and in the future.

## Merging

Merge everywhere.