### PR TITLE
update vendor packages

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -29,10 +29,10 @@ airflow:
       tag: ~
     statsd:
       repository: quay.io/astronomer/ap-statsd-exporter
-      tag: 0.27.1
+      tag: 0.27.2
     redis:
       repository: quay.io/astronomer/ap-redis
-      tag: 7.2.5
+      tag: 7.2.6
     pgbouncer:
       repository: quay.io/astronomer/ap-pgbouncer
       tag: 1.23.1-1
@@ -489,7 +489,7 @@ extraObjects: []
 authSidecar:
   enabled: false
   repository: quay.io/astronomer/ap-auth-sidecar
-  tag: 1.25.5
+  tag: 1.27.1
   pullPolicy: IfNotPresent
   port: 8084
   securityContext: {}
@@ -501,7 +501,7 @@ loggingSidecar:
   customConfig: false
   indexPattern: "%Y.%m.%d"
   indexNamePrefix: vector
-  image: quay.io/astronomer/ap-vector:0.32.2-2
+  image: quay.io/astronomer/ap-vector:0.40.2-1
 
 # Ingress configuration
 ingress:


### PR DESCRIPTION
## Description

| imageName | oldTag | newTag |
|--------|--------|--------|
| ap-statsd-exporter | 0.27.1 | 0.27.2 |
| ap-redis | 7.2.5 | 7.2.6 |
| ap-auth-sidecar | 1.25.5 | 1.27.1 |
| ap-vector | 0.32.2-2 | 0.40.2-1 | 

## Related Issues

https://github.com/astronomer/issues/issues/6557

## Testing

normal airflow chart install flow

## Merging

cherry-pick to release-1.13, 1.11,1.10
