### PR TITLE
update backend custom chart version 1.13.3

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: airflow
-  repository: https://github.com/astronomer/airflow/releases/download/oss-helm-chart/1.13.2-astro
-  version: 1.13.2-astro
-digest: sha256:9433396b6e290f6722ee2babf25228cf7ad3e46001b0d6ada1bfa9d8e06fc677
-generated: "2025-02-03T10:57:35.655821+05:30"
+  repository: https://github.com/astronomer/airflow/releases/download/oss-helm-chart/1.13.3-astro
+  version: 1.13.3-astro
+digest: sha256:12c713c470a8a94c3f50e4f0fd065b941895b11e0bb9bfaef28311d862df6f89
+generated: "2025-05-06T17:46:50.032309+05:30"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v2 is Helm 3
 apiVersion: v2
 name: airflow
-version: 1.14.4
+version: 1.14.5
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:
@@ -9,5 +9,5 @@ keywords:
   - airflow
 dependencies:
   - name: airflow
-    version: 1.13.2-astro
-    repository: https://github.com/astronomer/airflow/releases/download/oss-helm-chart/1.13.2-astro
+    version: 1.13.3-astro
+    repository: https://github.com/astronomer/airflow/releases/download/oss-helm-chart/1.13.3-astro


### PR DESCRIPTION
## Description

This PR updates underlying airflow chart version and a version bump for astronomer airflow chart.

New Changes 
- Adds liveliness and readiness probes support for gitSync 
- Adds a conditional handle not to add liveliness and readiness probes for initContainers

custom chart PR -> https://github.com/astronomer/airflow/commit/1ba7a69a758dc6e532d810b36f5f54b0dab00763
OSS PR -> https://github.com/apache/airflow/pull/50218

## Related Issues

- https://github.com/astronomer/issues/issues/6929

## Testing

QA should now able to pass liveliness and readiness probe for git sync container

## Merging

merge and cherry-pick to release-1.14 and master
