### PR TITLE
Add dag server improvements, update some other components

### DIFF
--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -129,17 +129,20 @@ proxy_ssl_server_name       on;
 proxy_pass_request_headers  on;
 {{ end }}
 
-{{ define "default_nginx_settings_location" }}
-auth_request     /auth;
-auth_request_set $auth_status $upstream_status;
-auth_request_set $auth_cookie $upstream_http_set_cookie;
-add_header       Set-Cookie $auth_cookie;
+{{ define "default_nginx_auth_headers" }}
 auth_request_set $authHeader0 $upstream_http_authorization;
 proxy_set_header 'authorization' $authHeader0;
 auth_request_set $authHeader1 $upstream_http_username;
 proxy_set_header 'username' $authHeader1;
 auth_request_set $authHeader2 $upstream_http_email;
 proxy_set_header 'email' $authHeader2;
+{{ end }}
+
+{{ define "default_nginx_settings_location" }}
+auth_request     /auth;
+auth_request_set $auth_status $upstream_status;
+auth_request_set $auth_cookie $upstream_http_set_cookie;
+add_header       Set-Cookie $auth_cookie;
 error_page 401 = @401_auth_error;
 proxy_set_header Upgrade $http_upgrade;
 proxy_set_header Connection 'connection_upgrade';

--- a/templates/dag-deploy/dag-server-statefulset.yaml
+++ b/templates/dag-deploy/dag-server-statefulset.yaml
@@ -53,6 +53,8 @@ spec:
           resources:
             {{- toYaml .Values.dagDeploy.resources | nindent 12 }}
           env:
+          - name: HOUSTON_SERVICE_ENDPOINT
+            value: "http://{{ .Values.platform.release }}-houston.{{ .Values.platform.namespace }}.svc.cluster.local.:8871/v1/"
 {{- if .Values.dagDeploy.extraEnv }}
 {{ toYaml .Values.dagDeploy.extraEnv | indent 10 }}
 {{- end }}

--- a/templates/flower/flower-auth-sidecar-configmap.yaml
+++ b/templates/flower/flower-auth-sidecar-configmap.yaml
@@ -23,7 +23,7 @@ data:
       }
     http {
       upstream astro-flower {
-        server localhost:{{ .Values.airflow.ports.flowerUI }} ;
+        server 127.0.0.1:{{ .Values.airflow.ports.flowerUI }} ;
       }
       server {
         server_name {{ .Release.Name }}-flower.{{ .Values.ingress.baseDomain }} ;

--- a/templates/flower/flower-auth-sidecar-configmap.yaml
+++ b/templates/flower/flower-auth-sidecar-configmap.yaml
@@ -43,6 +43,7 @@ data:
 
         location ~* "^/{{ .Release.Name }}/flower(/|$)(.*)"  {
 {{ include "default_nginx_settings_location" . | indent 8  }}
+{{ include "default_nginx_auth_headers" . | indent 8 }}
 
           if ($host = '{{ .Values.platform.release }}-flower.{{ .Values.ingress.baseDomain }}' ) {
             rewrite ^ https://deployments.{{ .Values.ingress.baseDomain }}/{{ .Release.Name }}/flower permanent;

--- a/templates/webserver/webserver-auth-sidecar-configmap.yaml
+++ b/templates/webserver/webserver-auth-sidecar-configmap.yaml
@@ -49,7 +49,7 @@ data:
 
         location / {
 {{ include "default_nginx_settings_location" . | indent 8  }}
-
+{{ include "default_nginx_auth_headers" . | indent 8 }}
 
           #proxy_set_header X-Original-URI        $request_uri;
           if ($host = '{{ .Values.platform.release }}-airflow.{{ .Values.ingress.baseDomain }}' ) {

--- a/templates/webserver/webserver-auth-sidecar-configmap.yaml
+++ b/templates/webserver/webserver-auth-sidecar-configmap.yaml
@@ -23,7 +23,7 @@ data:
       }
     http {
       upstream astro-webserver {
-        server localhost:{{ .Values.airflow.ports.airflowUI }} ;
+        server 127.0.0.1:{{ .Values.airflow.ports.airflowUI }} ;
       }
       server {
         server_name {{ .Release.Name }}.{{ .Values.ingress.baseDomain }} ;

--- a/tests/chart/test_dag_server_statefulset.py
+++ b/tests/chart/test_dag_server_statefulset.py
@@ -20,12 +20,8 @@ def common_default_tests(doc):
         "-H",
         "0.0.0.0",
     ]
-    assert c_by_name["dag-server"]["image"].startswith(
-        "quay.io/astronomer/ap-dag-deploy:"
-    )
-    assert c_by_name["dag-server"]["image"].startswith(
-        "quay.io/astronomer/ap-dag-deploy:"
-    )
+    assert c_by_name["dag-server"]["image"].startswith("quay.io/astronomer/ap-dag-deploy:")
+    assert c_by_name["dag-server"]["image"].startswith("quay.io/astronomer/ap-dag-deploy:")
     assert c_by_name["dag-server"]["livenessProbe"]
 
 
@@ -56,14 +52,9 @@ class TestDagServerStatefulSet:
         c_by_name = get_containers_by_name(doc)
 
         env_vars = {x["name"]: x["value"] for x in c_by_name["dag-server"]["env"]}
-        assert (
-            env_vars["HOUSTON_SERVICE_ENDPOINT"]
-            == "http://-houston..svc.cluster.local.:8871/v1/"
-        )
+        assert env_vars["HOUSTON_SERVICE_ENDPOINT"] == "http://-houston..svc.cluster.local.:8871/v1/"
 
-    def test_dag_server_statefulset_houston_service_endpoint_override(
-        self, kube_version
-    ):
+    def test_dag_server_statefulset_houston_service_endpoint_override(self, kube_version):
         """Test that we see the right HOUSTON_SERVICE_ENDPOINT value when the relevant variables are set."""
         values = {
             "dagDeploy": {"enabled": True},
@@ -83,10 +74,7 @@ class TestDagServerStatefulSet:
         c_by_name = get_containers_by_name(doc)
 
         env_vars = {x["name"]: x["value"] for x in c_by_name["dag-server"]["env"]}
-        assert (
-            env_vars["HOUSTON_SERVICE_ENDPOINT"]
-            == "http://test-release-houston.test-namespace.svc.cluster.local.:8871/v1/"
-        )
+        assert env_vars["HOUSTON_SERVICE_ENDPOINT"] == "http://test-release-houston.test-namespace.svc.cluster.local.:8871/v1/"
 
     def test_dag_server_statefulset_with_resource_overrides(self, kube_version):
         """Test that Dag Server statefulset are configurable with custom resource limits."""

--- a/tests/chart/test_dag_server_statefulset.py
+++ b/tests/chart/test_dag_server_statefulset.py
@@ -6,6 +6,29 @@ from .. import supported_k8s_versions
 from . import get_containers_by_name
 
 
+def common_default_tests(doc):
+    """Test cases for default dag-server sts enabled"""
+
+    assert doc["kind"] == "StatefulSet"
+    assert doc["apiVersion"] == "apps/v1"
+    assert doc["metadata"]["name"] == "release-name-dag-server"
+    c_by_name = get_containers_by_name(doc)
+    assert len(c_by_name) == 1
+    assert c_by_name["dag-server"]["command"] == [
+        "sanic",
+        "dag_deploy.server.app",
+        "-H",
+        "0.0.0.0",
+    ]
+    assert c_by_name["dag-server"]["image"].startswith(
+        "quay.io/astronomer/ap-dag-deploy:"
+    )
+    assert c_by_name["dag-server"]["image"].startswith(
+        "quay.io/astronomer/ap-dag-deploy:"
+    )
+    assert c_by_name["dag-server"]["livenessProbe"]
+
+
 @pytest.mark.parametrize("kube_version", supported_k8s_versions)
 class TestDagServerStatefulSet:
     def test_dag_server_statefulset_default(self, kube_version):
@@ -27,20 +50,43 @@ class TestDagServerStatefulSet:
         )
         assert len(docs) == 1
         doc = docs[0]
-        assert doc["kind"] == "StatefulSet"
-        assert doc["apiVersion"] == "apps/v1"
-        assert doc["metadata"]["name"] == "release-name-dag-server"
+
+        common_default_tests(doc)
+
         c_by_name = get_containers_by_name(doc)
-        assert len(c_by_name) == 1
-        assert c_by_name["dag-server"]["command"] == [
-            "sanic",
-            "dag_deploy.server.app",
-            "-H",
-            "0.0.0.0",
-        ]
-        assert c_by_name["dag-server"]["image"].startswith("quay.io/astronomer/ap-dag-deploy:")
-        assert c_by_name["dag-server"]["image"].startswith("quay.io/astronomer/ap-dag-deploy:")
-        assert c_by_name["dag-server"]["livenessProbe"]
+
+        env_vars = {x["name"]: x["value"] for x in c_by_name["dag-server"]["env"]}
+        assert (
+            env_vars["HOUSTON_SERVICE_ENDPOINT"]
+            == "http://-houston..svc.cluster.local.:8871/v1/"
+        )
+
+    def test_dag_server_statefulset_houston_service_endpoint_override(
+        self, kube_version
+    ):
+        """Test that we see the right HOUSTON_SERVICE_ENDPOINT value when the relevant variables are set."""
+        values = {
+            "dagDeploy": {"enabled": True},
+            "platform": {"release": "test-release", "namespace": "test-namespace"},
+        }
+
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/dag-deploy/dag-server-statefulset.yaml",
+            values=values,
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+
+        common_default_tests(doc)
+
+        c_by_name = get_containers_by_name(doc)
+
+        env_vars = {x["name"]: x["value"] for x in c_by_name["dag-server"]["env"]}
+        assert (
+            env_vars["HOUSTON_SERVICE_ENDPOINT"]
+            == "http://test-release-houston.test-namespace.svc.cluster.local.:8871/v1/"
+        )
 
     def test_dag_server_statefulset_with_resource_overrides(self, kube_version):
         """Test that Dag Server statefulset are configurable with custom resource limits."""
@@ -62,9 +108,9 @@ class TestDagServerStatefulSet:
         )
         assert len(docs) == 1
         doc = docs[0]
-        assert doc["kind"] == "StatefulSet"
-        assert doc["apiVersion"] == "apps/v1"
-        assert doc["metadata"]["name"] == "release-name-dag-server"
+
+        common_default_tests(doc)
+
         c_by_name = get_containers_by_name(doc)
         assert c_by_name["dag-server"]["resources"] == resources
 
@@ -80,9 +126,9 @@ class TestDagServerStatefulSet:
         )
         assert len(docs) == 1
         doc = docs[0]
-        assert doc["kind"] == "StatefulSet"
-        assert doc["apiVersion"] == "apps/v1"
-        assert doc["metadata"]["name"] == "release-name-dag-server"
+
+        common_default_tests(doc)
+
         assert dag_serversecuritycontext == doc["spec"]["template"]["spec"]["securityContext"]
 
     def test_dag_server_statefulset_with_custom_registry_secret(self, kube_version):
@@ -99,7 +145,7 @@ class TestDagServerStatefulSet:
         )
         assert len(docs) == 1
         doc = docs[0]
-        assert doc["kind"] == "StatefulSet"
-        assert doc["apiVersion"] == "apps/v1"
-        assert doc["metadata"]["name"] == "release-name-dag-server"
+
+        common_default_tests(doc)
+
         assert [{"name": "gscsecret"}] == doc["spec"]["template"]["spec"]["imagePullSecrets"]

--- a/tests/chart/test_data/dag-server-authsidecar-nginx.conf
+++ b/tests/chart/test_data/dag-server-authsidecar-nginx.conf
@@ -52,12 +52,6 @@ http {
     auth_request_set $auth_status $upstream_status;
     auth_request_set $auth_cookie $upstream_http_set_cookie;
     add_header       Set-Cookie $auth_cookie;
-    auth_request_set $authHeader0 $upstream_http_authorization;
-    proxy_set_header 'authorization' $authHeader0;
-    auth_request_set $authHeader1 $upstream_http_username;
-    proxy_set_header 'username' $authHeader1;
-    auth_request_set $authHeader2 $upstream_http_email;
-    proxy_set_header 'email' $authHeader2;
     error_page 401 = @401_auth_error;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection 'connection_upgrade';

--- a/tests/chart/test_ingress.py
+++ b/tests/chart/test_ingress.py
@@ -80,10 +80,7 @@ class TestIngress:
 
         assert docs[1]["metadata"]["name"] == "release-name-dag-server-ingress"
         rule_0 = docs[1]["spec"]["rules"][0]
-        assert (
-            rule_0["http"]["paths"][0]["path"]
-            == "/release-name/dags/(upload|download)(/.*)?"
-        )
+        assert rule_0["http"]["paths"][0]["path"] == "/release-name/dags/(upload|download)(/.*)?"
         assert rule_0["host"] == "deployments.example.com"
 
         assert ingressAnnotation == docs[1]["metadata"]["annotations"]

--- a/tests/chart/test_ingress.py
+++ b/tests/chart/test_ingress.py
@@ -58,3 +58,32 @@ class TestIngress:
         rule_0 = docs[0]["spec"]["rules"][0]
         assert rule_0["http"]["paths"][0]["path"] == "/release-name/dags/(upload|download)(/.*)?"
         assert rule_0["host"] == "deployments.example.com"
+
+    def test_airflow_ingress_with_dag_server_ingress_annotation(self, kube_version):
+        """Test airflow ingress with DagServer."""
+
+        ingressAnnotation = {"kubernetes.io/ingress.class": "default"}
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/ingress.yaml",
+            values={
+                "ingress": {
+                    "enabled": True,
+                    "baseDomain": "example.com",
+                    "dagServerAnnotations": ingressAnnotation,
+                },
+                "dagDeploy": {"enabled": True},
+            },
+        )
+
+        assert len(docs) == 2
+
+        assert docs[1]["metadata"]["name"] == "release-name-dag-server-ingress"
+        rule_0 = docs[1]["spec"]["rules"][0]
+        assert (
+            rule_0["http"]["paths"][0]["path"]
+            == "/release-name/dags/(upload|download)(/.*)?"
+        )
+        assert rule_0["host"] == "deployments.example.com"
+
+        assert ingressAnnotation == docs[1]["metadata"]["annotations"]

--- a/values.yaml
+++ b/values.yaml
@@ -29,7 +29,7 @@ airflow:
       tag: ~
     statsd:
       repository: quay.io/astronomer/ap-statsd-exporter
-      tag: 0.26.1
+      tag: 0.27.1
     redis:
       repository: quay.io/astronomer/ap-redis
       tag: 6.2.14

--- a/values.yaml
+++ b/values.yaml
@@ -32,13 +32,13 @@ airflow:
       tag: 0.27.1
     redis:
       repository: quay.io/astronomer/ap-redis
-      tag: 6.2.14
+      tag: 7.2.5
     pgbouncer:
       repository: quay.io/astronomer/ap-pgbouncer
-      tag: 1.21.0
+      tag: 1.23.1-1
     pgbouncerExporter:
       repository: quay.io/astronomer/ap-pgbouncer-exporter
-      tag: 0.15.0-9
+      tag: 0.15.0-10
     gitSync:
       repository: quay.io/astronomer/ap-git-sync
       tag: 3.6.9
@@ -588,10 +588,10 @@ gitSyncRelay:
   images:
     gitDaemon:
       repository: "quay.io/astronomer/ap-git-daemon"
-      tag: "3.18.7-1"
+      tag: "3.18.8"
     gitSync:
       repository: "quay.io/astronomer/ap-git-sync-relay"
-      tag: "0.0.3-4"
+      tag: "0.0.3-5"
   repo:
     url: ~
     branch: main

--- a/values.yaml
+++ b/values.yaml
@@ -475,7 +475,7 @@ extraObjects: []
 authSidecar:
   enabled: false
   repository: quay.io/astronomer/ap-auth-sidecar
-  tag: 1.25.5
+  tag: 1.27.1
   pullPolicy: IfNotPresent
   port: 8084
   securityContext: {}
@@ -543,7 +543,7 @@ dagDeploy:
   images:
     dagServer:
       repository: quay.io/astronomer/ap-dag-deploy
-      tag: 0.3.2
+      tag: 0.3.5
       imagePullPolicy: IfNotPresent
   livenessProbe:
     initialDelaySeconds: 30

--- a/values.yaml
+++ b/values.yaml
@@ -507,7 +507,7 @@ ingress:
   flowerAnnotations: {}
 
   # Annotations always injected when configuring Dag Server Ingress object
-  dagDeployAnnotations: {}
+  dagServerAnnotations: {}
 
   # Base domain for ingress vhosts
   baseDomain: ~

--- a/values.yaml
+++ b/values.yaml
@@ -530,6 +530,7 @@ ingress:
 # what namespace astronomer is running in.
 platform:
   release: ~
+  namespace: ~
 
 astronomer:
   images:


### PR DESCRIPTION
## Description

This PR cherry-pick some of the major enhancements enabled in dag server service
* implements auth model for dag server service which requires auth sidecar enhancements ( removal of certain nginx headers from the nginx template)

* implements HOUSTON URL env in dag server statefulset to be used internally for connecting local endpoints
* CVE backports 


## Related Issues

related https://github.com/astronomer/issues/issues/6459
related https://github.com/astronomer/issues/issues/6547
related https://github.com/astronomer/issues/issues/6383
related https://github.com/astronomer/issues/issues/6374
related https://github.com/astronomer/issues/issues/5623
related https://github.com/astronomer/issues/issues/6696

CVE fixes
related https://github.com/astronomer/issues/issues/6557
related https://github.com/astronomer/issues/issues/6557
related https://github.com/astronomer/issues/issues/6500


## Testing

QA should able to validated above changes

## Merging

cherry-pick to release-1.10
