### PR TITLE
PINF-377: Enable sidecar ingestion of airflow file logs for AF2 as well.

### DIFF
--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -22,9 +22,7 @@ data:
         type: file
         include:
           - "${SIDECAR_LOGS}/*.log"
-          {{- if semverCompare ">=3.0.0" .Values.airflow.airflowVersion }}
           - "/usr/local/airflow/logs/**/*.log"
-          {{- end }}
         read_from: beginning
     transforms:
       # Parse Airflow 3 log file paths to extract metadata

--- a/tests/chart/test_logging_sidecar.py
+++ b/tests/chart/test_logging_sidecar.py
@@ -29,6 +29,10 @@ class TestLoggingSidecar:
         assert "ConfigMap" == doc["kind"]
         assert "v1" == doc["apiVersion"]
         vc = yaml.safe_load(doc["data"]["vector-config.yaml"])
+        assert vc["sources"]["airflow_log_files"]["include"] == [
+            "${SIDECAR_LOGS}/*.log",
+            "/usr/local/airflow/logs/**/*.log",
+        ]
         assert vc["sinks"]["out"]["auth"] == {
             "strategy": "basic",
             "user": "testuser",


### PR DESCRIPTION
## Description

This change updates logging sidecar ingestion so scheduler file-based logs are collected for both Airflow 2 and Airflow 3 deployments.

Changes:
- `templates/logging-sidecar-configmap.yaml`
  - Always include `/usr/local/airflow/logs/**/*.log` in `sources.airflow_log_files.include`.
  - Removed the Airflow `>=3.0.0` condition around that include path.
- `tests/chart/test_logging_sidecar.py`
  - Added assertion to verify rendered Vector config includes both:
    - `${SIDECAR_LOGS}/*.log`
    - `/usr/local/airflow/logs/**/*.log`

Why:
- Customers need scheduler parsing logs and `dag_processor_manager` logs (written under `/usr/local/airflow/logs`) in Elasticsearch/Kibana.
- This was previously missed for AF2 deployments.

## Related Issues

- https://github.com/astronomer/issues/issues/7054

## Testing

Unit tests:
- `cd /Users/manan.bhatt/all_repos/airflow-chart`
- `make venv`
- `helm dep update`
- `.venv/bin/python -m pytest -q tests/chart/test_logging_sidecar.py`
- Result: `40 passed`
```
manan.bhatt@MacBook-Pro-7 airflow-chart % .venv/bin/python -m pytest -q tests/chart/test_logging_sidecar.py
........................................                                                                                                                                              [100%]
Results (15.24s):
        40 passed

```

Live cluster validation (astronomer-logtest):
- Updated sidecar include list to add `/usr/local/airflow/logs/**/*.log`.
- Ensured sidecar container mounts `/usr/local/airflow/logs`.
- Verified sidecar runtime logs show:
  - `Starting file server. include=["/var/log/sidecar-log-consumer/*.log", "/usr/local/airflow/logs/**/*.log"]`
  - `Found new file to watch` for:
    - `/usr/local/airflow/logs/dag_processor_manager/dag_processor_manager.log`
    - `/usr/local/airflow/logs/scheduler/<date>/*.py.log`
- Verified Elasticsearch now returns hits for scheduler file-log messages, including:
  - `manager.py:483`
  - `Filling up the DagBag from /usr/local/airflow/dags/hello_logs.py`

[dag_processor_manager logs](https://kibana.cre-software-01.astro-cre.com/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-15m,to:now))&_a=(columns:!(),dataSource:(dataViewId:'vector.*',type:dataView),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,field:message,index:'fluentd.*',key:message,negate:!f,params:(query:manager.py),type:phrase),query:(match_phrase:(message:manager.py)))),interval:auto,query:(language:kuery,query:''),sort:!(!('@timestamp',desc))))
[scheduler parsing log](https://kibana.cre-software-01.astro-cre.com/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-15m,to:now))&_a=(columns:!(),dataSource:(dataViewId:'vector.*',type:dataView),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,field:message,index:'fluentd.*',key:message,negate:!f,params:(query:'%22Filling%20up%20the%20DagBag%20from%20%2Fusr%2Flocal%2Fairflow%2Fdags%2Fhello_logs.py%22'),type:phrase),query:(match_phrase:(message:'%22Filling%20up%20the%20DagBag%20from%20%2Fusr%2Flocal%2Fairflow%2Fdags%2Fhello_logs.py%22')))),interval:auto,query:(language:kuery,query:''),sort:!(!('@timestamp',desc))))

<img width="3450" height="1950" alt="image" src="https://github.com/user-attachments/assets/67ba1cc2-bbf1-47ba-b38b-5cb67a1bf509" />

<img width="3450" height="1950" alt="image" src="https://github.com/user-attachments/assets/edf40909-8cba-468a-87cf-1190af0e177b" />

## Merging

- Merge target: `master`
- Cherry-pick recommendation:
  - `release-1.15` (required for Software `0.37.x` line)
  - `release-1.17` 
