### PR TITLE
Fix PVC mode for git-sync-relay shared_volume

### DIFF
--- a/templates/git-sync-relay/git-sync-relay-pvc.yaml
+++ b/templates/git-sync-relay/git-sync-relay-pvc.yaml
@@ -1,7 +1,10 @@
 ########################
 ## git-sync-relay pvc ##
 ########################
-{{- if and .Values.gitSyncRelay.enabled ( eq .Values.gitSyncRelay.repoShareMode "shared_volume") }}
+{{- if and
+  .Values.gitSyncRelay.enabled
+  (eq .Values.gitSyncRelay.repoShareMode "shared_volume")
+}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -14,7 +17,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   resources:
     requests:
       storage: {{ .Values.gitSyncRelay.volumeSync.volumeSize }}

--- a/tests/chart/test_git_sync_relay_pvc.py
+++ b/tests/chart/test_git_sync_relay_pvc.py
@@ -1,0 +1,29 @@
+from tests import git_root_dir
+from tests.chart.helm_template_generator import render_chart
+
+
+def test_gsr_pvc_defaults():
+    """Test that no git-sync-relay pvc templates are rendered by default."""
+    docs = render_chart(
+        show_only=sorted([str(x.relative_to(git_root_dir)) for x in git_root_dir.rglob("*git-sync-relay-pvc*.yaml")]),
+    )
+    assert len(docs) == 0
+
+
+def test_gsr_repo_share_mode_shared_volume():
+    """Test that a git-sync-relay pvc template has the right contents when gitSyncRelay is enabled with shared_volume mode."""
+    values = {
+        "gitSyncRelay": {
+            "enabled": True,
+            "repoShareMode": "shared_volume",
+        }
+    }
+    docs = render_chart(
+        values=values,
+        show_only=sorted([str(x.relative_to(git_root_dir)) for x in git_root_dir.rglob("*git-sync-relay-pvc*.yaml")]),
+    )
+    assert len(docs) == 1
+    assert docs[0]["kind"] == "PersistentVolumeClaim"
+    assert docs[0]["spec"]["accessModes"] == ["ReadWriteMany"]
+    assert docs[0]["spec"]["resources"]["requests"]["storage"] == "10Gi"
+    assert not docs[0]["spec"]["storageClassName"]


### PR DESCRIPTION
## Description

Correct the git-sync-relay shared_volume mode and add pvc tests.

## Related Issues

- <https://github.com/astronomer/issues/issues/6965>

## Testing

I added unit tests, but have not tested in an actual cluster. @himabindu07 will do so to circle back on <https://github.com/astronomer/issues/issues/6965> which she opened.

## Merging

Merge only to release-1.13 branch.