### PR TITLE
PINF-638 - add extraannotation support

### DIFF
--- a/templates/dag-deploy/dag-server-statefulset.yaml
+++ b/templates/dag-deploy/dag-server-statefulset.yaml
@@ -18,6 +18,9 @@ metadata:
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- if .Values.dagDeploy.annotations }}
+  annotations: {{- toYaml .Values.dagDeploy.annotations | nindent 4 }}
+  {{- end }}
 spec:
   {{- if and .Values.dagDeploy.persistence.enabled .Values.dagDeploy.persistence.persistentVolumeClaimRetentionPolicy }}
   persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.dagDeploy.persistence.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
@@ -40,6 +43,9 @@ spec:
         {{- with .Values.labels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- if .Values.dagDeploy.podAnnotations }}
+      annotations: {{- toYaml .Values.dagDeploy.podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       {{- if or .Values.airflow.registry.secretName .Values.airflow.registry.connection }}
       imagePullSecrets:

--- a/templates/git-sync-relay/git-sync-relay-deployment.yaml
+++ b/templates/git-sync-relay/git-sync-relay-deployment.yaml
@@ -15,6 +15,9 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Release.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
+  {{- if .Values.gitSyncRelay.annotations }}
+  annotations: {{- toYaml .Values.gitSyncRelay.annotations | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   selector:
@@ -30,8 +33,11 @@ spec:
         chart: "{{ .Release.Name }}-{{ .Chart.Version }}"
         heritage: {{ .Release.Service }}
         {{- if .Values.labels }}
-        {{- .Values.labels | toYaml | nindent 8 }}
+        {{- toYaml .Values.labels | nindent 8 }}
         {{- end }}
+      {{- if .Values.gitSyncRelay.podAnnotations }}
+      annotations: {{- toYaml .Values.gitSyncRelay.podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       {{- if or .Values.airflow.registry.secretName .Values.airflow.registry.connection }}
       imagePullSecrets:

--- a/tests/chart/test_dag_server_statefulset.py
+++ b/tests/chart/test_dag_server_statefulset.py
@@ -56,6 +56,8 @@ class TestDagServerStatefulSet:
         common_default_tests(doc)
 
         assert "persistentVolumeClaimRetentionPolicy" not in doc["spec"]
+        assert "annotations" not in doc["metadata"]
+        assert "annotations" not in doc["spec"]["template"]["metadata"]
         spec = docs[0]["spec"]["template"]["spec"]
         assert spec["nodeSelector"] == {}
         assert spec["affinity"] == {}
@@ -475,3 +477,23 @@ class TestDagServerStatefulSet:
         spec = docs[0]["spec"]["template"]["spec"]
         assert values["dagDeploy"]["extraVolumes"][0] in spec["volumes"]
         assert values["dagDeploy"]["extraVolumeMounts"][0] in spec["containers"][0]["volumeMounts"]
+
+    def test_dag_server_annotations_overrides(self, kube_version):
+        """Test that dagDeploy annotations are set when dagDeploy.annotations when passed."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["templates/dag-deploy/dag-server-statefulset.yaml"],
+            values={"dagDeploy": {"enabled": True, "annotations": {"example.com/owner": "platform"}}},
+        )
+        assert len(docs) == 1
+        assert docs[0]["metadata"]["annotations"] == {"example.com/owner": "platform"}
+
+    def test_dag_server_pod_annotations_overrides(self, kube_version):
+        """Test that dagDeploy podAnnotations are set when dagDeploy.podAnnotations when passed."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["templates/dag-deploy/dag-server-statefulset.yaml"],
+            values={"dagDeploy": {"enabled": True, "podAnnotations": {"sidecar.istio.io/inject": "false"}}},
+        )
+        assert len(docs) == 1
+        assert docs[0]["spec"]["template"]["metadata"]["annotations"] == {"sidecar.istio.io/inject": "false"}

--- a/tests/chart/test_git_sync_relay_deployment.py
+++ b/tests/chart/test_git_sync_relay_deployment.py
@@ -40,6 +40,8 @@ class TestGitSyncRelayDeployment:
         assert c_by_name["git-sync"]["image"].startswith("quay.io/astronomer/ap-git-sync-relay:")
         assert c_by_name["git-daemon"]["image"].startswith("quay.io/astronomer/ap-git-daemon:")
         assert c_by_name["git-daemon"]["livenessProbe"]
+        assert "annotations" not in doc["metadata"]
+        assert "annotations" not in doc["spec"]["template"]["metadata"]
 
         git_dameon_env = get_env_vars_dict(c_by_name["git-daemon"].get("env"))
         assert not git_dameon_env.get("GIT_SYNC_REPO_FETCH_MODE")
@@ -549,3 +551,23 @@ class TestGitSyncRelayDeployment:
         assert spec["affinity"] == airflow_node_pool_config["affinity"]
         assert spec["nodeSelector"] == airflow_node_pool_config["nodeSelector"]
         assert spec["tolerations"] == airflow_node_pool_config["tolerations"]
+
+    def test_gsr_annotations_overrides(self, kube_version):
+        """Test that gitSyncRelay annotations are set when gitSyncRelay.annotations when passed."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/git-sync-relay/git-sync-relay-deployment.yaml",
+            values={"gitSyncRelay": {"enabled": True, "annotations": {"example.com/owner": "platform"}}},
+        )
+        assert len(docs) == 1
+        assert docs[0]["metadata"]["annotations"] == {"example.com/owner": "platform"}
+
+    def test_gsr_pod_annotations_overrides(self, kube_version):
+        """Test that gitSyncRelay podAnnotations are set when gitSyncRelay.podAnnotations when passed."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/git-sync-relay/git-sync-relay-deployment.yaml",
+            values={"gitSyncRelay": {"enabled": True, "podAnnotations": {"sidecar.istio.io/inject": "false"}}},
+        )
+        assert len(docs) == 1
+        assert docs[0]["spec"]["template"]["metadata"]["annotations"] == {"sidecar.istio.io/inject": "false"}

--- a/values.yaml
+++ b/values.yaml
@@ -783,6 +783,7 @@ dagDeploy:
   readinessProbe: {}
   terminationGracePeriodSeconds: 30
   podAnnotations: {}
+  annotations: {}
   extraEnv: []
   extraContainers: []
   extraVolumeMounts: []
@@ -895,6 +896,8 @@ gitSyncRelay:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+  podAnnotations: {}
+  annotations: {}
 
   # Enable metrics for git-sync-relay
   metrics:


### PR DESCRIPTION
## Description

Adds optional `annotations`  and `podAnnotations`  values for `dagDeploy` and `gitSyncRelay`. Both default to `{}` and only render when set.

## Related Issues

https://linear.app/astronomer/issue/PINF-638/support-annotations-for-dag-server-velero-backups

## Testing

Covered by new unit tests in `tests/chart/test_dag_server_statefulset.py` and `tests/chart/test_git_sync_relay_deployment.py` (`*_annotations_overrides`, `*_pod_annotations_overrides`); default-absence asserts added to the existing baseline-defaults tests.

## Merging

Merge to `master`.