### PR TITLE
add scc support for gitsync relay service

### DIFF
--- a/templates/airflow-scc-anyuid.yaml
+++ b/templates/airflow-scc-anyuid.yaml
@@ -35,6 +35,9 @@ users:
 {{- if .Values.dagDeploy.enabled }}
 - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-dag-server
 {{- end }}
+{{- if and .Values.gitSyncRelay.enabled }}
+- system:serviceaccount:{{ .Release.Namespace }}:{{ include "astro.gitSyncRelay.serviceAccountName" . }}
+{{- end }}
 volumes:
 - configMap
 - downwardAPI


### PR DESCRIPTION
## Description

add scc support for gitsync relay service

## Related Issues

- https://github.com/astronomer/issues/issues/7073

## Testing

QA should be able to create deployment and see no issues with git sync based deployments

## Merging

cherry-pick to release-1.14
