### PR TITLE
PINF-492: Make TLS configuration conditional across all ingress

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v2 is Helm 3
 apiVersion: v2
 name: airflow
-version: 1.17.28
+version: 1.17.29
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:

--- a/templates/git-sync-relay/git-sync-relay-ingress.yaml
+++ b/templates/git-sync-relay/git-sync-relay-ingress.yaml
@@ -25,10 +25,12 @@ metadata:
   {{ toYaml .Values.ingress.gitSyncRelayAnnotations | nindent 4 }}
 {{- end }}
 spec:
+  {{- if .Values.ingress.tlsSecretName }}
   tls:
     - secretName: {{ .Values.ingress.tlsSecretName | default "~" }}
       hosts:
         - {{ include "deployments_subdomain" . }}
+  {{- end }}
   rules:
     - host: {{ include "deployments_subdomain" . }}
       http:

--- a/templates/git-sync-relay/git-sync-relay-ingress.yaml
+++ b/templates/git-sync-relay/git-sync-relay-ingress.yaml
@@ -27,7 +27,7 @@ metadata:
 spec:
   {{- if .Values.ingress.tlsSecretName }}
   tls:
-    - secretName: {{ .Values.ingress.tlsSecretName | default "~" }}
+    - secretName: {{ .Values.ingress.tlsSecretName }}
       hosts:
         - {{ include "deployments_subdomain" . }}
   {{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -33,7 +33,7 @@ metadata:
 spec:
   {{- if .Values.ingress.tlsSecretName }}
   tls:
-    - secretName: {{ .Values.ingress.tlsSecretName | default "~" }}
+    - secretName: {{ .Values.ingress.tlsSecretName }}
       hosts:
         - {{- include "deployments_subdomain" . | indent 1 }}
         - {{- include "airflow_subdomain" . | indent 1 }}
@@ -121,7 +121,7 @@ metadata:
 spec:
   {{- if .Values.ingress.tlsSecretName }}
   tls:
-    - secretName: {{ .Values.ingress.tlsSecretName | default "~" }}
+    - secretName: {{ .Values.ingress.tlsSecretName }}
       hosts:
         - {{- include "deployments_subdomain" . | indent 1 }}
         - {{- include "flower_subdomain" . | indent 1 }}
@@ -195,7 +195,7 @@ metadata:
 spec:
   {{- if .Values.ingress.tlsSecretName }}
   tls:
-    - secretName: {{ .Values.ingress.tlsSecretName | default "~" }}
+    - secretName: {{ .Values.ingress.tlsSecretName }}
       hosts:
         - {{- include "deployments_subdomain" . | indent 1 }}
   {{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -31,11 +31,13 @@ metadata:
   {{- end }}
   {{- end }}
 spec:
+  {{- if .Values.ingress.tlsSecretName }}
   tls:
     - secretName: {{ .Values.ingress.tlsSecretName | default "~" }}
       hosts:
         - {{- include "deployments_subdomain" . | indent 1 }}
         - {{- include "airflow_subdomain" . | indent 1 }}
+  {{- end }}
   rules:
     - host: {{- include "deployments_subdomain" . | indent 1 }}
       http:
@@ -117,11 +119,13 @@ metadata:
   {{- end }}
   {{- end }}
 spec:
+  {{- if .Values.ingress.tlsSecretName }}
   tls:
     - secretName: {{ .Values.ingress.tlsSecretName | default "~" }}
       hosts:
         - {{- include "deployments_subdomain" . | indent 1 }}
         - {{- include "flower_subdomain" . | indent 1 }}
+  {{- end }}
   rules:
     - host: {{- include "deployments_subdomain" . | indent 1 }}
       http:
@@ -189,10 +193,12 @@ metadata:
   {{- end }}
   {{- end }}
 spec:
+  {{- if .Values.ingress.tlsSecretName }}
   tls:
     - secretName: {{ .Values.ingress.tlsSecretName | default "~" }}
       hosts:
         - {{- include "deployments_subdomain" . | indent 1 }}
+  {{- end }}
   rules:
     - host: {{- include "deployments_subdomain" . | indent 1 }}
       http:

--- a/tests/chart/test_ingress.py
+++ b/tests/chart/test_ingress.py
@@ -57,6 +57,7 @@ class TestIngress:
         assert "Ingress" == doc["kind"]
         assert "networking.k8s.io/v1" == doc["apiVersion"]
         assert "/release-name/flower/" == doc["spec"]["rules"][0]["http"]["paths"][0]["path"]
+        assert "tls" not in doc["spec"]
 
     def test_airflow_ingress_with_celery_executor_with_tls_overides(self, kube_version):
         """Test airflow ingress and tls secret overrides with CeleryExecutor."""
@@ -131,3 +132,36 @@ class TestIngress:
 
         assert ingressAnnotations == docs[1]["metadata"]["annotations"]
         assert docs[1]["spec"]["tls"][0]["secretName"] == tls_secret_name
+
+    def test_git_sync_relay_ingress_without_tls(self, kube_version):
+        """Test git-sync-relay ingress has no TLS block when tlsSecretName is not set."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/git-sync-relay/git-sync-relay-ingress.yaml",
+            values={
+                "gitSyncRelay": {"enabled": True, "repoFetchMode": "webhook"},
+                "ingress": {"baseDomain": "example.com"},
+            },
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+        assert "Ingress" == doc["kind"]
+        assert doc["metadata"]["name"] == "release-name-git-sync-relay-ingress"
+        assert "tls" not in doc["spec"]
+
+    def test_git_sync_relay_ingress_with_tls(self, kube_version):
+        """Test git-sync-relay ingress has TLS block when tlsSecretName is set."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/git-sync-relay/git-sync-relay-ingress.yaml",
+            values={
+                "gitSyncRelay": {"enabled": True, "repoFetchMode": "webhook"},
+                "ingress": {"baseDomain": "example.com", "tlsSecretName": tls_secret_name},
+            },
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+        assert "Ingress" == doc["kind"]
+        assert doc["metadata"]["name"] == "release-name-git-sync-relay-ingress"
+        assert doc["spec"]["tls"][0]["secretName"] == tls_secret_name
+        assert "deployments.example.com" in doc["spec"]["tls"][0]["hosts"]

--- a/tests/chart/test_ingress.py
+++ b/tests/chart/test_ingress.py
@@ -52,6 +52,7 @@ class TestIngress:
         assert "Ingress" == doc["kind"]
         assert "networking.k8s.io/v1" == doc["apiVersion"]
         assert "/release-name/airflow" == doc["spec"]["rules"][0]["http"]["paths"][0]["path"]
+        assert "tls" not in doc["spec"]
 
         doc = docs[1]
         assert "Ingress" == doc["kind"]

--- a/tests/chart/test_ingress.py
+++ b/tests/chart/test_ingress.py
@@ -20,7 +20,7 @@ class TestIngress:
         assert "Ingress" == doc["kind"]
         assert "networking.k8s.io/v1" == doc["apiVersion"]
         assert "/release-name/airflow" == docs[0]["spec"]["rules"][0]["http"]["paths"][0]["path"]
-        assert doc["spec"]["tls"][0]["secretName"] is None
+        assert "tls" not in doc["spec"]
 
     def test_airflow_ingress_tls_secret_overrides(self, kube_version):
         """Test airflow ingress and tls secret overrides with KubernetesExecutor."""
@@ -98,7 +98,7 @@ class TestIngress:
         rule_0 = docs[0]["spec"]["rules"][0]
         assert rule_0["http"]["paths"][0]["path"] == "/release-name/dags/(upload|downloads|healthz)(/.*)?"
         assert rule_0["host"] == "deployments.example.com"
-        assert docs[0]["spec"]["tls"][0]["secretName"] is None
+        assert "tls" not in docs[0]["spec"]
 
     def test_airflow_ingress_with_dag_server_ingress_annotation_and_tls_secret(self, kube_version):
         """Test airflow ingress annotation and tls secret with DagServer."""


### PR DESCRIPTION
## Description

This PR makes TLS configuration conditional across all ingress templates so the tls block is only rendered when ingress.tlsSecretName is explicitly set, preventing invalid ingress specs with secretName: ~ 

## Related Issues

https://linear.app/astronomer/issue/PINF-492/conditionally-render-tls-block-in-ingress-templates-when-tlssecret-is

## Testing

- Unittests updated.

## Merging

Master, 1.17