### PR TITLE
remove houston service endpoint from dagserver

### DIFF
--- a/templates/dag-deploy/dag-server-statefulset.yaml
+++ b/templates/dag-deploy/dag-server-statefulset.yaml
@@ -70,8 +70,6 @@ spec:
           resources:
             {{- toYaml .Values.dagDeploy.resources | nindent 12 }}
           env:
-          - name: HOUSTON_SERVICE_ENDPOINT
-            value: "http://{{ .Values.platform.release }}-houston.{{ .Values.platform.namespace }}.svc.cluster.local.:8871/v1/"
 {{- if .Values.dagDeploy.extraEnv }}
 {{ toYaml .Values.dagDeploy.extraEnv | indent 10 }}
 {{- end }}

--- a/tests/chart/test_dag_server_statefulset.py
+++ b/tests/chart/test_dag_server_statefulset.py
@@ -64,16 +64,10 @@ class TestDagServerStatefulSet:
 
     def test_dag_server_statefulset_houston_service_endpoint_override(self, kube_version):
         """Test that we see the right HOUSTON_SERVICE_ENDPOINT value when the relevant variables are set."""
-        extraEnv = [{
-            "name": "HOUSTON_SERVICE_ENDPOINT",
-            "value": "http://test-release-houston.test-namespace.svc.cluster.local.:8871/v1/"
-        }]
-        values = {
-            "dagDeploy": {
-                "enabled": True,
-                "extraEnv":extraEnv
-                        }
-        }
+        extraEnv = [
+            {"name": "HOUSTON_SERVICE_ENDPOINT", "value": "http://test-release-houston.test-namespace.svc.cluster.local.:8871/v1/"}
+        ]
+        values = {"dagDeploy": {"enabled": True, "extraEnv": extraEnv}}
 
         docs = render_chart(
             kube_version=kube_version,

--- a/tests/chart/test_dag_server_statefulset.py
+++ b/tests/chart/test_dag_server_statefulset.py
@@ -56,11 +56,6 @@ class TestDagServerStatefulSet:
 
         common_default_tests(doc)
 
-        c_by_name = get_containers_by_name(doc)
-
-        env_vars = {x["name"]: x["value"] for x in c_by_name["dag-server"]["env"]}
-        assert env_vars["HOUSTON_SERVICE_ENDPOINT"] == "http://-houston..svc.cluster.local.:8871/v1/"
-
         assert "persistentVolumeClaimRetentionPolicy" not in doc["spec"]
         spec = docs[0]["spec"]["template"]["spec"]
         assert spec["nodeSelector"] == {}
@@ -69,9 +64,15 @@ class TestDagServerStatefulSet:
 
     def test_dag_server_statefulset_houston_service_endpoint_override(self, kube_version):
         """Test that we see the right HOUSTON_SERVICE_ENDPOINT value when the relevant variables are set."""
+        extraEnv = [{
+            "name": "HOUSTON_SERVICE_ENDPOINT",
+            "value": "http://test-release-houston.test-namespace.svc.cluster.local.:8871/v1/"
+        }]
         values = {
-            "dagDeploy": {"enabled": True},
-            "platform": {"release": "test-release", "namespace": "test-namespace"},
+            "dagDeploy": {
+                "enabled": True,
+                "extraEnv":extraEnv
+                        }
         }
 
         docs = render_chart(


### PR DESCRIPTION
## Description

Generate Houston service URL from api that will be passed to airflow deployment to update deploy revision to database .
previously it was all way around connecting to local houston url , due to our new control and dataplane logic it will need a public URL for internal communication

## Related Issues

- https://github.com/astronomer/issues/issues/7656

## Testing

<img width="3440" height="488" alt="image" src="https://github.com/user-attachments/assets/5656273d-98e1-4750-8f21-92b03ca495fc" />


## Merging

merge to master
