### PR TITLE
PLX-301: Add runAsUser: 50000 to git-sync-relay pod security context

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v2 is Helm 3
 apiVersion: v2
 name: airflow
-version: 1.17.29
+version: 1.17.28
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v2 is Helm 3
 apiVersion: v2
 name: airflow
-version: 1.17.28
+version: 1.17.29
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:

--- a/templates/git-sync-relay/git-sync-relay-deployment.yaml
+++ b/templates/git-sync-relay/git-sync-relay-deployment.yaml
@@ -85,8 +85,7 @@ spec:
         - name: git-config-manager
           command: ["git", "config", "--global", "--add", "safe.directory", "/git"]
           image: "{{ .Values.gitSyncRelay.images.gitSync.repository }}:{{ .Values.gitSyncRelay.images.gitSync.tag }}"
-          securityContext:
-            readOnlyRootFilesystem: true
+          securityContext: {{- toYaml .Values.gitSyncRelay.gitSync.securityContext | nindent 12 }}
           volumeMounts:
             - name: git-sync-home
               mountPath: /home/git-sync
@@ -100,8 +99,7 @@ spec:
             - -c
             - /entrypoint.sh 1> >( tee -a /var/log/sidecar-logging-consumer/out.log ) 2> >( tee -a /var/log/sidecar-logging-consumer/err.log >&2 )
           {{- end }}
-          securityContext:
-            readOnlyRootFilesystem: true
+          securityContext: {{- toYaml .Values.gitSyncRelay.gitSync.securityContext | nindent 12 }}
           volumeMounts:
             - name: git-sync-home
               mountPath: /home/git-sync
@@ -179,8 +177,7 @@ spec:
         {{- if eq .Values.gitSyncRelay.repoShareMode "git_daemon" }}
         - name: git-daemon
           image: "{{ .Values.gitSyncRelay.images.gitDaemon.repository }}:{{ .Values.gitSyncRelay.images.gitDaemon.tag }}"
-          securityContext:
-            readOnlyRootFilesystem: true
+          securityContext: {{- toYaml .Values.gitSyncRelay.gitDaemon.securityContext | nindent 12 }}
           volumeMounts:
             - name: git-repo-contents
               mountPath: /git

--- a/values.yaml
+++ b/values.yaml
@@ -840,6 +840,7 @@ gitSyncRelay:
   webhookSecretKey: ~
   securityContext:
     fsGroup: 65533
+    runAsUser: 50000
   terminationGracePeriodSeconds: 30
   gitDaemon: {}
   gitSync:

--- a/values.yaml
+++ b/values.yaml
@@ -842,9 +842,13 @@ gitSyncRelay:
     fsGroup: 65533
     runAsUser: 50000
   terminationGracePeriodSeconds: 30
-  gitDaemon: {}
+  gitDaemon:
+    securityContext:
+      readOnlyRootFilesystem: true
   gitSync:
     webhookPort: 8000
+    securityContext:
+      readOnlyRootFilesystem: true
   images:
     gitDaemon:
       repository: "quay.io/astronomer/ap-git-daemon"


### PR DESCRIPTION
## Description

This PR adds `runAsUser: 50000` to the pod-level securityContext in values.yaml. The git-daemon container in the git-sync-relay pod was crash-looping on startup. Its entrypoint runs touch `/git/.git/git-daemon-export-ok` to mark the repo as exportable before starting git daemon. This was failing with Permission denied.

## Related Issues

- https://linear.app/astronomer/issue/PLX-301/gitsync-tests-failing-with-some-env-dollargit-sync-add-user-has-been

## Testing

- Tested this config on a cluster.
<img width="718" height="996" alt="Screenshot 2026-04-09 at 2 10 18 PM" src="https://github.com/user-attachments/assets/c5c1fc6a-19cb-486e-b4ce-97d1a0a8a52f" />

- All the pods are stable: 
<img width="720" height="213" alt="Screenshot 2026-04-13 at 9 29 45 PM" src="https://github.com/user-attachments/assets/ec175b8f-ff98-472e-92d3-e1476a43f69d" />

- Dags are also present:
<img width="1346" height="602" alt="Screenshot 2026-04-13 at 9 30 17 PM" src="https://github.com/user-attachments/assets/0e1580da-8e22-4b1c-94a0-781343149664" />

## Merging

master, 1.17