### PR TITLE
Avoid hostname binary in Celery worker probe

### DIFF
--- a/tests/chart/test_airflow.py
+++ b/tests/chart/test_airflow.py
@@ -67,6 +67,21 @@ class TestAirflow:
         assert len(docs) == 1
         assert docs[0]["spec"]["template"]["spec"]["serviceAccountName"] == "release-name-airflow-api-server"
 
+    def test_celery_worker_liveness_probe_uses_python_hostname(self, kube_version):
+        """Test Celery worker liveness probe does not require the hostname binary."""
+        values = {"airflow": {"airflowVersion": "3.2.0", "executor": "CeleryExecutor"}}
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/airflow/templates/workers/worker-deployment.yaml"],
+            values=values,
+        )
+
+        assert len(docs) == 1
+        c_by_name = get_containers_by_name(docs[0])
+        liveness_probe_command = c_by_name["worker"]["livenessProbe"]["exec"]["command"][-1]
+        assert "socket.gethostname()" in liveness_probe_command
+        assert "$(hostname)" not in liveness_probe_command
+
     def test_airflow_flower_with_preAirflowExtraInitContainers(self, kube_version):
         """Test flower deployment behaviors with preAirflowExtraInitContainers."""
         values = get_all_features()

--- a/tests/chart/test_airflow.py
+++ b/tests/chart/test_airflow.py
@@ -67,21 +67,6 @@ class TestAirflow:
         assert len(docs) == 1
         assert docs[0]["spec"]["template"]["spec"]["serviceAccountName"] == "release-name-airflow-api-server"
 
-    def test_celery_worker_liveness_probe_uses_python_hostname(self, kube_version):
-        """Test Celery worker liveness probe does not require the hostname binary."""
-        values = {"airflow": {"airflowVersion": "3.2.0", "executor": "CeleryExecutor"}}
-        docs = render_chart(
-            kube_version=kube_version,
-            show_only=["charts/airflow/templates/workers/worker-deployment.yaml"],
-            values=values,
-        )
-
-        assert len(docs) == 1
-        c_by_name = get_containers_by_name(docs[0])
-        liveness_probe_command = c_by_name["worker"]["livenessProbe"]["exec"]["command"][-1]
-        assert 'version("apache-airflow")' in liveness_probe_command
-        assert "socket.gethostname()" in liveness_probe_command
-
     def test_airflow_flower_with_preAirflowExtraInitContainers(self, kube_version):
         """Test flower deployment behaviors with preAirflowExtraInitContainers."""
         values = get_all_features()

--- a/tests/chart/test_airflow.py
+++ b/tests/chart/test_airflow.py
@@ -79,8 +79,8 @@ class TestAirflow:
         assert len(docs) == 1
         c_by_name = get_containers_by_name(docs[0])
         liveness_probe_command = c_by_name["worker"]["livenessProbe"]["exec"]["command"][-1]
+        assert 'version("apache-airflow")' in liveness_probe_command
         assert "socket.gethostname()" in liveness_probe_command
-        assert "$(hostname)" not in liveness_probe_command
 
     def test_airflow_flower_with_preAirflowExtraInitContainers(self, kube_version):
         """Test flower deployment behaviors with preAirflowExtraInitContainers."""

--- a/values.yaml
+++ b/values.yaml
@@ -134,7 +134,7 @@ airflow:
         - -c
         - >-
           CONNECTION_CHECK_MAX_COUNT=0 exec /entrypoint python -m celery --app
-          $(python -c 'import airflow, re; version = getattr(airflow, "__version__", "0.0"); major, minor = map(int, re.match(r"(\d+)\.(\d+)", version).groups()); print("airflow.providers.celery.executors.celery_executor.app" if (major, minor) >= (2, 7) else "airflow.executors.celery_executor.app")')
+          $(python -c 'import re; from importlib.metadata import version; airflow_version = version("apache-airflow"); major, minor = map(int, re.match(r"(\d+)\.(\d+)", airflow_version).groups()); print("airflow.providers.celery.executors.celery_executor.app" if (major, minor) >= (2, 7) else "airflow.executors.celery_executor.app")')
           inspect ping -d celery@$(python -c 'import socket; print(socket.gethostname())')
     persistence:
       # Enable persistent volumes

--- a/values.yaml
+++ b/values.yaml
@@ -127,6 +127,15 @@ airflow:
 
   # Airflow worker settings
   workers:
+    livenessProbe:
+      # UBI-based Runtime images may not include the hostname binary.
+      command:
+        - sh
+        - -c
+        - >-
+          CONNECTION_CHECK_MAX_COUNT=0 exec /entrypoint python -m celery --app
+          $(python -c 'import airflow, re; version = getattr(airflow, "__version__", "0.0"); major, minor = map(int, re.match(r"(\d+)\.(\d+)", version).groups()); print("airflow.providers.celery.executors.celery_executor.app" if (major, minor) >= (2, 7) else "airflow.executors.celery_executor.app")')
+          inspect ping -d celery@$(python -c 'import socket; print(socket.gethostname())')
     persistence:
       # Enable persistent volumes
       enabled: false


### PR DESCRIPTION
## Description

The default Celery worker liveness probe currently builds the Celery node name with the OS-level `hostname` executable:

```sh
celery inspect ping -d celery@$(hostname)
```

Some minimal container images, including UBI-based Runtime images, do not include that executable. That makes the probe fail before it can check whether the Celery worker is alive.

This wrapper-chart override keeps the same behavior of targeting the worker container's hostname, but reads it with Python's standard `socket.gethostname()` instead:

```sh
celery inspect ping -d celery@$(python -c 'import socket; print(socket.gethostname())')
```

The probe already depends on Python to run Celery, so this avoids adding another OS binary requirement. Kubernetes also documents that the container hostname is available through the `gethostname` function call: https://kubernetes.io/docs/concepts/containers/container-environment/

Because `airflow-chart` consumes the Airflow worker template from the packaged `astronomer/apc-airflow` subchart, this PR applies the mitigation as an APC wrapper-chart default. The permanent template fix is tracked separately in `astronomer/apc-airflow`.

The override also selects the Celery app import path at runtime from the installed `apache-airflow` package metadata, so it remains compatible with older Airflow 2 images and Airflow 3 images without importing Airflow during shell command substitution.

Related:
- apache/airflow#67471
- astronomer/apc-airflow#18

## Validation

- `uv run pytest tests/chart/test_airflow.py -q`
- `prek run --files values.yaml tests/chart/test_airflow.py`
- Rendered the Celery worker deployment with `helm template` and confirmed the generated worker liveness probe command uses `socket.gethostname()`.
- Ran the command substitutions in `quay.io/astronomer/ap-airflow:2.4.3` and confirmed they expand to the expected Celery app path and container hostname.
