### PR TITLE
helm 3.18.4, kind 0.29, latest ci runners.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ jobs:
   run_pre_commit:
     resource_class: small
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2025-05
+      - image: quay.io/astronomer/ci-pre-commit:2025-07
     steps:
       - checkout
       - run:
@@ -180,7 +180,7 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2025-05
+      - image: quay.io/astronomer/ci-helm-release:2025-07
     parallelism: 8
     steps:
       - setup_remote_docker:
@@ -199,7 +199,7 @@ jobs:
 
   build-and-release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2025-05
+      - image: quay.io/astronomer/ci-helm-release:2025-07
     steps:
       - checkout
       - run:
@@ -239,7 +239,7 @@ jobs:
           path: test-results
   release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2025-05
+      - image: quay.io/astronomer/ci-helm-release:2025-07
     steps:
       - checkout
       - run:
@@ -248,7 +248,7 @@ jobs:
 
   release-public:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2025-05
+      - image: quay.io/astronomer/ci-helm-release:2025-07
     steps:
       - checkout
       - publish-github-release

--- a/bin/generate_circleci_config.py
+++ b/bin/generate_circleci_config.py
@@ -13,7 +13,7 @@ kube_versions = metadata["test_k8s_versions"]
 
 executors = ["CeleryExecutor", "LocalExecutor", "KubernetesExecutor"]
 machine_image_version = "ubuntu-2204:2024.11.1"  # https://circleci.com/developer/machine/image/ubuntu-2204
-ci_runner_version = "2025-05"  # This should be the current YYYY-MM
+ci_runner_version = "2025-07"  # This should be the current YYYY-MM
 
 
 def main():

--- a/bin/install-ci-tools
+++ b/bin/install-ci-tools
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-KIND_VERSION="0.27.0" # https://github.com/kubernetes-sigs/kind/releases
-HELM_VERSION="3.17.3" # https://github.com/helm/helm/releases
+KIND_VERSION="0.29.0" # https://github.com/kubernetes-sigs/kind/releases
+HELM_VERSION="3.18.4" # https://github.com/helm/helm/releases
 
 # Determine the platform we are running on
 OS=$(uname | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
## Description

- helm 3.18.4 (CVE fix)
- kind 0.29
- ci runners 2025-07 which include helm 3.18.4 starting today

## Related Issues

- <https://github.com/astronomer/issues/issues/7452>

## Testing

No testing needed

## Merging

This should go everywhere. Any merge conflicts should prioritize these changes over whatever is in the other branch.