### PR TITLE
Whitespace and typo fix

### DIFF
--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -301,7 +301,7 @@ Create the name of the cleanup service account to use
   {{- default (printf "%s-registry" .Release.Name) .Values.airflow.registry.secretName }}
 {{- end }}
 
-{{- define "sideccar_container_spec" -}}
+{{- define "sidecar_container_spec" -}}
 - name: {{ .Values.loggingSidecar.name }}
   image: "{{ .Values.loggingSidecar.image }}"
   env:

--- a/templates/dag-deploy/dag-server-statefulset.yaml
+++ b/templates/dag-deploy/dag-server-statefulset.yaml
@@ -126,7 +126,7 @@ spec:
             subPath: nginx.conf
 {{- end }}
 {{- if .Values.loggingSidecar.enabled }}
-{{- include "sideccar_container_spec" . | nindent 8 }}
+{{- include "sidecar_container_spec" . | nindent 8 }}
 {{- end }}
 {{- if .Values.dagDeploy.extraContainers }}
 {{- toYaml .Values.dagDeploy.extraContainers | nindent 8 }}

--- a/templates/git-sync-relay/git-sync-relay-deployment.yaml
+++ b/templates/git-sync-relay/git-sync-relay-deployment.yaml
@@ -2,7 +2,6 @@
 ## git-sync-relay Deployment ##
 ###############################
 {{- if .Values.gitSyncRelay.enabled }}
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -32,8 +31,7 @@ spec:
       imagePullSecrets:
         - name: {{ template "astro.registry_secret" . }}
       {{- end }}
-      securityContext:
-{{ toYaml .Values.gitSyncRelay.securityContext | indent 8 }}
+      securityContext: {{ toYaml .Values.gitSyncRelay.securityContext | nindent 8 }}
       volumes:
         - name: git-repo-contents
           emptyDir: {}
@@ -124,13 +122,11 @@ spec:
               - /git/.git/git-daemon-export-ok
             initialDelaySeconds: 5
             periodSeconds: 15
-          resources:
-            {{- toYaml .Values.gitSyncRelay.gitDaemonResources | nindent 12 }}
-        {{- if .Values.loggingSidecar.enabled }}
-{{- include "sideccar_container_spec" . | nindent 8 }}
-          {{- end }}
-
-{{- if .Values.gitSyncRelay.extraContainers }}
-{{- toYaml .Values.gitSyncRelay.extraContainers | nindent 8 }}
-{{- end }}
+          resources: {{- toYaml .Values.gitSyncRelay.gitDaemonResources | nindent 12 }}
+      {{- if .Values.loggingSidecar.enabled }}
+        {{- include "sidecar_container_spec" . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.gitSyncRelay.extraContainers }}
+        {{- toYaml .Values.gitSyncRelay.extraContainers | nindent 8 }}
+      {{- end }}
 {{- end -}}


### PR DESCRIPTION
## Description

While working on https://github.com/astronomer/issues/issues/6789 I found a typo, so here is that fix and some whitespace changes that we can backport to all branches where git-sync sidecar is used.

- Fix a typo.
- Whitespace changes.

## Related Issues

Not really related to https://github.com/astronomer/issues/issues/6789 but this was found while working on it.

## Testing

CI tests are sufficient.

## Merging

Backport to anywhere we use git-sync-relay.