### PR TITLE
PINF-542 update backend helm chart with version 1.17.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,7 @@ jobs:
   run_pre_commit:
     resource_class: small
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2026-04
+      - image: quay.io/astronomer/ci-pre-commit:2026-05
     steps:
       - checkout
       - run:
@@ -207,7 +207,7 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-04
+      - image: quay.io/astronomer/ci-helm-release:2026-05
     parallelism: 8
     steps:
       - setup_remote_docker:
@@ -226,7 +226,7 @@ jobs:
 
   build-and-release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-04
+      - image: quay.io/astronomer/ci-helm-release:2026-05
     steps:
       - checkout
       - run:
@@ -267,7 +267,7 @@ jobs:
           path: test-results
   release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-04
+      - image: quay.io/astronomer/ci-helm-release:2026-05
     steps:
       - checkout
       - run:
@@ -276,7 +276,7 @@ jobs:
 
   release-public:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-04
+      - image: quay.io/astronomer/ci-helm-release:2026-05
     steps:
       - checkout
       - publish-github-release

--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: airflow
-  repository: https://github.com/astronomer/apc-airflow/releases/download/oss-helm-chart/1.17.8-astro
-  version: 1.17.8-astro
-digest: sha256:aaf097e611124705c872df87f037af39af7a5c72b6dac083505bfd1267d1836e
-generated: "2026-03-01T01:55:13.909647+05:30"
+  repository: https://github.com/astronomer/apc-airflow/releases/download/oss-helm-chart/1.17.9-astro
+  version: 1.17.9-astro
+digest: sha256:a24e5125a8183646ebd535dd8b217a60143b4547edf7d968ee3d6f195598eae7
+generated: "2026-05-05T18:54:35.141363+05:30"

--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: airflow
-  repository: https://github.com/astronomer/apc-airflow/releases/download/oss-helm-chart/1.17.9-astro
-  version: 1.17.9-astro
-digest: sha256:a24e5125a8183646ebd535dd8b217a60143b4547edf7d968ee3d6f195598eae7
-generated: "2026-05-05T18:54:35.141363+05:30"
+  repository: https://github.com/astronomer/apc-airflow/releases/download/oss-helm-chart/1.17.10-astro
+  version: 1.17.10-astro
+digest: sha256:2519cdb5f9c196ee8f65307e80da1d8d51fe49df63be366efb4aa0be9a15e723
+generated: "2026-05-06T15:13:50.466111+05:30"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -9,5 +9,5 @@ keywords:
   - airflow
 dependencies:
   - name: airflow
-    version: 1.17.9-astro
-    repository: https://github.com/astronomer/apc-airflow/releases/download/oss-helm-chart/1.17.9-astro
+    version: 1.17.10-astro
+    repository: https://github.com/astronomer/apc-airflow/releases/download/oss-helm-chart/1.17.10-astro

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v2 is Helm 3
 apiVersion: v2
 name: airflow
-version: 1.17.29
+version: 1.17.30
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:
@@ -9,5 +9,5 @@ keywords:
   - airflow
 dependencies:
   - name: airflow
-    version: 1.17.8-astro
-    repository: https://github.com/astronomer/apc-airflow/releases/download/oss-helm-chart/1.17.8-astro
+    version: 1.17.9-astro
+    repository: https://github.com/astronomer/apc-airflow/releases/download/oss-helm-chart/1.17.9-astro

--- a/tests/chart/test_airflow.py
+++ b/tests/chart/test_airflow.py
@@ -77,12 +77,10 @@ class TestAirflow:
             values=values,
         )
         assert len(docs) == 1
-        #assert "initContainers" in docs[0]["spec"]["template"]["spec"]
-        print(docs[0]["spec"]["template"])
-        assert True
-        #c_by_name = get_containers_by_name(docs[0], include_init_containers=True)
-        #assert "usr-local-airflow-copier" in c_by_name
-        #assert c_by_name["usr-local-airflow-copier"]["securityContext"]["readOnlyRootFilesystem"] is True
+        assert "initContainers" in docs[0]["spec"]["template"]["spec"]
+        c_by_name = get_containers_by_name(docs[0], include_init_containers=True)
+        assert "usr-local-airflow-copier" in c_by_name
+        assert c_by_name["usr-local-airflow-copier"]["securityContext"]["readOnlyRootFilesystem"] is True
 
     @pytest.mark.parametrize(
         "executor, expected_components",

--- a/tests/chart/test_airflow.py
+++ b/tests/chart/test_airflow.py
@@ -67,6 +67,23 @@ class TestAirflow:
         assert len(docs) == 1
         assert docs[0]["spec"]["template"]["spec"]["serviceAccountName"] == "release-name-airflow-api-server"
 
+    def test_airflow_flower_with_preAirflowExtraInitContainers(self, kube_version):
+        """Test flower deployment behaviors with preAirflowExtraInitContainers."""
+        values = get_all_features()
+        values.setdefault("airflow", {})["executor"] = "CeleryExecutor"
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/airflow/templates/flower/flower-deployment.yaml"],
+            values=values,
+        )
+        assert len(docs) == 1
+        #assert "initContainers" in docs[0]["spec"]["template"]["spec"]
+        print(docs[0]["spec"]["template"])
+        assert True
+        #c_by_name = get_containers_by_name(docs[0], include_init_containers=True)
+        #assert "usr-local-airflow-copier" in c_by_name
+        #assert c_by_name["usr-local-airflow-copier"]["securityContext"]["readOnlyRootFilesystem"] is True
+
     @pytest.mark.parametrize(
         "executor, expected_components",
         [

--- a/tests/enable_all_features.yaml
+++ b/tests/enable_all_features.yaml
@@ -6,6 +6,30 @@ airflow:
       capabilities:
         drop:
           - ALL
+  flower:
+    enabled: true
+    preAirflowExtraInitContainers: 
+      - command:
+          - sh
+          - -c
+          - cp -rvx /usr/local/airflow/. /usr_local_airflow_copy/
+        image: '{{ template "airflow_image" . }}'
+        name: usr-local-airflow-copier
+        securityContext:
+          readOnlyRootFilesystem: true
+        volumeMounts:
+          - mountPath: /usr_local_airflow_copy
+            name: usr-local-airflow
+    extraVolumeMounts:
+      - mountPath: /usr/local/airflow
+        name: usr-local-airflow
+      - mountPath: /tmp
+        name: tmp
+    extraVolumes:
+      - emptyDir: {}
+        name: usr-local-airflow
+      - emptyDir: {}
+        name: tmp
   apiServer:
     preAirflowExtraInitContainers:
       - command:

--- a/tests/enable_all_features.yaml
+++ b/tests/enable_all_features.yaml
@@ -8,7 +8,7 @@ airflow:
           - ALL
   flower:
     enabled: true
-    preAirflowExtraInitContainers: 
+    preAirflowExtraInitContainers:
       - command:
           - sh
           - -c


### PR DESCRIPTION
## Description

Bumps the `apc-airflow` subchart dependency from `1.17.8-astro` to `1.17.9-astro` and increments the `airflow-chart` version from `1.17.29` to `1.17.30`.

`1.17.10-astro` picks up the Flower `extraInitContainers` and `preAirflowExtraInitContainers` support (PINF-542). Without this bump, custom plugins and functions cannot be injected into Flower at pod startup — all other core Airflow components already support this pattern but Flower was missing it in `1.17.8-astro`.

### Changes

| File | What changed |
|------|-------------|
| `Chart.yaml` | `apc-airflow` dependency version: `1.17.8-astro` → `1.17.9-astro`; chart version: `1.17.29` → `1.17.30` |
| `Chart.lock` | Regenerated with updated repository URL, version, and SHA256 digest for `1.17.9-astro` |

### Improvements

- `flower.extraInitContainers` and `flower.preAirflowExtraInitContainers` are now available for deployments using this chart
- Custom plugins and functions can be injected into Flower at pod startup via init containers, matching the capability already present in Scheduler, Worker, and other core components

## Related Issues

https://linear.app/astronomer/issue/PINF-542/add-extrainitcontainers-support-to-flower-to-match-other-airflow-core

## Testing

1. Deploy using the updated chart and verify `helm dependency list` shows `apc-airflow 1.17.9-astro`
2. Confirm `flower.extraInitContainers` and `flower.preAirflowExtraInitContainers` are accepted by the chart without validation errors
3. Verify existing deployments without init containers continue to work unchanged

## Merging

Merge to master.