### PR TITLE
sync OSS chart 1.13.x pod template to astronomer airflow chart

### DIFF
--- a/tests/chart/test_pod_template.py
+++ b/tests/chart/test_pod_template.py
@@ -5,6 +5,13 @@ from tests.chart.helm_template_generator import render_chart
 from .. import supported_k8s_versions
 
 
+def common_pod_template_test(docs):
+    """Test common asserts for pod template pod spec."""
+    assert len(docs) == 1
+    doc = docs[0]
+    assert doc["kind"] == "ConfigMap"
+
+
 @pytest.mark.parametrize("kube_version", supported_k8s_versions)
 class TestPodTemplate:
     def test_pod_template_defaults(self, kube_version):
@@ -14,9 +21,8 @@ class TestPodTemplate:
             values={},
             show_only="charts/airflow/templates/configmaps/configmap.yaml",
         )
-        assert len(docs) == 1
+        common_pod_template_test(docs)
         doc = docs[0]
-        assert doc["kind"] == "ConfigMap"
         podTemplate = yaml.safe_load(doc["data"]["pod_template_file.yaml"])
         assert {"tier": "airflow", "component": "worker", "release": "release-name"} == podTemplate["metadata"]["labels"]
 
@@ -32,10 +38,42 @@ class TestPodTemplate:
             },
             show_only="charts/airflow/templates/configmaps/configmap.yaml",
         )
-        assert len(docs) == 1
+        common_pod_template_test(docs)
         doc = docs[0]
-        assert doc["kind"] == "ConfigMap"
         podTemplate = yaml.safe_load(doc["data"]["pod_template_file.yaml"])
-        assert {"tier": "airflow", "component": "worker", "release": "release-name", "service": "airflow", "servicetype": "workers"} == podTemplate[
-            "metadata"
-        ]["labels"]
+        assert {
+            "tier": "airflow",
+            "component": "worker",
+            "release": "release-name",
+            "service": "airflow",
+            "servicetype": "workers",
+        } == podTemplate["metadata"]["labels"]
+
+    def test_pod_template_pod_annotation_defaults(self, kube_version):
+        """Test airflow pod template labels overrides."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={},
+            show_only="charts/airflow/templates/configmaps/configmap.yaml",
+        )
+        common_pod_template_test(docs)
+        doc = docs[0]
+        podTemplate = yaml.safe_load(doc["data"]["pod_template_file.yaml"])
+        assert "annotations" not in podTemplate["metadata"]
+
+    def test_pod_template_pod_annotation_overrides(self, kube_version):
+        """Test airflow pod template labels overrides."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "airflow": {
+                    "airflowPodAnnotations": {"app.kubernetes.io": "airflow"},
+                    "workers": {"podAnnotations": {"app.worker.kubernetes.io": "workers"}},
+                }
+            },
+            show_only="charts/airflow/templates/configmaps/configmap.yaml",
+        )
+        common_pod_template_test(docs)
+        doc = docs[0]
+        podTemplate = yaml.safe_load(doc["data"]["pod_template_file.yaml"])
+        assert {"app.kubernetes.io": "airflow", "app.worker.kubernetes.io": "workers"} == podTemplate["metadata"]["annotations"]

--- a/tests/chart/test_pod_template.py
+++ b/tests/chart/test_pod_template.py
@@ -25,6 +25,8 @@ class TestPodTemplate:
         doc = docs[0]
         podTemplate = yaml.safe_load(doc["data"]["pod_template_file.yaml"])
         assert {"tier": "airflow", "component": "worker", "release": "release-name"} == podTemplate["metadata"]["labels"]
+        assert "runtimeClassName" not in podTemplate["spec"]
+        assert "priorityClassName" not in podTemplate["spec"]
 
     def test_pod_template_labels_overrides(self, kube_version):
         """Test airflow pod template labels overrides."""
@@ -77,3 +79,35 @@ class TestPodTemplate:
         doc = docs[0]
         podTemplate = yaml.safe_load(doc["data"]["pod_template_file.yaml"])
         assert {"app.kubernetes.io": "airflow", "app.worker.kubernetes.io": "workers"} == podTemplate["metadata"]["annotations"]
+
+    def test_pod_template_pod_priority_class_name_overrides(self, kube_version):
+        """Test airflow pod template labels overrides."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "airflow": {
+                    "workers": {"priorityClassName": "criticalworkload"},
+                }
+            },
+            show_only="charts/airflow/templates/configmaps/configmap.yaml",
+        )
+        common_pod_template_test(docs)
+        doc = docs[0]
+        podTemplate = yaml.safe_load(doc["data"]["pod_template_file.yaml"])
+        assert "criticalworkload" == podTemplate["spec"]["priorityClassName"]
+
+    def test_pod_template_pod_runtime_class_name_overrides(self, kube_version):
+        """Test airflow pod template labels overrides."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "airflow": {
+                    "workers": {"runtimeClassName": "criticalworkload"},
+                }
+            },
+            show_only="charts/airflow/templates/configmaps/configmap.yaml",
+        )
+        common_pod_template_test(docs)
+        doc = docs[0]
+        podTemplate = yaml.safe_load(doc["data"]["pod_template_file.yaml"])
+        assert "criticalworkload" == podTemplate["spec"]["runtimeClassName"]

--- a/tests/chart/test_pod_template.py
+++ b/tests/chart/test_pod_template.py
@@ -1,0 +1,21 @@
+import pytest
+import yaml
+from tests.chart.helm_template_generator import render_chart
+
+from .. import supported_k8s_versions
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+class TestPodTemplate:
+    def test_pod_template_defaults(self, kube_version):
+        """Test airflow pod template defaults."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={},
+            show_only="charts/airflow/templates/configmaps/configmap.yaml",
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "ConfigMap"
+        podTemplate = yaml.safe_load(doc["data"]["pod_template_file.yaml"])
+        assert {"tier": "airflow", "component": "worker", "release": "release-name"} == podTemplate["metadata"]["labels"]

--- a/tests/chart/test_pod_template.py
+++ b/tests/chart/test_pod_template.py
@@ -19,3 +19,23 @@ class TestPodTemplate:
         assert doc["kind"] == "ConfigMap"
         podTemplate = yaml.safe_load(doc["data"]["pod_template_file.yaml"])
         assert {"tier": "airflow", "component": "worker", "release": "release-name"} == podTemplate["metadata"]["labels"]
+
+    def test_pod_template_labels_overrides(self, kube_version):
+        """Test airflow pod template labels overrides."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "airflow": {
+                    "labels": {"service": "airflow"},
+                    "workers": {"labels": {"servicetype": "workers"}},
+                }
+            },
+            show_only="charts/airflow/templates/configmaps/configmap.yaml",
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "ConfigMap"
+        podTemplate = yaml.safe_load(doc["data"]["pod_template_file.yaml"])
+        assert {"tier": "airflow", "component": "worker", "release": "release-name", "service": "airflow", "servicetype": "workers"} == podTemplate[
+            "metadata"
+        ]["labels"]

--- a/values.yaml
+++ b/values.yaml
@@ -209,12 +209,17 @@ airflow:
         tier: airflow
         component: worker
         release: {{ .Release.Name }}
-    {{- with .Values.labels }}
-    {{ toYaml . | indent 4 }}
+    {{- if or (.Values.labels) (.Values.workers.labels) }}
+      {{- mustMerge .Values.workers.labels .Values.labels | toYaml | nindent 4 }}
     {{- end }}
-      {{- if .Values.airflowPodAnnotations }}
+      {{- if or .Values.airflowPodAnnotations .Values.workers.podAnnotations }}
       annotations:
-      {{- toYaml .Values.airflowPodAnnotations | nindent 4 }}
+        {{- if .Values.airflowPodAnnotations }}
+          {{- toYaml .Values.airflowPodAnnotations | nindent 4 }}
+        {{- end }}
+        {{- if .Values.workers.podAnnotations }}
+          {{- toYaml .Values.workers.podAnnotations | nindent 4 }}
+        {{- end }}
       {{- end }}
     spec:
       {{- if or (and .Values.dags.gitSync.enabled (not .Values.dags.persistence.enabled)) .Values.workers.extraInitContainers }}

--- a/values.yaml
+++ b/values.yaml
@@ -268,6 +268,15 @@ airflow:
     {{- toYaml .Values.workers.extraContainers | nindent 4 }}
     {{- end }}
       hostNetwork: false
+      {{- if .Values.workers.priorityClassName }}
+      priorityClassName: {{ .Values.workers.priorityClassName }}
+      {{- end }}
+      {{- if .Values.workers.runtimeClassName }}
+      runtimeClassName: {{ .Values.workers.runtimeClassName }}
+      {{- end }}
+      {{- if .Values.workers.hostAliases }}
+      hostAliases: {{- toYaml .Values.workers.hostAliases | nindent 4 }}
+      {{- end }}
       {{- if or .Values.registry.secretName .Values.registry.connection }}
       imagePullSecrets:
         - name: {{ template "registry_secret" . }}


### PR DESCRIPTION

## Description

currently our pod spec template is out of sync with oss airflow chart changes which seems quite outdated and lacks couple of component specific features , this PR brings back the features to our managed pod_template to keep up to date

**what changes are mapped here**

till now only global labels and pod annotations are respected with this new change will now repsect worker specific labels as well

## Related Issues
https://github.com/astronomer/issues/issues/6650
https://github.com/astronomer/issues/issues/6593
https://github.com/astronomer/issues/issues/6594

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

cherry-pick to all valid airflow chart releases
