### PR TITLE
add base scc feature json schema and dag processor testing

### DIFF
--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -308,12 +308,12 @@ Create the name of the cleanup service account to use
 {{- end -}}
 
 {{/* Create the name of the dag processor service account to use */}}
-{{- define "astro.airflow.dagProcessor.serviceAccountName" -}}
-  {{- if .Values.airflow.dagProcessor.serviceAccount.create }}
-    {{- default (printf "%s-dag-processor" (include "airflow.serviceAccountName" .)) .Values.airflow.dagProcessor.serviceAccount.name }}
-  {{- else }}
-    {{- default "default" .Values.airflow.dagProcessor.serviceAccount.name }}
-  {{- end }}
+{{- define "astro.dagProcessor.serviceAccountName" -}}
+{{- if .Values.airflow.dagProcessor.serviceAccount.create }}
+  {{- default (printf "%s-dag-processor" (include "airflow.serviceAccountName" .)) .Values.airflow.dagProcessor.serviceAccount.name }}
+{{- else }}
+  {{- default "default" .Values.airflow.dagProcessor.serviceAccount.name }}
+{{- end }}
 {{- end }}
 
 {{- define "astro.registry_secret" -}}

--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -307,6 +307,15 @@ Create the name of the cleanup service account to use
 {{- end -}}
 {{- end -}}
 
+{{/* Create the name of the dag processor service account to use */}}
+{{- define "astro.airflow.dagProcessor.serviceAccountName" -}}
+  {{- if .Values.airflow.dagProcessor.serviceAccount.create }}
+    {{- default (printf "%s-dag-processor" (include "airflow.serviceAccountName" .)) .Values.airflow.dagProcessor.serviceAccount.name }}
+  {{- else }}
+    {{- default "default" .Values.airflow.dagProcessor.serviceAccount.name }}
+  {{- end }}
+{{- end }}
+
 {{- define "astro.registry_secret" -}}
   {{- default (printf "%s-registry" .Release.Name) .Values.airflow.registry.secretName }}
 {{- end }}

--- a/templates/airflow-scc-anyuid.yaml
+++ b/templates/airflow-scc-anyuid.yaml
@@ -32,6 +32,7 @@ users:
 - system:serviceaccount:{{ .Release.Namespace }}:{{ include "astro.triggerer.serviceAccountName" . }}
 - system:serviceaccount:{{ .Release.Namespace }}:{{ include "astro.pgbouncer.serviceAccountName" . }}
 - system:serviceaccount:{{ .Release.Namespace }}:{{ include "astro.cleanup.serviceAccountName" . }}
+- system:serviceaccount:{{ .Release.Namespace }}:{{ include "astro.dagProcessor.serviceAccountName" .}}
 {{- if .Values.dagDeploy.enabled }}
 - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-dag-server
 {{- end }}

--- a/tests/chart/test_dag_processor.py
+++ b/tests/chart/test_dag_processor.py
@@ -1,0 +1,51 @@
+from tests.chart.helm_template_generator import render_chart
+
+from . import get_containers_by_name
+
+
+class TestDagProcessor:
+    def test_dag_processor_defaults(self):
+        """Test Dag Processor defaults."""
+        docs = render_chart(
+            values={},
+            show_only=[
+                "charts/airflow/templates/dag-processor/dag-processor-deployment.yaml",
+                "charts/airflow/templates/dag-processor/dag-processor-serviceaccount.yaml",
+            ],
+        )
+        assert len(docs) == 0
+
+    def test_dag_processor_log_grommer_defaults(self):
+        """Test Dag Processor enabled defaults with log groomer."""
+        default_env_vars = [
+            {"name": "AIRFLOW__LOG_RETENTION_DAYS", "value": "15"},
+            {"name": "AIRFLOW_HOME", "value": "/usr/local/airflow"},
+        ]
+        docs = render_chart(
+            values={
+                "airflow": {"airflowVersion": "2.4.3", "dagProcessor": {"enabled": True}},
+            },
+            show_only=["charts/airflow/templates/dag-processor/dag-processor-deployment.yaml"],
+        )
+        assert len(docs) == 1
+        c_by_name = get_containers_by_name(docs[0])
+        assert "/usr/local/bin/clean-airflow-logs" in c_by_name["dag-processor-log-groomer"]["args"]
+        print(c_by_name["dag-processor-log-groomer"]["env"])
+        assert default_env_vars == c_by_name["dag-processor-log-groomer"]["env"]
+
+    def test_triggerer_log_grommer_overrides(self):
+        """Test Dag Processor enabled defaults with log groomer custom env vars."""
+        env = {"name": "ASTRONOMER__AIRFLOW___LOG_RETENTION_DAYS", "value": "5"}
+        docs = render_chart(
+            values={
+                "airflow": {
+                    "airflowVersion": "2.4.3",
+                    "dagProcessor": {"enabled": True, "logGroomerSidecar": {"env": [env]}},
+                },
+            },
+            show_only=["charts/airflow/templates/dag-processor/dag-processor-deployment.yaml"],
+        )
+        assert len(docs) == 1
+        c_by_name = get_containers_by_name(docs[0])
+        assert "/usr/local/bin/clean-airflow-logs" in c_by_name["dag-processor-log-groomer"]["args"]
+        assert env in c_by_name["dag-processor-log-groomer"]["env"]

--- a/tests/chart/test_dag_processor.py
+++ b/tests/chart/test_dag_processor.py
@@ -15,7 +15,7 @@ class TestDagProcessor:
         )
         assert len(docs) == 0
 
-    def test_dag_processor_log_grommer_defaults(self):
+    def test_dag_processor_enabled_with_log_grommer_defaults(self):
         """Test Dag Processor enabled defaults with log groomer."""
         default_env_vars = [
             {"name": "AIRFLOW__LOG_RETENTION_DAYS", "value": "15"},
@@ -33,7 +33,7 @@ class TestDagProcessor:
         print(c_by_name["dag-processor-log-groomer"]["env"])
         assert default_env_vars == c_by_name["dag-processor-log-groomer"]["env"]
 
-    def test_triggerer_log_grommer_overrides(self):
+    def test_dag_processor_enbaled_with_log_grommer_overrides(self):
         """Test Dag Processor enabled defaults with log groomer custom env vars."""
         env = {"name": "ASTRONOMER__AIRFLOW___LOG_RETENTION_DAYS", "value": "5"}
         docs = render_chart(

--- a/tests/chart/test_dag_processor.py
+++ b/tests/chart/test_dag_processor.py
@@ -49,3 +49,24 @@ class TestDagProcessor:
         c_by_name = get_containers_by_name(docs[0])
         assert "/usr/local/bin/clean-airflow-logs" in c_by_name["dag-processor-log-groomer"]["args"]
         assert env in c_by_name["dag-processor-log-groomer"]["env"]
+
+    def test_dag_processor_deployment_enabled_with_defaults(self):
+        """Test dag processor defaults."""
+
+        docs = render_chart(
+            values={
+                "airflow": {
+                    "airflowVersion": "2.4.3",
+                    "dagProcessor": {"enabled": True},
+                },
+            },
+            show_only=["charts/airflow/templates/dag-processor/dag-processor-deployment.yaml"],
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "Deployment"
+        assert doc["apiVersion"] == "apps/v1"
+        assert doc["metadata"]["name"] == "release-name-dag-processor"
+        assert doc["spec"]["template"]["spec"]["serviceAccountName"] == "release-name-airflow-dag-processor"
+        c_by_name = get_containers_by_name(doc)
+        assert len(c_by_name) == 2

--- a/tests/chart/test_scc.py
+++ b/tests/chart/test_scc.py
@@ -39,4 +39,5 @@ class TestAirflowSccPrivileges:
             "system:serviceaccount:default:release-name-airflow-triggerer",
             "system:serviceaccount:default:release-name-airflow-pgbouncer",
             "system:serviceaccount:default:release-name-airflow-cleanup",
+            "system:serviceaccount:default:airflow-dag-processor",
         ]

--- a/tests/chart/test_scc.py
+++ b/tests/chart/test_scc.py
@@ -19,9 +19,24 @@ class TestAirflowSccPrivileges:
         """Test airflow scc privileges with defaults - disabled."""
         docs = render_chart(
             kube_version=kube_version,
-            values={
-                "sccEnabled": True
-            },
+            values={"sccEnabled": True},
             show_only="templates/airflow-scc-anyuid.yaml",
         )
         assert len(docs) == 1
+        assert docs[0]["kind"] == "SecurityContextConstraints"
+        assert docs[0]["apiVersion"] == "security.openshift.io/v1"
+        assert docs[0]["metadata"]["name"] == "release-name-anyuid"
+        assert docs[0]["users"] == [
+            "system:serviceaccount:default:default",
+            "system:serviceaccount:default:release-name-airflow-webserver",
+            "system:serviceaccount:default:release-name-airflow-redis",
+            "system:serviceaccount:default:release-name-airflow-flower",
+            "system:serviceaccount:default:release-name-airflow-scheduler",
+            "system:serviceaccount:default:release-name-airflow-statsd",
+            "system:serviceaccount:default:release-name-airflow-create-user-job",
+            "system:serviceaccount:default:release-name-airflow-migrate-database-job",
+            "system:serviceaccount:default:release-name-airflow-worker",
+            "system:serviceaccount:default:release-name-airflow-triggerer",
+            "system:serviceaccount:default:release-name-airflow-pgbouncer",
+            "system:serviceaccount:default:release-name-airflow-cleanup",
+        ]

--- a/tests/chart/test_scc.py
+++ b/tests/chart/test_scc.py
@@ -39,5 +39,5 @@ class TestAirflowSccPrivileges:
             "system:serviceaccount:default:release-name-airflow-triggerer",
             "system:serviceaccount:default:release-name-airflow-pgbouncer",
             "system:serviceaccount:default:release-name-airflow-cleanup",
-            "system:serviceaccount:default:airflow-dag-processor",
+            "system:serviceaccount:default:release-name-dag-processor",
         ]

--- a/tests/chart/test_scc.py
+++ b/tests/chart/test_scc.py
@@ -14,3 +14,14 @@ class TestAirflowSccPrivileges:
             show_only="templates/airflow-scc-anyuid.yaml",
         )
         assert len(docs) == 0
+
+    def test_scc_privileges_enabled(self, kube_version):
+        """Test airflow scc privileges with defaults - disabled."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "sccEnabled": True
+            },
+            show_only="templates/airflow-scc-anyuid.yaml",
+        )
+        assert len(docs) == 1

--- a/tests/chart/test_scc.py
+++ b/tests/chart/test_scc.py
@@ -39,5 +39,5 @@ class TestAirflowSccPrivileges:
             "system:serviceaccount:default:release-name-airflow-triggerer",
             "system:serviceaccount:default:release-name-airflow-pgbouncer",
             "system:serviceaccount:default:release-name-airflow-cleanup",
-            "system:serviceaccount:default:release-name-dag-processor",
+            "system:serviceaccount:default:release-name-airflow-processor",
         ]

--- a/tests/chart/test_scc.py
+++ b/tests/chart/test_scc.py
@@ -39,5 +39,5 @@ class TestAirflowSccPrivileges:
             "system:serviceaccount:default:release-name-airflow-triggerer",
             "system:serviceaccount:default:release-name-airflow-pgbouncer",
             "system:serviceaccount:default:release-name-airflow-cleanup",
-            "system:serviceaccount:default:release-name-airflow-processor",
+            "system:serviceaccount:default:release-name-airflow-dag-processor",
         ]

--- a/tests/k8s_schema/v1.29.0-standalone/securitycontextconstraints-security-v1.json
+++ b/tests/k8s_schema/v1.29.0-standalone/securitycontextconstraints-security-v1.json
@@ -1,0 +1,48 @@
+{
+    "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+    "properties": {
+      "allowPrivilegeEscalation": {
+            "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+            "type": "boolean"
+      },
+      "capabilities": {
+        "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.",
+        "$ref": "https://kubernetesjsonschema.dev/v1.12.6/_definitions.json#/definitions/io.k8s.api.core.v1.Capabilities"
+      },
+      "privileged": {
+        "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
+        "type": [
+          "boolean"
+        ]
+      },
+      "procMount": {
+        "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "readOnlyRootFilesystem": {
+            "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+            "type": "boolean"
+      },
+      "runAsGroup": {
+        "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+        "type": [
+          "integer",
+          "null"
+        ],
+        "format": "int64"
+      },
+      "runAsNonRoot": {
+            "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+            "type": "boolean"
+      },
+      "seLinuxOptions": {
+        "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+        "$ref": "https://kubernetesjsonschema.dev/v1.12.6/_definitions.json#/definitions/io.k8s.api.core.v1.SELinuxOptions"
+      }
+    },
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object"
+  }

--- a/tests/k8s_schema/v1.30.0-standalone/securitycontextconstraints-security-v1.json
+++ b/tests/k8s_schema/v1.30.0-standalone/securitycontextconstraints-security-v1.json
@@ -1,0 +1,48 @@
+{
+    "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+    "properties": {
+      "allowPrivilegeEscalation": {
+            "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+            "type": "boolean"
+      },
+      "capabilities": {
+        "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.",
+        "$ref": "https://kubernetesjsonschema.dev/v1.12.6/_definitions.json#/definitions/io.k8s.api.core.v1.Capabilities"
+      },
+      "privileged": {
+        "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
+        "type": [
+          "boolean"
+        ]
+      },
+      "procMount": {
+        "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "readOnlyRootFilesystem": {
+            "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+            "type": "boolean"
+      },
+      "runAsGroup": {
+        "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+        "type": [
+          "integer",
+          "null"
+        ],
+        "format": "int64"
+      },
+      "runAsNonRoot": {
+            "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+            "type": "boolean"
+      },
+      "seLinuxOptions": {
+        "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+        "$ref": "https://kubernetesjsonschema.dev/v1.12.6/_definitions.json#/definitions/io.k8s.api.core.v1.SELinuxOptions"
+      }
+    },
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object"
+  }

--- a/tests/k8s_schema/v1.31.0-standalone/securitycontextconstraints-security-v1.json
+++ b/tests/k8s_schema/v1.31.0-standalone/securitycontextconstraints-security-v1.json
@@ -1,0 +1,48 @@
+{
+    "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+    "properties": {
+      "allowPrivilegeEscalation": {
+            "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+            "type": "boolean"
+      },
+      "capabilities": {
+        "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.",
+        "$ref": "https://kubernetesjsonschema.dev/v1.12.6/_definitions.json#/definitions/io.k8s.api.core.v1.Capabilities"
+      },
+      "privileged": {
+        "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
+        "type": [
+          "boolean"
+        ]
+      },
+      "procMount": {
+        "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "readOnlyRootFilesystem": {
+            "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+            "type": "boolean"
+      },
+      "runAsGroup": {
+        "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+        "type": [
+          "integer",
+          "null"
+        ],
+        "format": "int64"
+      },
+      "runAsNonRoot": {
+            "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+            "type": "boolean"
+      },
+      "seLinuxOptions": {
+        "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+        "$ref": "https://kubernetesjsonschema.dev/v1.12.6/_definitions.json#/definitions/io.k8s.api.core.v1.SELinuxOptions"
+      }
+    },
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object"
+  }

--- a/tests/k8s_schema/v1.32.0-standalone/securitycontextconstraints-security-v1.json
+++ b/tests/k8s_schema/v1.32.0-standalone/securitycontextconstraints-security-v1.json
@@ -1,0 +1,48 @@
+{
+    "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+    "properties": {
+      "allowPrivilegeEscalation": {
+            "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+            "type": "boolean"
+      },
+      "capabilities": {
+        "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.",
+        "$ref": "https://kubernetesjsonschema.dev/v1.12.6/_definitions.json#/definitions/io.k8s.api.core.v1.Capabilities"
+      },
+      "privileged": {
+        "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
+        "type": [
+          "boolean"
+        ]
+      },
+      "procMount": {
+        "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "readOnlyRootFilesystem": {
+            "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+            "type": "boolean"
+      },
+      "runAsGroup": {
+        "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+        "type": [
+          "integer",
+          "null"
+        ],
+        "format": "int64"
+      },
+      "runAsNonRoot": {
+            "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+            "type": "boolean"
+      },
+      "seLinuxOptions": {
+        "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+        "$ref": "https://kubernetesjsonschema.dev/v1.12.6/_definitions.json#/definitions/io.k8s.api.core.v1.SELinuxOptions"
+      }
+    },
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object"
+  }


### PR DESCRIPTION
## Description

Add dag processor scc support for openshift aro and on prem clusters

## Related Issues

 https://github.com/astronomer/issues/issues/6572

## Testing

QA should able to provision standalone dag processor with sccEnabled feature

## Merging

cherry-pick to all valid branches
