### PR TITLE
ap-git-sync-relay 0.1.9 which has tiny improvements.

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -622,7 +622,7 @@ gitSyncRelay:
       tag: "3.20.5"
     gitSync:
       repository: "quay.io/astronomer/ap-git-sync-relay"
-      tag: "0.1.8"
+      tag: "0.1.9"
   repo:
     url: ~
     branch: main


### PR DESCRIPTION
## Description

ap-git-sync-relay which has some tiny improvements like re-ordering some code for slightly better flow, and not warning about an operation that is normal.

## Related Issues

- <https://github.com/astronomer/issues/issues/6786>
- <https://github.com/astronomer/git-sync-relay/pull/6>

## Testing

I have manually tested this code for astronomer/astronomer 0.37.0. No QA is needed for that release.

## Merging

Merge to 1.14, should also work with 1.13.
