### PR TITLE
add git sync relay service account support

### DIFF
--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -175,6 +175,16 @@ Create the name of the dag-server service account to use
 {{- end -}}
 {{- end -}}
 
+{{/*
+Create the name of the git-sync-relay service account to use
+*/}}
+{{- define "astro.gitSyncRelay.serviceAccountName" -}}
+{{- if .Values.gitSyncRelay.serviceAccount.create -}}
+    {{ default (printf "%s-git-sync-relay" (include "airflow.fullname" .)) .Values.gitSyncRelay.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.gitSyncRelay.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
 
 {{/*
 Create the name of the webserver service account to use

--- a/templates/git-sync-relay/git-sync-relay-deployment.yaml
+++ b/templates/git-sync-relay/git-sync-relay-deployment.yaml
@@ -31,6 +31,7 @@ spec:
       imagePullSecrets:
         - name: {{ template "astro.registry_secret" . }}
       {{- end }}
+      serviceAccountName: {{ template "astro.gitSyncRelay.serviceAccountName" . }}
       securityContext: {{ toYaml .Values.gitSyncRelay.securityContext | nindent 8 }}
       volumes:
         - name: git-repo-contents

--- a/templates/git-sync-relay/git-sync-relay-serviceaccount.yaml
+++ b/templates/git-sync-relay/git-sync-relay-serviceaccount.yaml
@@ -1,7 +1,7 @@
 #################################
 ## dag-server ServiceAccount   ##
 #################################
-{{- if and .Values.gitSyncRelay.enabled .Values.dagDeploy.serviceAccount.create }}
+{{- if and .Values.gitSyncRelay.enabled .Values.gitSyncRelay.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/templates/git-sync-relay/git-sync-relay-serviceaccount.yaml
+++ b/templates/git-sync-relay/git-sync-relay-serviceaccount.yaml
@@ -1,0 +1,16 @@
+#################################
+## dag-server ServiceAccount   ##
+#################################
+{{- if and .Values.gitSyncRelay.enabled .Values.dagDeploy.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "astro.gitSyncRelay.serviceAccountName" . }}
+  labels:
+    component: git-sync-relay
+    tier: airflow
+    release: {{ .Release.Name }}
+    chart: "{{ .Release.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+  annotations: {{- toYaml .Values.gitSyncRelay.serviceAccount.annotations | nindent 4 }}
+{{- end }}

--- a/tests/chart/test_git_sync_relay_serviceaccount.py
+++ b/tests/chart/test_git_sync_relay_serviceaccount.py
@@ -1,0 +1,93 @@
+import pytest
+
+from tests import supported_k8s_versions
+from tests.chart.helm_template_generator import render_chart
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+class TestGitSyncRelayServiceAccount:
+    def test_git_sync_relay_service_default(self, kube_version):
+        """Test that no git-sync-relay service templates are rendered by default."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/git-sync-relay/git-sync-relay-serviceaccount.yaml",
+        )
+        assert len(docs) == 0
+
+    def test_git_sync_relay_service_enabled(self, kube_version):
+        """Test that a valid serviceAccount is rendered when git-sync-relay is enabled."""
+        values = {"gitSyncRelay": {"enabled": True}}
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/git-sync-relay/git-sync-relay-serviceaccount.yaml",
+            values=values,
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "ServiceAccount"
+        assert doc["apiVersion"] == "v1"
+        assert doc["metadata"]["name"] == "release-name-git-sync-relay"
+
+    def test_git_sync_relay_server_annotations(self, kube_version):
+        """Test that a valid serviceAccount is rendered with proper annotations
+        when git_sync_relay is enabled and annotations are provided."""
+        annotations = {"foo-key": "foo-value", "bar-key": "bar-value"}
+        values = {
+            "gitSyncRelay": {
+                "enabled": True,
+                "serviceAccount": {"annotations": annotations},
+            }
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[
+                "templates/git-sync-relay/git-sync-relay-serviceaccount.yaml",
+                "templates/git-sync-relay/git-sync-relay-deployment.yaml",
+            ],
+            values=values,
+        )
+        assert len(docs) == 2
+        doc = docs[0]
+        assert doc["kind"] == "ServiceAccount"
+        assert doc["apiVersion"] == "v1"
+        assert doc["metadata"]["name"] == "release-name-git-sync-relay"
+        assert doc["metadata"]["annotations"] == annotations
+        assert "release-name-git-sync-relay" == docs[1]["spec"]["template"]["spec"]["serviceAccountName"]
+
+    def test_git_sync_relay_server_serviceaccount_overrides_defaults(self, kube_version):
+        """Test that a serviceAccount overridable with disabled creation"""
+        values = {
+            "gitSyncRelay": {
+                "enabled": True,
+                "serviceAccount": {"create": False},
+            }
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[
+                "templates/git-sync-relay/git-sync-relay-serviceaccount.yaml",
+                "templates/git-sync-relay/git-sync-relay-deployment.yaml",
+            ],
+            values=values,
+        )
+        assert len(docs) == 1
+        assert "default" == docs[0]["spec"]["template"]["spec"]["serviceAccountName"]
+
+    def test_git_sync_relay_server_serviceaccount_overrides(self, kube_version):
+        """Test that a serviceAccount overridable with disabled creation"""
+        values = {
+            "gitSyncRelay": {
+                "enabled": True,
+                "serviceAccount": {"create": False, "name": "git-sync-relay"},
+            }
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[
+                "templates/git-sync-relay/git-sync-relay-serviceaccount.yaml",
+                "templates/git-sync-relay/git-sync-relay-deployment.yaml",
+            ],
+            values=values,
+        )
+        assert len(docs) == 1
+        assert "git-sync-relay" == docs[0]["spec"]["template"]["spec"]["serviceAccountName"]

--- a/values.yaml
+++ b/values.yaml
@@ -646,7 +646,6 @@ gitSyncRelay:
     annotations: {}
     name: ~
 
-
 certgenerator:
   extraAnnotations: {}
   affinity: {}

--- a/values.yaml
+++ b/values.yaml
@@ -641,6 +641,11 @@ gitSyncRelay:
     volumeSize: 10Gi
     # The specified storageClassName must support ReadWriteMany
     storageClassName: ~
+  serviceAccount:
+    create: true
+    annotations: {}
+    name: ~
+
 
 certgenerator:
   extraAnnotations: {}


### PR DESCRIPTION
## Description

Add support for service account to  git sync relay component to ensure or skip policy managers rejecting the deploy request

## Related Issues

https://github.com/astronomer/issues/issues/6747

## Testing

Yet to update

## Merging

cherry-pick to master 
