### PR TITLE
Addapiserver

### DIFF
--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -82,6 +82,14 @@ data:
           type: "vrl"
           source: 'includes(["airflow-downgrade"], .component)'
 
+      filter_apiserver_logs:
+        type: filter
+        inputs:
+          - transform_airflow_logs
+        condition:
+          type: "vrl"
+          source: 'includes(["api-server"], .component)'
+
       transform_task_log:
         type: remap
         inputs:
@@ -114,6 +122,7 @@ data:
           - filter_gitsyncrelay_logs
           - filter_dagserver_logs
           - filter_airflow_downgrade_logs
+          - filter_apiserver_logs
         source: |
           del(.host)
           del(.file)


### PR DESCRIPTION
## Description

This change adds support for collecting logs from the api-server component in the Vector logging sidecar configuration. The api-server component was missing from the existing component filters, preventing its logs from being properly collected and forwarded to Elasticsearch.

## Changes Made

- Added `filter_apiserver_logs` transform to filter logs specifically from the `api-server` component
- Updated `transform_remove_fields` inputs to include the new `api-server` filter

## Related Issues

- https://github.com/astronomer/issues/issues/7390

## Testing

API server logs will now be collected alongside other Airflow component logs and indexed in Elasticsearch with the same naming pattern as existing components when usinf Airflow3

## Merging

Master, 1.17