### PR TITLE
quay.io/astronomer/ap-git-sync-relay:0.1.8 with added debugging

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -622,7 +622,7 @@ gitSyncRelay:
       tag: "3.20.5"
     gitSync:
       repository: "quay.io/astronomer/ap-git-sync-relay"
-      tag: "0.1.7"
+      tag: "0.1.8"
   repo:
     url: ~
     branch: main

--- a/values.yaml
+++ b/values.yaml
@@ -622,7 +622,7 @@ gitSyncRelay:
       tag: "3.20.5"
     gitSync:
       repository: "quay.io/astronomer/ap-git-sync-relay"
-      tag: "0.1.5"
+      tag: "0.1.6"
   repo:
     url: ~
     branch: main

--- a/values.yaml
+++ b/values.yaml
@@ -622,7 +622,7 @@ gitSyncRelay:
       tag: "3.20.5"
     gitSync:
       repository: "quay.io/astronomer/ap-git-sync-relay"
-      tag: "0.1.6"
+      tag: "0.1.7"
   repo:
     url: ~
     branch: main


### PR DESCRIPTION
## Description

Use quay.io/astronomer/ap-git-sync-relay:0.1.8 with added debugging.

## Related Issues

https://github.com/astronomer/issues/issues/7004

## Testing

This is just additional debugging code that is not enabled unless the environment has "DEBUG=1" set. No testing is needed.

## Merging

Merge only to release-1.13