### PR TITLE
add taint, toleration and node selector support

### DIFF
--- a/templates/dag-deploy/dag-server-statefulset.yaml
+++ b/templates/dag-deploy/dag-server-statefulset.yaml
@@ -42,6 +42,9 @@ spec:
       imagePullSecrets:
         - name: {{ template "astro.registry_secret" . }}
       {{- end }}
+      nodeSelector: {{ toYaml .Values.dagDeploy.nodeSelector | nindent 8 }}
+      affinity: {{ toYaml .Values.dagDeploy.affinity | nindent 8 }}
+      tolerations: {{ toYaml .Values.dagDeploy.tolerations | nindent 8 }}
       serviceAccountName: {{ template "astro.dagDeploy.serviceAccountName" . }}
       securityContext: {{ toYaml .Values.dagDeploy.securityContexts.pod | nindent 8 }}
       containers:

--- a/templates/git-sync-relay/git-sync-relay-deployment.yaml
+++ b/templates/git-sync-relay/git-sync-relay-deployment.yaml
@@ -34,9 +34,9 @@ spec:
       imagePullSecrets:
         - name: {{ template "astro.registry_secret" . }}
       {{- end }}
-      nodeSelector: {{ toYaml .Values.gitSyncRelay.nodeSelector | indent 8 }}
-      affinity: {{ toYaml .Values.gitSyncRelay.affinity | indent 8 }}
-      tolerations: {{ toYaml  .Values.gitSyncRelay.tolerations | indent 8 }}
+      nodeSelector: {{ toYaml .Values.gitSyncRelay.nodeSelector | nindent 8 }}
+      affinity: {{ toYaml .Values.gitSyncRelay.affinity | nindent 8 }}
+      tolerations: {{ toYaml .Values.gitSyncRelay.tolerations | nindent 8 }}
       serviceAccountName: {{ template "astro.gitSyncRelay.serviceAccountName" . }}
       securityContext: {{ toYaml .Values.gitSyncRelay.securityContext | nindent 8 }}
       volumes:

--- a/templates/git-sync-relay/git-sync-relay-deployment.yaml
+++ b/templates/git-sync-relay/git-sync-relay-deployment.yaml
@@ -34,6 +34,9 @@ spec:
       imagePullSecrets:
         - name: {{ template "astro.registry_secret" . }}
       {{- end }}
+      nodeSelector: {{ toYaml .Values.gitSyncRelay.nodeSelector | indent 8 }}
+      affinity: {{ toYaml .Values.gitSyncRelay.affinity | indent 8 }}
+      tolerations: {{ toYaml  .Values.gitSyncRelay.tolerations | indent 8 }}
       serviceAccountName: {{ template "astro.gitSyncRelay.serviceAccountName" . }}
       securityContext: {{ toYaml .Values.gitSyncRelay.securityContext | nindent 8 }}
       volumes:

--- a/tests/chart/conftest.py
+++ b/tests/chart/conftest.py
@@ -73,3 +73,34 @@ def docker_client():
         client = docker.from_env()
         yield client
         client.close()
+
+
+@pytest.fixture(scope="function")
+def airflow_node_pool_config():
+    yield {
+        "nodeSelector": {"role": "airflow"},
+        "affinity": {
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "astronomer.io/multi-tenant",
+                                    "operator": "In",
+                                    "values": ["false"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "tolerations": [
+            {
+                "effect": "NoSchedule",
+                "key": "airflow",
+                "operator": "Exists",
+            }
+        ],
+    }

--- a/tests/chart/test_dag_server_statefulset.py
+++ b/tests/chart/test_dag_server_statefulset.py
@@ -62,6 +62,10 @@ class TestDagServerStatefulSet:
         assert env_vars["HOUSTON_SERVICE_ENDPOINT"] == "http://-houston..svc.cluster.local.:8871/v1/"
 
         assert "persistentVolumeClaimRetentionPolicy" not in doc["spec"]
+        spec = docs[0]["spec"]["template"]["spec"]
+        assert spec["nodeSelector"] == {}
+        assert spec["affinity"] == {}
+        assert spec["tolerations"] == []
 
     def test_dag_server_statefulset_houston_service_endpoint_override(self, kube_version):
         """Test that we see the right HOUSTON_SERVICE_ENDPOINT value when the relevant variables are set."""
@@ -320,7 +324,7 @@ class TestDagServerStatefulSet:
         assert doc["metadata"]["name"] == "release-name-dag-server"
 
     def test_dag_server_affinity(self, kube_version, airflow_node_pool_config):
-        """Test that dagserver affinity correctly inserts the affinity."""
+        """Test that dagserver affinity correctly inserts affinity, node pool and tolleration configs."""
         values = {
             "dagDeploy": {
                 "enabled": True,
@@ -338,6 +342,7 @@ class TestDagServerStatefulSet:
         doc = docs[0]
         common_default_tests(doc)
         assert len(docs) == 1
-        assert docs[0]["spec"]["template"]["spec"]["affinity"] == airflow_node_pool_config["affinity"]
-        assert docs[0]["spec"]["template"]["spec"]["nodeSelector"] == airflow_node_pool_config["nodeSelector"]
-        assert docs[0]["spec"]["template"]["spec"]["tolerations"] == airflow_node_pool_config["tolerations"]
+        spec = docs[0]["spec"]["template"]["spec"]
+        assert spec["affinity"] == airflow_node_pool_config["affinity"]
+        assert spec["nodeSelector"] == airflow_node_pool_config["nodeSelector"]
+        assert spec["tolerations"] == airflow_node_pool_config["tolerations"]

--- a/tests/chart/test_dag_server_statefulset.py
+++ b/tests/chart/test_dag_server_statefulset.py
@@ -324,7 +324,7 @@ class TestDagServerStatefulSet:
         assert doc["metadata"]["name"] == "release-name-dag-server"
 
     def test_dag_server_affinity(self, kube_version, airflow_node_pool_config):
-        """Test that dagserver affinity correctly inserts affinity, node pool and tolleration configs."""
+        """Test that dagserver affinity correctly inserts affinity, node pool and toleration configs."""
         values = {
             "dagDeploy": {
                 "enabled": True,

--- a/tests/chart/test_dag_server_statefulset.py
+++ b/tests/chart/test_dag_server_statefulset.py
@@ -338,8 +338,7 @@ class TestDagServerStatefulSet:
                 }
             }
         }
-        values = {"dagDeploy": {"enabled": True,
-                                "affinity": affinity }}
+        values = {"dagDeploy": {"enabled": True, "affinity": affinity}}
 
         docs = render_chart(
             kube_version=kube_version,

--- a/tests/chart/test_dag_server_statefulset.py
+++ b/tests/chart/test_dag_server_statefulset.py
@@ -318,3 +318,35 @@ class TestDagServerStatefulSet:
         doc = docs[0]
         assert doc["kind"] == "StatefulSet"
         assert doc["metadata"]["name"] == "release-name-dag-server"
+
+    def test_dag_server_affinity(self, kube_version):
+        """Test that dagserver affinity correctly inserts the affinity."""
+        affinity = {
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "foo",
+                                    "operator": "In",
+                                    "values": ["bar", "baz"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+        values = {"dagDeploy": {"enabled": True,
+                                "affinity": affinity }}
+
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/dag-deploy/dag-server-statefulset.yaml",
+            values=values,
+        )
+        doc = docs[0]
+        common_default_tests(doc)
+        assert len(docs) == 1
+        assert docs[0]["spec"]["template"]["spec"]["affinity"] == affinity

--- a/tests/chart/test_git_sync_relay_deployment.py
+++ b/tests/chart/test_git_sync_relay_deployment.py
@@ -368,3 +368,38 @@ class TestGitSyncRelayDeployment:
         doc = docs[0]
         assert doc["kind"] == "Deployment"
         assert doc["metadata"]["name"] == "release-name-git-sync-relay"
+
+
+    def test_git_sync_relay_affinity(self, kube_version):
+        """Test that git sync relay affinity correctly inserts the affinity."""
+        affinity = {
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "foo",
+                                    "operator": "In",
+                                    "values": ["bar", "baz"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+        values={
+                "gitSyncRelay": {
+                    "enabled": True,
+                    "affinity": affinity
+                },
+            }
+
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/git-sync-relay/git-sync-relay-deployment.yaml",
+            values=values,
+        )
+        assert len(docs) == 1
+        assert docs[0]["spec"]["template"]["spec"]["affinity"] == affinity

--- a/tests/chart/test_git_sync_relay_deployment.py
+++ b/tests/chart/test_git_sync_relay_deployment.py
@@ -369,7 +369,6 @@ class TestGitSyncRelayDeployment:
         assert doc["kind"] == "Deployment"
         assert doc["metadata"]["name"] == "release-name-git-sync-relay"
 
-
     def test_git_sync_relay_affinity(self, kube_version):
         """Test that git sync relay affinity correctly inserts the affinity."""
         affinity = {
@@ -389,12 +388,9 @@ class TestGitSyncRelayDeployment:
                 }
             }
         }
-        values={
-                "gitSyncRelay": {
-                    "enabled": True,
-                    "affinity": affinity
-                },
-            }
+        values = {
+            "gitSyncRelay": {"enabled": True, "affinity": affinity},
+        }
 
         docs = render_chart(
             kube_version=kube_version,

--- a/tests/chart/test_git_sync_relay_deployment.py
+++ b/tests/chart/test_git_sync_relay_deployment.py
@@ -374,7 +374,7 @@ class TestGitSyncRelayDeployment:
         assert doc["metadata"]["name"] == "release-name-git-sync-relay"
 
     def test_git_sync_relay_affinity(self, kube_version, airflow_node_pool_config):
-        """Test that git sync relay affinity, node pool and tolleration configs."""
+        """Test that git sync relay affinity, node pool and toleration configs."""
         values = {
             "gitSyncRelay": {
                 "enabled": True,

--- a/values.yaml
+++ b/values.yaml
@@ -571,6 +571,9 @@ dagDeploy:
     size: 10Gi
     storageClassName: ~
     annotations: {}
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
 
   ports:
     dagServerHttp: 8000
@@ -647,6 +650,9 @@ gitSyncRelay:
     create: true
     annotations: {}
     name: ~
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
 
 certgenerator:
   extraAnnotations: {}


### PR DESCRIPTION
## Description

add taint,tolleration and node selector support for git-sync-relay and dag-server

## Related Issues

- https://github.com/astronomer/issues/issues/7526
- https://github.com/astronomer/issues/issues/7335

## Testing

QA should able to override taint,tolleration and node selector for git-sync and dag-server components

## Merging

merge to master and release-1.15
