### PR TITLE
pgbouncer-exporter 0.18.0

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -38,7 +38,7 @@ airflow:
       tag: 1.23.1-1
     pgbouncerExporter:
       repository: quay.io/astronomer/ap-pgbouncer-exporter
-      tag: 0.15.0-10
+      tag: 0.18.0
     gitSync:
       repository: quay.io/astronomer/ap-git-sync
       tag: 3.6.9


### PR DESCRIPTION
## Description

Bump pgbouncer-exporter to 0.18.0 which is compatible with pgbouncer 1.23 metrics. https://github.com/Vonng/pg_exporter/commit/8e24e9b307f9ed7c7489f4489947e5e733e09c0c

## Related Issues

https://github.com/astronomer/issues/issues/6761

## Testing

Make sure pgbouncer metrix work in 0.36.0

## Merging

This should go anywhere that we are using pgbouncer 1.23