### PR TITLE
fix pgbouncer service account name

### DIFF
--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -290,7 +290,7 @@ Create the name of the pgbouncer service account to use
 */}}
 {{- define "astro.pgbouncer.serviceAccountName" -}}
 {{- if .Values.airflow.pgbouncer.serviceAccount.create -}}
-    {{ default (printf "%s-pgbouncer" (include "airflow.fullname" .)) .Values.airflow.pgbouncer.serviceAccount.name }}
+    {{ default (printf "%s-pgbouncer" (include "airflow.serviceAccountName" .)) .Values.airflow.pgbouncer.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.airflow.pgbouncer.serviceAccount.name }}
 {{- end -}}

--- a/tests/chart/test_pgbouncer.py
+++ b/tests/chart/test_pgbouncer.py
@@ -37,3 +37,19 @@ class TestPgbouncerSecret:
         ini = base64.b64decode(doc["data"]["pgbouncer.ini"]).decode()
 
         assert "server_idle_timeout" in ini
+
+    def test_pgbouncer_serviceaccount_defaults(self):
+        """Test pgbouncer service account defaults."""
+        docs = render_chart(
+            values={
+                "airflow": {
+                    "pgbouncer": {
+                        "enabled": True,
+                    },
+                },
+            },
+            show_only=["charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml"],
+        )
+
+        assert len(docs) == 1
+        assert "release-name-airflow-pgbouncer" == docs[0]["spec"]["template"]["spec"]["serviceAccountName"]


### PR DESCRIPTION
## Description

fix pgbouncer service account name

pgbouncer service account template has been changed in oss chart since the upgrade of 1.13 and we have ported all airflow related service account changes inside the chart

- https://github.com/astronomer/issues/issues/7096

## Related Issues

- https://github.com/astronomer/issues/issues/7096

## Testing

QA should now see refactored service account in the pgbouncer deployment spec

## Merging

cherry-pick to release-1.13,1.14,master
