### PR TITLE
Restore AF3 version gate for log path inclusion

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v2 is Helm 3
 apiVersion: v2
 name: airflow
-version: 1.17.35
+version: 1.17.36
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:

--- a/templates/logging-sidecar-configmap.yaml
+++ b/templates/logging-sidecar-configmap.yaml
@@ -22,7 +22,9 @@ data:
         type: file
         include:
           - "${SIDECAR_LOGS}/*.log"
+          {{- if semverCompare ">=3.0.0" .Values.airflow.airflowVersion }}
           - "/usr/local/airflow/logs/**/*.log"
+          {{- end }}
         read_from: beginning
     transforms:
       # Parse Airflow 3 log file paths to extract metadata

--- a/tests/chart/test_logging_sidecar.py
+++ b/tests/chart/test_logging_sidecar.py
@@ -31,7 +31,6 @@ class TestLoggingSidecar:
         vc = yaml.safe_load(doc["data"]["vector-config.yaml"])
         assert vc["sources"]["airflow_log_files"]["include"] == [
             "${SIDECAR_LOGS}/*.log",
-            "/usr/local/airflow/logs/**/*.log",
         ]
         assert vc["sinks"]["out"]["auth"] == {
             "strategy": "basic",
@@ -154,6 +153,11 @@ class TestLoggingSidecar:
         )
         assert len(docs) == 1
         vc = yaml.safe_load(docs[0]["data"]["vector-config.yaml"])
+
+        assert vc["sources"]["airflow_log_files"]["include"] == [
+            "${SIDECAR_LOGS}/*.log",
+            "/usr/local/airflow/logs/**/*.log",
+        ]
 
         parse_airflow3_path = vc["transforms"]["parse_airflow3_path"]
         assert parse_airflow3_path["type"] == "remap"


### PR DESCRIPTION
## Description

Previously, `/usr/local/airflow/logs/**/*.log` was unconditionally included in the Vector sidecar log sources. This path only exists in Airflow 3.x deployments. and including it for AF2 emits more logs for AF3, causing cost hike for customers specially using external elasticsearch.

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

## Testing

- Added unittests.
- This is what we had before as well, no QA needed. 

## Merging

Master, 1.17