### PR TITLE
Exclude .agents, .claude, .devcontainer from helm package

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -9,6 +9,7 @@
 .bzrignore
 .circleci
 .claude/
+.devcontainer/
 .git/
 .github
 .gitignore

--- a/.helmignore
+++ b/.helmignore
@@ -4,9 +4,11 @@
 *.tmproj
 *~
 .DS_Store
+.agents/
 .bzr/
 .bzrignore
 .circleci
+.claude/
 .git/
 .github
 .gitignore


### PR DESCRIPTION
## Description

PR adds `.agents/`, `.claude/`, and `.devcontainer/ ` to `.helmignore` so these dev-tooling/agent config folders are excluded when packaging the Helm chart, consistent with existing exclusions like `.github`, `.circleci`, and `dev`.

## Merging

Master