### PR TITLE
sync astronomer airflow chart with oss chart

### DIFF
--- a/tests/chart/test_pod_template.py
+++ b/tests/chart/test_pod_template.py
@@ -111,3 +111,22 @@ class TestPodTemplate:
         doc = docs[0]
         podTemplate = yaml.safe_load(doc["data"]["pod_template_file.yaml"])
         assert "criticalworkload" == podTemplate["spec"]["runtimeClassName"]
+
+    def test_pod_template_worker_env_overrides(self, kube_version):
+        """Test airflow pod template labels overrides."""
+        env = {"name": "WORKERS_TYPE", "value": "GPU_ONLY"}
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "airflow": {
+                    "workers": {
+                        "env": [env],
+                    },
+                },
+            },
+            show_only="charts/airflow/templates/configmaps/configmap.yaml",
+        )
+        common_pod_template_test(docs)
+        doc = docs[0]
+        podTemplate = yaml.safe_load(doc["data"]["pod_template_file.yaml"])
+        assert env in podTemplate["spec"]["containers"][0]["env"]

--- a/values.yaml
+++ b/values.yaml
@@ -241,6 +241,7 @@ airflow:
               value: LocalExecutor
     {{- include "standard_airflow_environment" . | indent 6}}
     {{- include "custom_airflow_environment" . | indent 6 }}
+    {{- include "container_extra_envs" (list . .Values.workers.env) | indent 6 }}
           image: {{ template "pod_template_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           name: base


### PR DESCRIPTION
## Description

This change allows workers specific env to be auto include to pod template when specified

our current shipped podMutation templates lacks few features from oss helm chart , this PR addresses the behaviour by including the required changes to work with astronomer airflow chart 
- changes included PR adds a fix where workers specific env to be auto included to pod mutation template which allows the airflow task pod to use the worker env vars

## Related Issues

- https://github.com/astronomer/issues/issues/6650
- https://github.com/astronomer/issues/issues/6593
- https://github.com/astronomer/issues/issues/6594

## Testing

QA should see worker specific env are viewed in the airflow task pods 

## Merging

cherry-pick to release-1.13
