### PR TITLE
upgrading ap-vendor packages

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -41,7 +41,7 @@ airflow:
       tag: 0.18.0
     gitSync:
       repository: quay.io/astronomer/ap-git-sync
-    tag: 4.2.3-1
+      tag: 4.2.3-1
   # Airflow scheduler settings
   scheduler:
     livenessProbe:

--- a/values.yaml
+++ b/values.yaml
@@ -41,7 +41,7 @@ airflow:
       tag: 0.18.0
     gitSync:
       repository: quay.io/astronomer/ap-git-sync
-      tag: 3.6.9
+    tag: 4.2.3-1
   # Airflow scheduler settings
   scheduler:
     livenessProbe:
@@ -505,7 +505,7 @@ loggingSidecar:
   customConfig: false
   indexPattern: "%Y.%m.%d"
   indexNamePrefix: vector
-  image: quay.io/astronomer/ap-vector:0.40.2-1
+  image: quay.io/astronomer/ap-vector:0.44.0-1
   livenessProbe: {}
   readinessProbe: {}
 
@@ -612,10 +612,10 @@ gitSyncRelay:
   images:
     gitDaemon:
       repository: "quay.io/astronomer/ap-git-daemon"
-      tag: "3.18.9"
+      tag: "3.20.3-1"
     gitSync:
       repository: "quay.io/astronomer/ap-git-sync-relay"
-      tag: "0.0.3-6"
+      tag: "0.0.3-7"
   repo:
     url: ~
     branch: main


### PR DESCRIPTION
## Description

 This PR Updates  ap-vendor packages to resolve some of the CVE's for astronomer software 

Image Name |  old  Tag| New tag |
-- | -- | -- |
ap-vector | 0.42.0 | 0.44.0-1
git-daemon  | 3.18.9 | 3.20.3-1
git-sync-relay | 0.0.3-6 |0.0.3-7
git-sync | 3.6.9 | 4.2.3-1


## Related Issues
https://github.com/astronomer/issues/issues/6830

## Testing

QA should be able to test git sync and logging-sidecar features without any fail 

## Merging

cherry-picked into release-037 and release-036
