### PR TITLE
remove webserver authsidecar config when airflow3 is enabled

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v2 is Helm 3
 apiVersion: v2
 name: airflow
-version: 1.17.4
+version: 1.17.5
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:

--- a/templates/webserver/webserver-auth-sidecar-configmap.yaml
+++ b/templates/webserver/webserver-auth-sidecar-configmap.yaml
@@ -1,7 +1,7 @@
 ######################################
 ## WebServer auth sidecar ConfigMap ##
 ######################################
-{{- if .Values.authSidecar.enabled  }}
+{{- if and ( semverCompare "<3.0.0" .Values.airflow.airflowVersion )  .Values.authSidecar.enabled  }}
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/tests/chart/test_auth_sidecar.py
+++ b/tests/chart/test_auth_sidecar.py
@@ -100,6 +100,20 @@ class TestAuthSidecar:
         )
         assert len(docs) == 0
 
+    def test_webserver_auth_sidecar_config_not_enabled_with_airflow3(self, kube_version):
+        """Test webserver auth sidecar config is not generated for Airflow 3.x"""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "authSidecar": {"enabled": True},
+                "airflow": {"airflowVersion": "3.0.0"},
+            },
+            show_only=[
+                "templates/webserver/webserver-auth-sidecar-configmap.yaml",
+            ],
+        )
+        assert len(docs) == 0
+
     def test_auth_sidecar_config_with_dag_server_enabled(self, kube_version):
         """Test logging sidecar config with defaults"""
         resources = {


### PR DESCRIPTION
## Description

remove webserver authsidecar config when airflow3 is enabled

## Related Issues

- https://github.com/astronomer/issues/issues/7955

## Testing

QA should not see webserver authsidecar configmap when airflow 3 enabled

## Merging

merge to master and release-1.0
