### PR TITLE
APC-1313: Add dagDeploy.podSecurityContext

### DIFF
--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -492,3 +492,16 @@ Strips fsGroup and runAsUser on OpenShift to comply with restricted-v2 SCC.
 {{- toYaml (.Values.gitSyncRelay.securityContext | default dict) }}
 {{- end -}}
 {{- end }}
+
+{{/*
+dag-deploy pod-level securityContext
+Strips fsGroup and runAsUser on OpenShift to comply with restricted-v2 SCC.
+*/}}
+{{- define "dagDeploy.podSecurityContext" -}}
+{{- if .Values.openshift.enabled }}
+{{- $required := dict "runAsNonRoot" true }}
+{{- merge $required (omit (.Values.dagDeploy.securityContexts.pod | default dict) "runAsUser" "fsGroup") | toYaml }}
+{{- else }}
+{{- toYaml (.Values.dagDeploy.securityContexts.pod | default dict) }}
+{{- end -}}
+{{- end }}

--- a/templates/dag-deploy/dag-server-statefulset.yaml
+++ b/templates/dag-deploy/dag-server-statefulset.yaml
@@ -50,7 +50,7 @@ spec:
       tolerations: {{- toYaml $tolerations | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.dagDeploy.terminationGracePeriodSeconds }}
       serviceAccountName: {{ template "astro.dagDeploy.serviceAccountName" . }}
-      securityContext: {{- toYaml .Values.dagDeploy.securityContexts.pod | nindent 8 }}
+      securityContext: {{- include "dagDeploy.podSecurityContext" . | nindent 8 }}
       containers:
         - name: dag-server
           image: "{{ .Values.dagDeploy.images.dagServer.repository }}:{{ .Values.dagDeploy.images.dagServer.tag }}"

--- a/tests/chart/test_dag_server_statefulset.py
+++ b/tests/chart/test_dag_server_statefulset.py
@@ -145,6 +145,64 @@ class TestDagServerStatefulSet:
             "readOnlyRootFilesystem": True,
         }
 
+    def test_dag_server_openshift_strips_incompatible_security_context(self, kube_version):
+        """Test that fsGroup and runAsUser are stripped from pod securityContext when OpenShift is enabled,
+        even if a customer explicitly sets them."""
+        values = {
+            "openshift": {"enabled": True},
+            "dagDeploy": {
+                "enabled": True,
+                "securityContexts": {
+                    "pod": {
+                        "fsGroup": 65533,
+                        "runAsUser": 50000,
+                        "runAsNonRoot": True,
+                    },
+                },
+            },
+        }
+
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/dag-deploy/dag-server-statefulset.yaml",
+            values=values,
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "StatefulSet"
+        pod_security_context = doc["spec"]["template"]["spec"]["securityContext"]
+
+        assert "fsGroup" not in pod_security_context
+        assert "runAsUser" not in pod_security_context
+
+        assert pod_security_context["runAsNonRoot"] is True
+
+    def test_dag_server_non_openshift_preserves_security_context(self, kube_version):
+        """Test that fsGroup and runAsUser are preserved in pod securityContext when OpenShift is disabled."""
+        dag_server_pod_securitycontext = {"fsGroup": 65533, "runAsUser": 50000, "runAsNonRoot": True}
+        values = {
+            "openshift": {"enabled": False},
+            "dagDeploy": {
+                "enabled": True,
+                "securityContexts": {
+                    "pod": dag_server_pod_securitycontext,
+                },
+            },
+        }
+
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/dag-deploy/dag-server-statefulset.yaml",
+            values=values,
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+        pod_security_context = doc["spec"]["template"]["spec"]["securityContext"]
+
+        assert pod_security_context["fsGroup"] == 65533
+        assert pod_security_context["runAsUser"] == 50000
+        assert pod_security_context["runAsNonRoot"] is True
+
     def test_dag_server_statefulset_with_custom_registry_secret(self, kube_version):
         """Test dag-server statefulset with custom registry secret."""
         values = {

--- a/values.yaml
+++ b/values.yaml
@@ -818,7 +818,8 @@ dagDeploy:
   safeToEvict: true
 
   securityContexts:
-    pod: {}
+    pod:
+      runAsUser: 50000
     container: {}
 
   flower:


### PR DESCRIPTION
## Description

This PR: 
- Adds `dagDeploy.podSecurityContext` helper in `_helpers.yaml` that strips `fsGroup` and `runAsUser` from the dag-server pod-level securityContext when `openshift.enabled` is true, matching the pattern already merged for git-sync-relay in PR #726
- Updates dag-server-statefulset.yaml to use the new helper instead of directly rendering `.Values.dagDeploy.securityContexts.pod`

## Related Issues
https://linear.app/astronomer/issue/APC-1313/dag-server-pvc-write-permission-denied-fsgroup-not-applied-to-pod

## Testing

- Added unittests.
- This is just for extra security incase the `astronomer/astronomer` rendering fails. 

- Did a sanity test:
  - Used the custom airflow chart:
<img width="870" height="403" alt="Screenshot 2026-05-15 at 5 02 26 PM" src="https://github.com/user-attachments/assets/78752ac6-1c59-4c05-ba82-60112686b344" />

  - Create a DOD deployment:  
<img width="963" height="195" alt="Screenshot 2026-05-15 at 5 01 46 PM" src="https://github.com/user-attachments/assets/9e08ad86-9441-42da-8952-cb51394308df" />

  - UI stability:
<img width="1760" height="775" alt="Screenshot 2026-05-15 at 5 03 35 PM" src="https://github.com/user-attachments/assets/dd16e21b-5e9f-4f89-8b10-3b655ea6aa32" />



## Merging

Master, 1.17