### PR TITLE
PINF-784: support dots in dag_id and task_id for Vector log path parsing in sidecar logging.

### DIFF
--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -34,7 +34,7 @@ data:
         {{- if semverCompare ">=3.0.0" .Values.airflow.airflowVersion }}
           # Airflow 3.x - Parse JSON structured logs
           parsed_log = parse_json(.message) ?? .
-          parsed, err = parse_regex(.file, r'/dag_id=(?P<dag_id>[0-9a-zA-Z-_]+)/run_id=(?P<run_id>[^/]+)/task_id=(?P<task_id>[0-9a-zA-Z-_]+)/(?:map_index=(?P<map_index>-?[0-9])/)?attempt=(?P<attempt>[0-9]+)\.log$')
+          parsed, err = parse_regex(.file, r'/dag_id=(?P<dag_id>[0-9a-zA-Z._-]+)/run_id=(?P<run_id>[^/]+)/task_id=(?P<task_id>[0-9a-zA-Z._-]+)/(?:map_index=(?P<map_index>-?[0-9]+)/)?attempt=(?P<attempt>[0-9]+)\.log$')
 
           if err == null {
             # Airflow 3 structured logs


### PR DESCRIPTION
## Description

Task logs from TaskGroup tasks were silently dropped by Vector when using the Kubernetes executor with DS logging. This happened as the regex in the parse_airflowV3_path transform used [a-zA-Z0-9_-] for dag_id and task_id path segments. Airflow natively permits dots in these identifiers, and TaskGroup task IDs use dot notation by default (prefix_group_id=True), e.g. my_group.my_task. Vector failed to match these paths and dropped the logs entirely.

## Related Issues

https://linear.app/astronomer/issue/PINF-784/task-logs-from-taskgroup-tasks-with-prefix-group-idtrue-the-default

## Testing

-  Tested the fix on the cluster
<img width="1591" height="504" alt="Screenshot 2026-06-18 at 12 29 40 PM" src="https://github.com/user-attachments/assets/c8189a1d-5bbd-49b3-8123-ef03c60b3e7c" />

- With latest cm:
<img width="1572" height="302" alt="Screenshot 2026-06-18 at 12 30 26 PM" src="https://github.com/user-attachments/assets/646db0c8-d8f1-4e66-969d-5785672192de" />

- Also confirmed tha other tasks were able to emit logs without issues:
<img width="1578" height="639" alt="Screenshot 2026-06-18 at 12 31 19 PM" src="https://github.com/user-attachments/assets/2489fddb-218a-402f-9e27-c6c4051cf68b" />

## Merging

Master, 1.17