### PR TITLE
add execution api server url

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -358,6 +358,8 @@ airflow:
       # Set Flower URL prefix to empty string
       # Remove after https://github.com/apache/airflow/issues/27402 is resolved
       flower_url_prefix: ""
+    core:
+      execution_api_server_url: '{{ (printf "http://%s-api-server:%d/%s/airflow/execution/" (include "airflow.fullname" .) (int .Values.ports.apiServer) .Release.Name )  -}}'
 
     webserver:
       expose_config: True


### PR DESCRIPTION
## Description

Add airflow  execution api server url configuration which is needed for airflow3 

## Related Issues

https://github.com/astronomer/issues/issues/7650

## Testing

QA should able to run tasks from airflow3

## Merging

merge to master and release-1.0
