### PR TITLE
Remove the FS group added to dagserver

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -605,8 +605,7 @@ dagDeploy:
   safeToEvict: true
 
   securityContexts:
-    pod:
-      fsGroup: 50000
+    pod: {}
     container: {}
 
 gitSyncRelay:


### PR DESCRIPTION
## Description

This PR intends to remove FSgroup which was added to dagserver securitycontext.

## Related Issues

https://github.com/astronomer/issues/issues/7800

## Testing

- N/A
## Merging

Master