### PR TITLE
Add securityContext Support for dag-deploy

### DIFF
--- a/templates/dag-deploy/dag-server-statefulset.yaml
+++ b/templates/dag-deploy/dag-server-statefulset.yaml
@@ -61,6 +61,7 @@ spec:
             containerPort: {{ .Values.dagDeploy.ports.dagServerHttp }}
           resources:
             {{- toYaml .Values.dagDeploy.resources | nindent 12 }}
+          securityContext: {{ toYaml .Values.dagDeploy.securityContexts.container  | nindent 12 }}
           env:
           - name: HOUSTON_SERVICE_ENDPOINT
             value: "http://{{ .Values.platform.release }}-houston.{{ .Values.platform.namespace }}.svc.cluster.local.:8871/v1/"

--- a/templates/dag-deploy/dag-server-statefulset.yaml
+++ b/templates/dag-deploy/dag-server-statefulset.yaml
@@ -61,7 +61,6 @@ spec:
             containerPort: {{ .Values.dagDeploy.ports.dagServerHttp }}
           resources:
             {{- toYaml .Values.dagDeploy.resources | nindent 12 }}
-          securityContext: {{ toYaml .Values.dagDeploy.securityContexts.container  | nindent 12 }}
           env:
           - name: HOUSTON_SERVICE_ENDPOINT
             value: "http://{{ .Values.platform.release }}-houston.{{ .Values.platform.namespace }}.svc.cluster.local.:8871/v1/"

--- a/tests/chart/test_dag_server_statefulset.py
+++ b/tests/chart/test_dag_server_statefulset.py
@@ -106,7 +106,13 @@ class TestDagServerStatefulSet:
 
     def test_dag_server_statefulset_with_securitycontext_overrides(self, kube_version):
         """Test that dag-server statefulset are configurable with custom securitycontext."""
-        dag_serversecuritycontext = {"runAsUser": 12345, "allowPrivilegeEscalation": True, 'fsGroup': 2000, 'readOnlyRootFilesystem': True, 'runAsGroup': 1000,}
+        dag_serversecuritycontext = {
+            "runAsUser": 12345,
+            "allowPrivilegeEscalation": True,
+            "fsGroup": 2000,
+            "readOnlyRootFilesystem": True,
+            "runAsGroup": 1000,
+        }
         values = {"dagDeploy": {"enabled": True, "securityContext": dag_serversecuritycontext}}
 
         docs = render_chart(

--- a/tests/chart/test_dag_server_statefulset.py
+++ b/tests/chart/test_dag_server_statefulset.py
@@ -106,7 +106,7 @@ class TestDagServerStatefulSet:
 
     def test_dag_server_statefulset_with_securitycontext_overrides(self, kube_version):
         """Test that dag-server statefulset are configurable with custom securitycontext."""
-        dag_serversecuritycontext = {"runAsUser": 12345, "privileged": True}
+        dag_serversecuritycontext = {"runAsUser": 12345, "allowPrivilegeEscalation": True, 'fsGroup': 2000, 'readOnlyRootFilesystem': True, 'runAsGroup': 1000,}
         values = {"dagDeploy": {"enabled": True, "securityContext": dag_serversecuritycontext}}
 
         docs = render_chart(

--- a/values.yaml
+++ b/values.yaml
@@ -594,9 +594,13 @@ dagDeploy:
   # when it wants to scale a node down.
   safeToEvict: true
 
-  securityContext: {}
-  #  runAsUser: 999
-  #  runAsGroup: 0
+  # Add default values to avoid changes in behavior
+  securityContext:
+    runAsUser: null
+    runAsGroup: null
+    fsGroup: null
+    allowPrivilegeEscalation: null
+    readOnlyRootFilesystem: null
 
 gitSyncRelay:
   enabled: ~


### PR DESCRIPTION
## Description

This PR intends to add securityContext Support for dag-deploy pod

## Related Issues

Related https://github.com/astronomer/issues/issues/6729

## Testing

QA should be able to pass security contexts to dag-deploy components. 

## Merging

0.36
