### PR TITLE
update astronome airflow chart with custom forked airflow chart

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: airflow
-  repository: https://github.com/astronomer/airflow/releases/download/oss-helm-chart/1.13.1
-  version: 1.13.1
-digest: sha256:45f1d9aabbcbe6893a85e50ed324aa553096c67ea045bc1cf550f02514c41721
-generated: "2024-10-15T13:06:11.685006+05:30"
+  repository: https://github.com/astronomer/airflow/releases/download/oss-helm-chart/1.13.1-astro
+  version: 1.13.1-astro
+digest: sha256:102879a4aae75223b65ccf123abdbfbd9603b69eec9553a04fbbe34ba4f171cd
+generated: "2024-10-24T23:39:10.197288+05:30"

--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: airflow
-  repository: https://airflow.apache.org
+  repository: https://github.com/astronomer/airflow/releases/download/oss-helm-chart/1.13.1
   version: 1.13.1
-digest: sha256:9e0977d38102669dc54d2b4ca78431ea1373e089746dfd07de4c1ab1fac05d40
-generated: "2024-09-17T19:37:36.788661+05:30"
+digest: sha256:45f1d9aabbcbe6893a85e50ed324aa553096c67ea045bc1cf550f02514c41721
+generated: "2024-10-15T13:06:11.685006+05:30"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v2 is Helm 3
 apiVersion: v2
 name: airflow
-version: 1.13.2
+version: 1.13.3
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:
@@ -10,4 +10,4 @@ keywords:
 dependencies:
   - name: airflow
     version: 1.13.1
-    repository: https://airflow.apache.org
+    repository: https://github.com/astronomer/airflow/releases/download/oss-helm-chart/1.13.1

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -9,5 +9,5 @@ keywords:
   - airflow
 dependencies:
   - name: airflow
-    version: 1.13.1
-    repository: https://github.com/astronomer/airflow/releases/download/oss-helm-chart/1.13.1
+    version: 1.13.1-astro
+    repository: https://github.com/astronomer/airflow/releases/download/oss-helm-chart/1.13.1-astro

--- a/tests/chart/test_airflow.py
+++ b/tests/chart/test_airflow.py
@@ -25,7 +25,7 @@ class TestAirflow:
         """Test custom behaviors of the scheduler that we rely on."""
         env = {"name": "ENABLE_AUTH_TYPE", "value": "SHA256"}
         values = {
-            "airflow":{
+            "airflow": {
                 "migrateDatabaseJob": {
                     "env": [env],
                 }

--- a/tests/chart/test_airflow.py
+++ b/tests/chart/test_airflow.py
@@ -1,0 +1,41 @@
+# Beyoncé Rule tests for OSS airflow scheduler behaviors
+
+import pytest
+
+from tests.chart.helm_template_generator import render_chart
+
+from .. import supported_k8s_versions
+from . import get_containers_by_name
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+class TestAirflow:
+
+    def test_migrate_database_job_defaults(self, kube_version):
+        """Test custom behaviors of the scheduler that we rely on."""
+        docs = render_chart(
+            kube_version=kube_version, show_only=["charts/airflow/templates/jobs/migrate-database-job.yaml"], values={}
+        )
+
+        assert len(docs) == 1
+        c_by_name = get_containers_by_name(docs[0])
+        assert {"name": "PYTHONUNBUFFERED", "value": "1"} in c_by_name["run-airflow-migrations"]["env"]
+
+    def test_migrate_database_job_overrides(self, kube_version):
+        """Test custom behaviors of the scheduler that we rely on."""
+        env = {"name": "ENABLE_AUTH_TYPE", "value": "SHA256"}
+        values = {
+            "airflow":{
+                "migrateDatabaseJob": {
+                    "env": [env],
+                }
+            }
+        }
+        docs = render_chart(
+            kube_version=kube_version, show_only=["charts/airflow/templates/jobs/migrate-database-job.yaml"], values=values
+        )
+
+        assert len(docs) == 1
+        c_by_name = get_containers_by_name(docs[0])
+        assert {"name": "PYTHONUNBUFFERED", "value": "1"} in c_by_name["run-airflow-migrations"]["env"]
+        assert {"name": "ENABLE_AUTH_TYPE", "value": "SHA256"} in c_by_name["run-airflow-migrations"]["env"]


### PR DESCRIPTION
## Description

This PR points back to custom fork version from 1.13.1 of oss chart to add support to pass custom env vars to migrate database job 

## Related Issues

- https://github.com/astronomer/issues/issues/6646
- related oss PR https://github.com/apache/airflow/pull/42345

## Testing

NA

## Merging

cherry-pick to 1.13
