### PR TITLE
\/airflow wide config pattern enablement for node selector, tolleration and taints

### DIFF
--- a/templates/dag-deploy/dag-server-statefulset.yaml
+++ b/templates/dag-deploy/dag-server-statefulset.yaml
@@ -48,6 +48,7 @@ spec:
       nodeSelector: {{- toYaml $nodeSelector | nindent 8 }}
       affinity: {{- toYaml $affinity | nindent 8 }}
       tolerations: {{- toYaml $tolerations | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.dagDeploy.terminationGracePeriodSeconds }}
       serviceAccountName: {{ template "astro.dagDeploy.serviceAccountName" . }}
       securityContext: {{ toYaml .Values.dagDeploy.securityContexts.pod | nindent 8 }}
       containers:

--- a/templates/dag-deploy/dag-server-statefulset.yaml
+++ b/templates/dag-deploy/dag-server-statefulset.yaml
@@ -2,6 +2,9 @@
 ## dag-server StatefulSet ##
 ############################
 {{- if .Values.dagDeploy.enabled }}
+{{- $nodeSelector := or .Values.dagDeploy.nodeSelector .Values.airflow.nodeSelector }}
+{{- $affinity := or .Values.dagDeploy.affinity .Values.airflow.affinity }}
+{{- $tolerations := or .Values.dagDeploy.tolerations .Values.airflow.tolerations }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -42,9 +45,9 @@ spec:
       imagePullSecrets:
         - name: {{ template "astro.registry_secret" . }}
       {{- end }}
-      nodeSelector: {{ toYaml .Values.dagDeploy.nodeSelector | nindent 8 }}
-      affinity: {{ toYaml .Values.dagDeploy.affinity | nindent 8 }}
-      tolerations: {{ toYaml .Values.dagDeploy.tolerations | nindent 8 }}
+      nodeSelector: {{- toYaml $nodeSelector | nindent 8 }}
+      affinity: {{- toYaml $affinity | nindent 8 }}
+      tolerations: {{- toYaml $tolerations | nindent 8 }}
       serviceAccountName: {{ template "astro.dagDeploy.serviceAccountName" . }}
       securityContext: {{ toYaml .Values.dagDeploy.securityContexts.pod | nindent 8 }}
       containers:

--- a/templates/git-sync-relay/git-sync-relay-deployment.yaml
+++ b/templates/git-sync-relay/git-sync-relay-deployment.yaml
@@ -40,6 +40,7 @@ spec:
       nodeSelector: {{- toYaml $nodeSelector | nindent 8 }}
       affinity: {{- toYaml $affinity | nindent 8 }}
       tolerations: {{- toYaml $tolerations | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.gitSyncRelay.terminationGracePeriodSeconds }}
       serviceAccountName: {{ template "astro.gitSyncRelay.serviceAccountName" . }}
       securityContext: {{ toYaml .Values.gitSyncRelay.securityContext | nindent 8 }}
       volumes:

--- a/templates/git-sync-relay/git-sync-relay-deployment.yaml
+++ b/templates/git-sync-relay/git-sync-relay-deployment.yaml
@@ -2,6 +2,9 @@
 ## git-sync-relay Deployment ##
 ###############################
 {{- if .Values.gitSyncRelay.enabled }}
+{{- $nodeSelector := or .Values.gitSyncRelay.nodeSelector .Values.airflow.nodeSelector }}
+{{- $affinity := or .Values.gitSyncRelay.affinity .Values.airflow.affinity }}
+{{- $tolerations := or .Values.gitSyncRelay.tolerations .Values.airflow.tolerations }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -34,9 +37,9 @@ spec:
       imagePullSecrets:
         - name: {{ template "astro.registry_secret" . }}
       {{- end }}
-      nodeSelector: {{ toYaml .Values.gitSyncRelay.nodeSelector | nindent 8 }}
-      affinity: {{ toYaml .Values.gitSyncRelay.affinity | nindent 8 }}
-      tolerations: {{ toYaml .Values.gitSyncRelay.tolerations | nindent 8 }}
+      nodeSelector: {{- toYaml $nodeSelector | nindent 8 }}
+      affinity: {{- toYaml $affinity | nindent 8 }}
+      tolerations: {{- toYaml $tolerations | nindent 8 }}
       serviceAccountName: {{ template "astro.gitSyncRelay.serviceAccountName" . }}
       securityContext: {{ toYaml .Values.gitSyncRelay.securityContext | nindent 8 }}
       volumes:

--- a/tests/chart/test_git_sync_relay_deployment.py
+++ b/tests/chart/test_git_sync_relay_deployment.py
@@ -373,6 +373,28 @@ class TestGitSyncRelayDeployment:
         assert doc["kind"] == "Deployment"
         assert doc["metadata"]["name"] == "release-name-git-sync-relay"
 
+    def test_git_sync_relay_airflow_affinity(self, kube_version, airflow_node_pool_config):
+        """Test that git sync relay global airflow affinity, node pool and toleration configs."""
+        values = {
+            "airflow": {
+                "nodeSelector": airflow_node_pool_config["nodeSelector"],
+                "affinity": airflow_node_pool_config["affinity"],
+                "tolerations": airflow_node_pool_config["tolerations"],
+            },
+            "gitSyncRelay": {"enabled": True},
+        }
+
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/git-sync-relay/git-sync-relay-deployment.yaml",
+            values=values,
+        )
+        assert len(docs) == 1
+        spec = docs[0]["spec"]["template"]["spec"]
+        assert spec["affinity"] == airflow_node_pool_config["affinity"]
+        assert spec["nodeSelector"] == airflow_node_pool_config["nodeSelector"]
+        assert spec["tolerations"] == airflow_node_pool_config["tolerations"]
+
     def test_git_sync_relay_affinity(self, kube_version, airflow_node_pool_config):
         """Test that git sync relay affinity, node pool and toleration configs."""
         values = {

--- a/values.yaml
+++ b/values.yaml
@@ -610,6 +610,7 @@ gitSyncRelay:
   # webhookSecurityKey is only needed when repoFetchMode=webhook
   webhookSecretKey: ~
   securityContext: {}
+  terminationGracePeriodSeconds: 30
   gitDaemon: {}
   gitSync:
     webhookPort: 8000


### PR DESCRIPTION
## Description

add taint,tolleration and node selector support for git-sync-relay and dag-server

## Related Issues

- https://github.com/astronomer/issues/issues/7526
- https://github.com/astronomer/issues/issues/7335

## Testing

QA should able to override taint,tolleration and node selector for git-sync and dag-server components

## Merging

merge to master and release-1.15
