### PR TITLE
gitsync relay probes support

### DIFF
--- a/templates/git-sync-relay/git-sync-relay-deployment.yaml
+++ b/templates/git-sync-relay/git-sync-relay-deployment.yaml
@@ -104,8 +104,14 @@ spec:
               value: "false"
             {{- end }}
             {{- end }}
+          {{- if .Values.gitSyncRelay.gitSync.livenessProbe  }}
+          livenessProbe: {{ tpl (toYaml .Values.gitSyncRelay.gitSync.livenessProbe) . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.gitSyncRelay.gitSync.readinessProbe  }}
+          readinessProbe: {{ tpl (toYaml .Values.gitSyncRelay.gitSync.readinessProbe) . | nindent 12 }}
+          {{- end }}
           resources:
-            {{- toYaml .Values.gitSyncRelay.gitSyncResources | nindent 12 }}
+            {{- toYaml .Values.gitSyncRelay.gitSync.resources | nindent 12 }}
         - name: git-daemon
           image: "{{ .Values.gitSyncRelay.images.gitDaemon.repository }}:{{ .Values.gitSyncRelay.images.gitDaemon.tag }}"
           volumeMounts:
@@ -129,7 +135,7 @@ spec:
           {{- if .Values.gitSyncRelay.gitDaemon.readinessProbe  }}
           readinessProbe: {{ tpl (toYaml .Values.gitSyncRelay.gitDaemon.readinessProbe) . | nindent 12 }}
           {{- end }}
-          resources: {{- toYaml .Values.gitSyncRelay.gitDaemonResources | nindent 12 }}
+          resources: {{- toYaml .Values.gitSyncRelay.gitDaemon.resources | nindent 12 }}
       {{- if .Values.loggingSidecar.enabled }}
         {{- include "sidecar_container_spec" . | nindent 8 }}
       {{- end }}

--- a/templates/git-sync-relay/git-sync-relay-deployment.yaml
+++ b/templates/git-sync-relay/git-sync-relay-deployment.yaml
@@ -122,7 +122,7 @@ spec:
             - name: GIT_ROOT
               value: /git
           {{- if .Values.gitSyncRelay.gitDaemon.livenessProbe  }}
-          livenessProbe: {{ tpl (toYaml .Values.authSidecar.livenessProbe) . | nindent 12 }}
+          livenessProbe: {{ tpl (toYaml .Values.gitSyncRelay.gitDaemon.livenessProbe) . | nindent 12 }}
           {{- else }}
           livenessProbe:
             exec:

--- a/templates/git-sync-relay/git-sync-relay-deployment.yaml
+++ b/templates/git-sync-relay/git-sync-relay-deployment.yaml
@@ -115,6 +115,9 @@ spec:
           env:
             - name: GIT_ROOT
               value: /git
+          {{- if .Values.gitSyncRelay.gitDaemon.livenessProbe  }}
+          livenessProbe: {{ tpl (toYaml .Values.authSidecar.livenessProbe) . | nindent 12 }}
+          {{- else }}
           livenessProbe:
             exec:
               command:
@@ -122,6 +125,10 @@ spec:
               - /git/.git/git-daemon-export-ok
             initialDelaySeconds: 5
             periodSeconds: 15
+          {{- end }}
+          {{- if .Values.gitSyncRelay.gitDaemon.readinessProbe  }}
+          readinessProbe: {{ tpl (toYaml .Values.gitSyncRelay.gitDaemon.readinessProbe) . | nindent 12 }}
+          {{- end }}
           resources: {{- toYaml .Values.gitSyncRelay.gitDaemonResources | nindent 12 }}
       {{- if .Values.loggingSidecar.enabled }}
         {{- include "sidecar_container_spec" . | nindent 8 }}

--- a/tests/chart/test_git_sync_relay_deployment.py
+++ b/tests/chart/test_git_sync_relay_deployment.py
@@ -5,6 +5,8 @@ from tests.chart.helm_template_generator import render_chart
 
 from . import get_containers_by_name
 
+readinessProbe = {"httpGet": {"initialDelaySeconds": 20, "periodSeconds": 20, "path": "/rhealthz", "port": 8080, "scheme": "HTTP"}}
+livenessProbe = {"httpGet": {"initialDelaySeconds": 20, "periodSeconds": 20, "path": "/chealthz", "port": 8080, "scheme": "HTTP"}}
 
 @pytest.mark.parametrize("kube_version", supported_k8s_versions)
 class TestGitSyncRelayDeployment:
@@ -220,3 +222,28 @@ class TestGitSyncRelayDeployment:
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "release-name-git-sync-relay"
         assert [{"name": "gscsecret"}] == doc["spec"]["template"]["spec"]["imagePullSecrets"]
+
+    def test_gsr_deployment_with_custom_probes(self, kube_version):
+        """Test git-sync-relay deployment with custom liveliness and readiness probes."""
+        values = {
+            "gitSyncRelay": {
+                "enabled": True,
+                "gitSync": {"readinessProbe": readinessProbe, "livenessProbe": livenessProbe},
+                "gitDaemon": {"readinessProbe": readinessProbe, "livenessProbe": livenessProbe}}
+        }
+
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/git-sync-relay/git-sync-relay-deployment.yaml",
+            values=values,
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "Deployment"
+        assert doc["apiVersion"] == "apps/v1"
+        assert doc["metadata"]["name"] == "release-name-git-sync-relay"
+        c_by_name = get_containers_by_name(doc)
+        assert readinessProbe == c_by_name["git-daemon"]["readinessProbe"]
+        assert livenessProbe == c_by_name["git-daemon"]["livenessProbe"]
+        assert readinessProbe == c_by_name["git-sync"]["readinessProbe"]
+        assert livenessProbe == c_by_name["git-sync"]["livenessProbe"]

--- a/tests/chart/test_git_sync_relay_deployment.py
+++ b/tests/chart/test_git_sync_relay_deployment.py
@@ -166,8 +166,8 @@ class TestGitSyncRelayDeployment:
         values = {
             "gitSyncRelay": {
                 "enabled": True,
-                "gitSyncResources": resources,
-                "gitDaemonResources": resources,
+                "gitSync": { "resources": resources },
+                "gitDaemon": { "resources": resources },
             }
         }
 

--- a/tests/chart/test_git_sync_relay_deployment.py
+++ b/tests/chart/test_git_sync_relay_deployment.py
@@ -8,6 +8,7 @@ from . import get_containers_by_name
 readinessProbe = {"httpGet": {"initialDelaySeconds": 20, "periodSeconds": 20, "path": "/rhealthz", "port": 8080, "scheme": "HTTP"}}
 livenessProbe = {"httpGet": {"initialDelaySeconds": 20, "periodSeconds": 20, "path": "/chealthz", "port": 8080, "scheme": "HTTP"}}
 
+
 @pytest.mark.parametrize("kube_version", supported_k8s_versions)
 class TestGitSyncRelayDeployment:
     def test_gsr_deployment_default(self, kube_version):
@@ -229,7 +230,8 @@ class TestGitSyncRelayDeployment:
             "gitSyncRelay": {
                 "enabled": True,
                 "gitSync": {"readinessProbe": readinessProbe, "livenessProbe": livenessProbe},
-                "gitDaemon": {"readinessProbe": readinessProbe, "livenessProbe": livenessProbe}}
+                "gitDaemon": {"readinessProbe": readinessProbe, "livenessProbe": livenessProbe},
+            }
         }
 
         docs = render_chart(

--- a/tests/chart/test_git_sync_relay_deployment.py
+++ b/tests/chart/test_git_sync_relay_deployment.py
@@ -166,8 +166,8 @@ class TestGitSyncRelayDeployment:
         values = {
             "gitSyncRelay": {
                 "enabled": True,
-                "gitSync": { "resources": resources },
-                "gitDaemon": { "resources": resources },
+                "gitSync": {"resources": resources},
+                "gitDaemon": {"resources": resources},
             }
         }
 

--- a/values.yaml
+++ b/values.yaml
@@ -607,6 +607,7 @@ gitSyncRelay:
   gitDaemonResources: {}
   securityContext: {}
   gitDaemon: {}
+  gitSync: {}
   images:
     gitDaemon:
       repository: "quay.io/astronomer/ap-git-daemon"

--- a/values.yaml
+++ b/values.yaml
@@ -602,10 +602,11 @@ dagDeploy:
     container: {}
 
 gitSyncRelay:
-  enabled: ~
+  enabled: false
   gitSyncResources: {}
   gitDaemonResources: {}
   securityContext: {}
+  gitDaemon: {}
   images:
     gitDaemon:
       repository: "quay.io/astronomer/ap-git-daemon"


### PR DESCRIPTION
## Description

This PR adds support for git sync deployment containers with probes support and introduces new granular field segments for per container config support

## Related Issues

- <https://github.com/astronomer/issues/issues/6876>
- <https://github.com/astronomer/issues/issues/6746>
- https://github.com/astronomer/issues/issues/6874

## Testing

QA should able to override the resource and probe values from astronomer helm chart 

## Merging

cherry-pick to release-1.13
