### PR TITLE
7107 add global label test

### DIFF
--- a/templates/git-sync-relay/git-sync-relay-deployment.yaml
+++ b/templates/git-sync-relay/git-sync-relay-deployment.yaml
@@ -26,6 +26,9 @@ spec:
         release: {{ .Release.Name }}
         chart: "{{ .Release.Name }}-{{ .Chart.Version }}"
         heritage: {{ .Release.Service }}
+        {{- if .Values.labels }}
+        {{- .Values.labels | toYaml | nindent 8 }}
+        {{- end }}
     spec:
       {{- if or .Values.airflow.registry.secretName .Values.airflow.registry.connection }}
       imagePullSecrets:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,11 +3,11 @@ from pathlib import Path
 import yaml
 
 # The top-level path of this repository
-git_root_dir = [x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()][-1]
+git_root_dir = next(iter([x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()]), None)
 
-metadata = yaml.safe_load((Path(git_root_dir) / "metadata.yaml").read_text())
+metadata = yaml.safe_load((git_root_dir / "metadata.yaml").read_text())
 # replace all patch versions with 0 so we end up with ['a.b.0', 'x.y.0']
-supported_k8s_versions = [".".join(x.split(".")[:-1] + ["0"]) for x in metadata["test_k8s_versions"]]
+supported_k8s_versions = [".".join([*x.split(".")[:-1], "0"]) for x in metadata["test_k8s_versions"]]
 
 
 def container_env_to_dict(container):

--- a/tests/chart/__init__.py
+++ b/tests/chart/__init__.py
@@ -1,5 +1,9 @@
-# Adding all helper functions to be imported by other modules
-def get_containers_by_name(doc, include_init_containers=False):
+import yaml
+
+from tests import git_root_dir
+
+
+def get_containers_by_name(doc, include_init_containers=False) -> dict:
     """Given a single doc, return all the containers by name.
 
     doc must be a valid spec for a pod manager. (EG: ds, sts)
@@ -13,7 +17,11 @@ def get_containers_by_name(doc, include_init_containers=False):
     return c_by_name
 
 
-def get_service_ports_by_name(doc):
+def get_service_ports_by_name(doc) -> dict:
     """Given a single service doc, return all the ports by name."""
 
     return {port_config["name"]: port_config for port_config in doc["spec"]["ports"]}
+
+
+def get_all_features() -> dict:
+    return yaml.safe_load((git_root_dir / "tests" / "enable_all_features.yaml").read_text())

--- a/tests/chart/conftest.py
+++ b/tests/chart/conftest.py
@@ -16,13 +16,12 @@
 # under the License.
 
 import subprocess
-from pathlib import Path
 
 import docker
 import pytest
 from filelock import FileLock
 
-git_root_dir = [x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()][-1]
+from tests import git_root_dir
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/chart/helm_template_generator.py
+++ b/tests/chart/helm_template_generator.py
@@ -86,7 +86,7 @@ def render_chart(
     kube_version: str = default_version,
     namespace: str | None = None,
     validate_objects: bool = True,
-):
+) -> list:
     """Render a helm chart into dictionaries."""
     values = values or {}
     chart_dir = chart_dir or sys.path[0]
@@ -118,7 +118,7 @@ def render_chart(
         try:
             manifests = subprocess.check_output(command, stderr=subprocess.PIPE)
             if not manifests:
-                return None
+                return []
         except subprocess.CalledProcessError as error:
             if DEBUG:
                 print("ERROR: subprocess.CalledProcessError:")

--- a/tests/chart/helm_template_generator.py
+++ b/tests/chart/helm_template_generator.py
@@ -30,12 +30,11 @@ import requests
 import yaml
 from kubernetes.client.api_client import ApiClient
 
-from tests import supported_k8s_versions
+from tests import git_root_dir, supported_k8s_versions
 
 api_client = ApiClient()
 
 BASE_URL_SPEC = "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master"
-git_root_dir = [x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()][-1]
 DEBUG = os.getenv("DEBUG", "").lower() in ["yes", "true", "1"]
 default_version = supported_k8s_versions[-1]
 

--- a/tests/chart/test_global_labels.py
+++ b/tests/chart/test_global_labels.py
@@ -1,0 +1,76 @@
+import pytest
+
+from tests.chart import get_all_features
+from tests.chart.helm_template_generator import render_chart
+
+POD_MANAGER_SPEC_LABEL_PATH = {
+    "StatefulSet": "spec.template.metadata.labels",
+    "Deployment": "spec.template.metadata.labels",
+    "CronJob": "spec.jobTemplate.spec.template.metadata.labels",
+    "Job": "spec.template.metadata.labels",
+    "DaemonSet": "spec.template.metadata.labels",
+    "Pod": "metadata.labels",
+}
+
+
+def get_labels_from_object(obj) -> str | None:
+    """Helper to get nested dictionary value using dot notation path.
+
+    Example:
+        path = "spec.template.metadata.labels" returns obj["spec"]["template"]["metadata"]["labels"]
+    """
+    if not (path := POD_MANAGER_SPEC_LABEL_PATH.get(obj.get("kind", ""), "")):
+        return None
+    keys = path.split(".")
+    current = obj
+    try:
+        for key in keys:
+            current = current[key]
+        return current
+    except (KeyError, TypeError):
+        return None
+
+
+def get_labels_from_pod_managers(docs: list) -> dict:
+    """Given a list of docs, return a dict of all pod labels for any pod managers in the list.
+
+    Returns a dictionary mapping resource names to their labels.
+    """
+    pod_docs = []
+
+    for doc in docs:
+        if not isinstance(doc, dict) or "kind" not in doc or "metadata" not in doc:
+            continue
+
+        kind = doc["kind"]
+
+        if kind not in POD_MANAGER_SPEC_LABEL_PATH:
+            continue
+        pod_labels = get_labels_from_object(doc)
+
+        if pod_labels is None:
+            continue
+
+        metadata = doc.get("metadata", {})
+        name = metadata.get("name", "unknown")
+
+        pod_docs.append({"name": name, "kind": kind, "labels": pod_labels})
+
+    return {f"{doc['kind']}_{doc['name']}": doc["labels"] for doc in pod_docs}
+
+
+values = get_all_features()
+values["labels"] = {"test-label-1": "test-value-1"}
+values["airflow"]["labels"] = {"test-label-1": "test-value-1"}
+
+docs = render_chart(values=values)
+# postgres is not our chart and is only for dev, so we skip it
+label_data = {k: v for k, v in get_labels_from_pod_managers(docs).items() if not k.endswith("postgresql")}
+
+
+@pytest.mark.parametrize("resource_name,pod_labels", list(label_data.items()), ids=list(label_data.keys()))
+def test_label_overrides(resource_name, pod_labels):
+    """Ensure that all pods get labels when using value overrides."""
+
+    assert "test-label-1" in pod_labels, f"Label 'test-label-1' not found in {resource_name}"
+    assert pod_labels["test-label-1"] == "test-value-1", f"Label 'test-label-1' has unexpected value in {resource_name}"

--- a/values.yaml
+++ b/values.yaml
@@ -651,3 +651,6 @@ gitSyncRelay:
 certgenerator:
   extraAnnotations: {}
   affinity: {}
+
+# Labels that are attached to all pods created by the airflow-chart, but not the sub-charts.
+labels: {}


### PR DESCRIPTION
## Description

- Add tests to ensure that `.Values.labels` adds labels to all pods.
- Fix the one place that the tests failed.

## Related Issues

- https://github.com/astronomer/issues/issues/7382
- Tangentially related to https://github.com/astronomer/issues/issues/7107

## Testing

No testing needed. Unit tests cover everything. Nothing will change unless the customers add new configuration values.

## Merging

Merge everywhere. It's only really needed for "Software" 1.0