### PR TITLE
Correct and improve comments about volumeSync parameters.

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -636,11 +636,12 @@ gitSyncRelay:
       gitlab.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFSMqzJeV9rUzU4kWitGjeR4PWSa29SPqJ1fVkhtj3Hw9xjLVXVYrU9QlYWrOLXBpQ6KWjbjTDTdDkoohFzgbEY=
       gitlab.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf
   extraContainers: []
-  ## Enabling volumeSync disables the git-daemon and uses a shared volume as the sync mechanism between all airflow components and
-  ## the git-sync-relay
+  # volumeSync controls aspects of the volume that is used when "repoShareMode: shared_volume" is configured.
   volumeSync:
     volumeSize: 10Gi
-    # The specified storageClassName must support ReadWriteMany
+    # storageClassName specifies the name of the storageClass that is used when "repoShareMode: shared_volume" is configured.
+    # It *MUST* support ReadWriteMany. This value is required when using "repoShareMode: shared_volume". If it is left empty,
+    # or if the given storageClass does not support ReadWriteMany, all airflow pods that use the dags files will fail.
     storageClassName: ~
   serviceAccount:
     create: true


### PR DESCRIPTION
## Description

Improve and correct comments about volumeSync.

## Related Issues

https://github.com/astronomer/issues/issues/7177

## Testing

These are just comment changes, no testing is needed.

## Merging

Merge only to release-1.14, because that is the oldest version that supports `repoShareMode: shared_volume`