### PR TITLE
add workers resource spec to pod template

### DIFF
--- a/tests/chart/test_pod_template.py
+++ b/tests/chart/test_pod_template.py
@@ -130,3 +130,26 @@ class TestPodTemplate:
         doc = docs[0]
         podTemplate = yaml.safe_load(doc["data"]["pod_template_file.yaml"])
         assert env in podTemplate["spec"]["containers"][0]["env"]
+
+    def test_pod_template_resource_overrides(self, kube_version):
+        """Test airflow pod template labels overrides."""
+        resources = {
+            "requests": {"cpu": "500m", "memory": "512Mi"},
+            "limits": {"cpu": "1000m", "memory": "1Gi"},
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "airflow": {
+                    "workers": {
+                        "resources": resources,
+                    },
+                },
+            },
+            show_only="charts/airflow/templates/configmaps/configmap.yaml",
+        )
+        common_pod_template_test(docs)
+        doc = docs[0]
+        podTemplate = yaml.safe_load(doc["data"]["pod_template_file.yaml"])
+        assert "resources" in podTemplate["spec"]["containers"][0]
+        assert resources == podTemplate["spec"]["containers"][0]["resources"]

--- a/tests/chart/test_pod_template.py
+++ b/tests/chart/test_pod_template.py
@@ -132,7 +132,7 @@ class TestPodTemplate:
         assert env in podTemplate["spec"]["containers"][0]["env"]
 
     def test_pod_template_resource_overrides(self, kube_version):
-        """Test airflow pod template labels overrides."""
+        """Test airflow pod template resources overrides."""
         resources = {
             "requests": {"cpu": "500m", "memory": "512Mi"},
             "limits": {"cpu": "1000m", "memory": "1Gi"},

--- a/values.yaml
+++ b/values.yaml
@@ -246,6 +246,7 @@ airflow:
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           name: base
           ports: []
+          resources: {{- toYaml .Values.workers.resources | nindent 8 }}
           volumeMounts:
             - mountPath: {{ template "airflow_logs" . }}
               name: logs


### PR DESCRIPTION
## Description

Add resource spec support for pod template to make kubernetes executor to have configurable resources

## Related Issues

- https://github.com/astronomer/issues/issues/6926

## Testing

QA should able to overrides task pod resources with kubernetes executor from the UI or api

## Merging

release-1.13
