### PR TITLE
fix workers scheduling ordering

### DIFF
--- a/tests/chart/test_pod_template.py
+++ b/tests/chart/test_pod_template.py
@@ -209,7 +209,7 @@ class TestPodTemplate:
         assert podTemplate["spec"]["tolerations"] == airflow_node_pool_config["tolerations"]
 
     def test_pod_template_worker_scheduling_overrides(self, kube_version, airflow_node_pool_config):
-        """Test airflow pod template scheduling overrides."""
+        """Test that nodeSelector, affinity, and tolerations defined at the worker level take precedence over global values."""
         nodeSelector = {"role": "worker"}
         tolerations = [
             {

--- a/tests/chart/test_pod_template.py
+++ b/tests/chart/test_pod_template.py
@@ -27,6 +27,9 @@ class TestPodTemplate:
         assert {"tier": "airflow", "component": "worker", "release": "release-name"} == podTemplate["metadata"]["labels"]
         assert "runtimeClassName" not in podTemplate["spec"]
         assert "priorityClassName" not in podTemplate["spec"]
+        assert podTemplate["spec"]["nodeSelector"] == {}
+        assert podTemplate["spec"]["affinity"] == {}
+        assert podTemplate["spec"]["tolerations"] == []
 
     def test_pod_template_labels_overrides(self, kube_version):
         """Test airflow pod template labels overrides."""

--- a/values.yaml
+++ b/values.yaml
@@ -198,9 +198,9 @@ airflow:
     # specific language governing permissions and limitations
     # under the License.
     ---
-    {{- $nodeSelector := or .Values.nodeSelector .Values.workers.nodeSelector }}
-    {{- $affinity := or .Values.affinity .Values.workers.affinity }}
-    {{- $tolerations := or .Values.tolerations .Values.workers.tolerations }}
+    {{- $nodeSelector := or .Values.workers.nodeSelector .Values.nodeSelector }}
+    {{- $affinity := or .Values.workers.affinity .Values.affinity }}
+    {{- $tolerations := or .Values.workers.tolerations .Values.tolerations }}
     {{- $securityContext := include "airflowPodSecurityContext" (list . .Values.workers) }}
     {{- $containerSecurityContext := include "containerSecurityContext" (list . .Values.workers) }}
     apiVersion: v1


### PR DESCRIPTION
## Description

currently airflow toleration, nodeselector and affinity takes higher precedence than worker specific configuration which is incorrect with this new change worker configuration takes higher priority than airflow defaults

## Related Issues

- https://github.com/astronomer/issues/issues/7615

## Testing

QA should able to pass customer nodeSelector, tolerations and affinity config to workers section to see those values are getting higher precedence order than defaults

## Merging

merge to master, release-1.15
