### PR TITLE
enable networkpolicy support for airflow astronomer components

### DIFF
--- a/templates/dag-deploy/dag-deploy-networkpolicy.yaml
+++ b/templates/dag-deploy/dag-deploy-networkpolicy.yaml
@@ -1,7 +1,7 @@
 ##############################
 ## dag-deploy NetworkPolicy ##
 ##############################
-{{- if and .Values.networkPolicyEnabled .Values.dagDeploy.enabled }}
+{{- if and .Values.networkPolicies.enabled .Values.dagDeploy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/templates/dag-deploy/dag-deploy-networkpolicy.yaml
+++ b/templates/dag-deploy/dag-deploy-networkpolicy.yaml
@@ -1,7 +1,7 @@
 ##############################
 ## dag-deploy NetworkPolicy ##
 ##############################
-{{- if and .Values.networkPolicies.enabled .Values.dagDeploy.enabled }}
+{{- if and .Values.airflow.networkPolicies.enabled .Values.dagDeploy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/templates/dag-deploy/dag-deploy-networkpolicy.yaml
+++ b/templates/dag-deploy/dag-deploy-networkpolicy.yaml
@@ -1,7 +1,7 @@
 ##############################
 ## dag-deploy NetworkPolicy ##
 ##############################
-{{- if .Values.dagDeploy.enabled }}
+{{- if and .Values.networkPolicyEnabled .Values.dagDeploy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/templates/git-sync-relay/git-sync-relay-networkpolicy.yaml
+++ b/templates/git-sync-relay/git-sync-relay-networkpolicy.yaml
@@ -1,7 +1,7 @@
 ##################################
 ## git-sync-relay NetworkPolicy ##
 ##################################
-{{- if and .Values.networkPolicyEnabled .Values.gitSyncRelay.enabled }}
+{{- if and .Values.networkPolicies.enabled .Values.gitSyncRelay.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/templates/git-sync-relay/git-sync-relay-networkpolicy.yaml
+++ b/templates/git-sync-relay/git-sync-relay-networkpolicy.yaml
@@ -1,7 +1,7 @@
 ##################################
 ## git-sync-relay NetworkPolicy ##
 ##################################
-{{- if and .Values.networkPolicies.enabled .Values.gitSyncRelay.enabled }}
+{{- if and .Values.airflow.networkPolicies.enabled .Values.gitSyncRelay.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/templates/git-sync-relay/git-sync-relay-networkpolicy.yaml
+++ b/templates/git-sync-relay/git-sync-relay-networkpolicy.yaml
@@ -1,7 +1,7 @@
 ##################################
 ## git-sync-relay NetworkPolicy ##
 ##################################
-{{- if .Values.gitSyncRelay.enabled }}
+{{- if and .Values.networkPolicyEnabled .Values.gitSyncRelay.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/tests/chart/test_dag_deploy_networkpolicy.py
+++ b/tests/chart/test_dag_deploy_networkpolicy.py
@@ -137,6 +137,7 @@ class TestDagDeployNetworkPolicy:
         """Test that a valid networkPolicy are rendered when authsidecar is enabled and ingressAllowedNamespaces is enabled."""
 
         values = {
+            "airflow": {"networkPolicies": {"enabled": True}},
             "dagDeploy": {"enabled": True},
             "authSidecar": {"enabled": True, "ingressAllowedNamespaces": ["astro", "ingress-namespace"]},
             "platform": {"namespace": "test-ns-99", "release": "test-release-42"},

--- a/tests/chart/test_dag_deploy_networkpolicy.py
+++ b/tests/chart/test_dag_deploy_networkpolicy.py
@@ -14,10 +14,27 @@ class TestDagDeployNetworkPolicy:
         )
         assert len(docs) == 0
 
+    def test_gsr_networkpolicy_defaults_with_authsidecar_enabled(self, kube_version):
+        """Test that a no networkPolicy are rendered when dag-deploy is enabled."""
+
+        values = {
+            "dagDeploy": {"enabled": True},
+            "authSidecar": {"enabled": True},
+            "platform": {"namespace": "test-ns-99", "release": "test-release-42"},
+        }
+
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/git-sync-relay/git-sync-relay-networkpolicy.yaml",
+            values=values,
+        )
+        assert len(docs) == 0
+
     def test_dag_deploy_networkpolicy_dag_deploy_enabled(self, kube_version):
         """Test that a valid networkPolicy are rendered when dag-deploy is enabled."""
 
         values = {
+            "airflow": {"networkPolicies": {"enabled": True}},
             "dagDeploy": {"enabled": True},
             "platform": {"namespace": "test-ns-99", "release": "test-release-42"},
         }

--- a/tests/chart/test_dag_deploy_networkpolicy.py
+++ b/tests/chart/test_dag_deploy_networkpolicy.py
@@ -88,6 +88,7 @@ class TestDagDeployNetworkPolicy:
         """Test that a valid networkPolicy are rendered when dag-deploy is enabled."""
 
         values = {
+            "airflow": {"networkPolicies": {"enabled": True}},
             "dagDeploy": {"enabled": True},
             "authSidecar": {"enabled": True},
             "platform": {"namespace": "test-ns-99", "release": "test-release-42"},

--- a/tests/chart/test_git_sync_relay_networkpolicy.py
+++ b/tests/chart/test_git_sync_relay_networkpolicy.py
@@ -82,6 +82,7 @@ class TestGitSyncRelayNetworkPolicy:
         """Test that a valid networkPolicy are rendered when git-sync-relay is enabled."""
 
         values = {
+            "airflow": {"networkPolicies": {"enabled": True}},
             "gitSyncRelay": {"enabled": True},
             "authSidecar": {"enabled": True},
             "platform": {"namespace": "test-ns-99", "release": "test-release-42"},

--- a/tests/chart/test_git_sync_relay_networkpolicy.py
+++ b/tests/chart/test_git_sync_relay_networkpolicy.py
@@ -128,6 +128,7 @@ class TestGitSyncRelayNetworkPolicy:
         """Test that a valid networkPolicy are rendered when authSidecar is enabled and ingressAllowedNamespaces is enabled."""
 
         values = {
+            "airflow": {"networkPolicies": {"enabled": True}},
             "gitSyncRelay": {"enabled": True},
             "authSidecar": {"enabled": True, "ingressAllowedNamespaces": ["astro", "ingress-namespace"]},
             "platform": {"namespace": "test-ns-99", "release": "test-release-42"},

--- a/tests/chart/test_git_sync_relay_networkpolicy.py
+++ b/tests/chart/test_git_sync_relay_networkpolicy.py
@@ -62,7 +62,23 @@ class TestGitSyncRelayNetworkPolicy:
         assert [{"protocol": "TCP", "port": 8000}] == spec["ingress"][0]["ports"]
         assert [{"protocol": "TCP", "port": 9418}] == spec["ingress"][1]["ports"]
 
-    def test_gsr_networkpolicy_with_authsidecar_enabled(self, kube_version):
+    def test_gsr_networkpolicy_defaults_with_authsidecar_enabled(self, kube_version):
+        """Test that a no networkPolicy are rendered when git-sync-relay is enabled."""
+
+        values = {
+            "gitSyncRelay": {"enabled": True},
+            "authSidecar": {"enabled": True},
+            "platform": {"namespace": "test-ns-99", "release": "test-release-42"},
+        }
+
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/git-sync-relay/git-sync-relay-networkpolicy.yaml",
+            values=values,
+        )
+        assert len(docs) == 0
+
+    def test_gsr_networkpolicy_enabled_with_authsidecar_enabled(self, kube_version):
         """Test that a valid networkPolicy are rendered when git-sync-relay is enabled."""
 
         values = {

--- a/tests/chart/test_git_sync_relay_networkpolicy.py
+++ b/tests/chart/test_git_sync_relay_networkpolicy.py
@@ -18,6 +18,7 @@ class TestGitSyncRelayNetworkPolicy:
         """Test that a valid networkPolicy are rendered when git-sync-relay is enabled."""
 
         values = {
+            "airflow": {"networkPolicies": {"enabled": True}},
             "gitSyncRelay": {"enabled": True},
             "platform": {"namespace": "test-ns-99", "release": "test-release-42"},
         }

--- a/values.yaml
+++ b/values.yaml
@@ -488,6 +488,9 @@ sccEnabled: false
 # Extra objects to deploy (these are passed through `tpl`)
 extraObjects: []
 
+# Disables networkpolicy for astronomer components 
+networkPolicyEnabled: true
+
 # Enable nginx auth sidecar
 authSidecar:
   enabled: false

--- a/values.yaml
+++ b/values.yaml
@@ -488,7 +488,7 @@ sccEnabled: false
 # Extra objects to deploy (these are passed through `tpl`)
 extraObjects: []
 
-# Disables networkpolicy for astronomer components 
+# Disables networkpolicy for astronomer components
 networkPolicyEnabled: true
 
 # Enable nginx auth sidecar

--- a/values.yaml
+++ b/values.yaml
@@ -488,9 +488,6 @@ sccEnabled: false
 # Extra objects to deploy (these are passed through `tpl`)
 extraObjects: []
 
-# Disables networkpolicy for astronomer components
-networkPolicyEnabled: true
-
 # Enable nginx auth sidecar
 authSidecar:
   enabled: false


### PR DESCRIPTION
## Description

Adds network policy support for astronomer provisioned airflow components 

## Related Issues

fixes  https://github.com/astronomer/issues/issues/7205

## Testing

QA should verify
```
airflow:
   networkPolicies:
       enabled: false
```


## Merging

Yet to update
