### PR TITLE
remove authsidecar tls secret hard codings

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -96,13 +96,13 @@ metadata:
   {{- end }}
 spec:
   tls:
-          {{- if .Values.ingress.acme }}
+  {{- if .Values.ingress.acme }}
     - secretName: {{ .Release.Name }}-airflow-tls
-          {{- else if .Values.ingress.tlsSecretName }}
+  {{- else if .Values.ingress.tlsSecretName }}
     - secretName: {{ .Values.ingress.tlsSecretName }}
-          {{ else }}
+  {{ else }}
     - secretName: ~
-            {{- end }}
+  {{- end }}
       hosts:
         - {{- include "deployments_subdomain" . | indent 1 }}
         - {{- include "flower_subdomain" . | indent 1 }}
@@ -170,12 +170,13 @@ metadata:
   {{- end }}
 spec:
   tls:
-          {{- if .Values.ingress.acme }}
+  {{- if .Values.ingress.acme }}
     - secretName: {{ .Release.Name }}-airflow-tls
-          {{- else if .Values.ingress.tlsSecretName }}
+  {{- else if .Values.ingress.tlsSecretName }}
     - secretName: {{ .Values.ingress.tlsSecretName }}
+  {{ else }}
     - secretName: ~
-            {{- end }}
+  {{- end }}
       hosts:
         - {{- include "deployments_subdomain" . | indent 1 }}
   rules:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -32,9 +32,6 @@ spec:
     - secretName: {{ .Release.Name }}-airflow-tls
   {{- else if .Values.ingress.tlsSecretName }}
     - secretName: {{ .Values.ingress.tlsSecretName }}
-  # this option to be relooked, for the sake of POC we have hardcoded
-  {{- else if .Values.authSidecar.enabled  }}
-    - secretName: astronomer-tls
   {{ else }}
     - secretName: ~
   {{- end }}
@@ -103,8 +100,6 @@ spec:
     - secretName: {{ .Release.Name }}-airflow-tls
           {{- else if .Values.ingress.tlsSecretName }}
     - secretName: {{ .Values.ingress.tlsSecretName }}
-          {{- else if .Values.authSidecar.enabled  }}
-    - secretName: astronomer-tls
           {{ else }}
     - secretName: ~
             {{- end }}
@@ -179,9 +174,6 @@ spec:
     - secretName: {{ .Release.Name }}-airflow-tls
           {{- else if .Values.ingress.tlsSecretName }}
     - secretName: {{ .Values.ingress.tlsSecretName }}
-          {{- else if .Values.authSidecar.enabled  }}
-    - secretName: astronomer-tls
-          {{ else }}
     - secretName: ~
             {{- end }}
       hosts:

--- a/tests/chart/test_ingress.py
+++ b/tests/chart/test_ingress.py
@@ -22,7 +22,7 @@ class TestIngress:
         assert doc["spec"]["tls"][0]["secretName"] is None
 
     def test_airflow_ingress_tls_secret_overrides(self, kube_version):
-        """Test airflow ingress with defaults - KubernetesExecutor."""
+        """Test airflow ingress and tls secret overrides with KubernetesExecutor."""
         docs = render_chart(
             kube_version=kube_version,
             show_only="templates/ingress.yaml",
@@ -50,12 +50,36 @@ class TestIngress:
         doc = docs[0]
         assert "Ingress" == doc["kind"]
         assert "networking.k8s.io/v1" == doc["apiVersion"]
-        assert "/release-name/airflow" == docs[0]["spec"]["rules"][0]["http"]["paths"][0]["path"]
+        assert "/release-name/airflow" == doc["spec"]["rules"][0]["http"]["paths"][0]["path"]
 
         doc = docs[1]
         assert "Ingress" == doc["kind"]
         assert "networking.k8s.io/v1" == doc["apiVersion"]
-        assert "/release-name/airflow" == docs[0]["spec"]["rules"][0]["http"]["paths"][0]["path"]
+        assert "/release-name/flower(/|$)(.*)" == doc["spec"]["rules"][0]["http"]["paths"][0]["path"]
+
+    def test_airflow_ingress_with_celery_executor_with_tls_overides(self, kube_version):
+        """Test airflow ingress and tls secret overrides with CeleryExecutor."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/ingress.yaml",
+            values={
+                "airflow": {"executor": "CeleryExecutor"},
+                "ingress": {"enabled": True, "baseDomain": "example.com", "tlsSecretName": "astronomer-tls"},
+            },
+        )
+        assert len(docs) == 2
+
+        doc = docs[0]
+        assert "Ingress" == doc["kind"]
+        assert "networking.k8s.io/v1" == doc["apiVersion"]
+        assert "/release-name/airflow" == doc["spec"]["rules"][0]["http"]["paths"][0]["path"]
+        assert "astronomer-tls" == doc["spec"]["tls"][0]["secretName"]
+
+        doc = docs[1]
+        assert "Ingress" == doc["kind"]
+        assert "networking.k8s.io/v1" == doc["apiVersion"]
+        assert "/release-name/flower(/|$)(.*)" == doc["spec"]["rules"][0]["http"]["paths"][0]["path"]
+        assert "astronomer-tls" == doc["spec"]["tls"][0]["secretName"]
 
     def test_airflow_ingress_with_dag_server(self, kube_version):
         """Test airflow ingress with DagServer."""
@@ -73,9 +97,10 @@ class TestIngress:
         rule_0 = docs[0]["spec"]["rules"][0]
         assert rule_0["http"]["paths"][0]["path"] == "/release-name/dags/(upload|downloads|healthz)(/.*)?"
         assert rule_0["host"] == "deployments.example.com"
+        assert docs[0]["spec"]["tls"][0]["secretName"] is None
 
-    def test_airflow_ingress_with_dag_server_ingress_annotation(self, kube_version):
-        """Test airflow ingress with DagServer."""
+    def test_airflow_ingress_with_dag_server_ingress_annotation_and_tls_secret(self, kube_version):
+        """Test airflow ingress annotation and tls secret with DagServer."""
 
         ingressAnnotation = {"kubernetes.io/ingress.class": "default"}
         docs = render_chart(
@@ -86,6 +111,7 @@ class TestIngress:
                     "enabled": True,
                     "baseDomain": "example.com",
                     "dagServerAnnotations": ingressAnnotation,
+                    "tlsSecretName": "astronomer-tls",
                 },
                 "dagDeploy": {"enabled": True},
             },
@@ -99,3 +125,4 @@ class TestIngress:
         assert rule_0["host"] == "deployments.example.com"
 
         assert ingressAnnotation == docs[1]["metadata"]["annotations"]
+        assert docs[1]["spec"]["tls"][0]["secretName"] == "astronomer-tls"

--- a/tests/chart/test_ingress.py
+++ b/tests/chart/test_ingress.py
@@ -5,6 +5,8 @@ from tests.chart.helm_template_generator import render_chart
 from .. import supported_k8s_versions
 
 tls_secret_name = "astronomer-tls"
+
+
 @pytest.mark.parametrize("kube_version", supported_k8s_versions)
 class TestIngress:
     def test_airflow_ingress_defaults(self, kube_version):

--- a/tests/chart/test_ingress.py
+++ b/tests/chart/test_ingress.py
@@ -19,6 +19,21 @@ class TestIngress:
         assert "Ingress" == doc["kind"]
         assert "networking.k8s.io/v1" == doc["apiVersion"]
         assert "/release-name/airflow" == docs[0]["spec"]["rules"][0]["http"]["paths"][0]["path"]
+        assert doc["spec"]["tls"][0]["secretName"] is None
+
+    def test_airflow_ingress_tls_secret_overrides(self, kube_version):
+        """Test airflow ingress with defaults - KubernetesExecutor."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/ingress.yaml",
+            values={"ingress": {"enabled": True, "baseDomain": "example.com", "tlsSecretName": "astronomer-tls"}},
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+        assert "Ingress" == doc["kind"]
+        assert "networking.k8s.io/v1" == doc["apiVersion"]
+        assert "/release-name/airflow" == doc["spec"]["rules"][0]["http"]["paths"][0]["path"]
+        assert "astronomer-tls" == doc["spec"]["tls"][0]["secretName"]
 
     def test_airflow_ingress_with_celery_executor(self, kube_version):
         """Test airflow ingress with CeleryExecutor."""


### PR DESCRIPTION
## Description

remove auth sidecar tls secret name hard coding and sync with global tls secretname, this allows users to pass their own secret name that will synced across all deployments.

## Related Issues

https://github.com/astronomer/issues/issues/6344

## Testing

QA should able to pass custom tls secret name for authsidecar and regular deployment from astronomer global values

## Merging

cherry-pick to 1.11 and 1.13
