### PR TITLE
PINF-425 add https git-sync from private repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ auto_update:
   cooldown_days: 7
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.15.9"
+    rev: "v0.15.18"
     hooks:
       - id: ruff-check
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,7 @@
 ---
 exclude: '^(venv|\.vscode|tests/k8s_schema|tests/chart/test_data)' # regex
+auto_update:
+  cooldown_days: 7
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: "v0.15.9"

--- a/templates/git-sync-relay/git-sync-relay-deployment.yaml
+++ b/templates/git-sync-relay/git-sync-relay-deployment.yaml
@@ -5,17 +5,27 @@
 {{- $nodeSelector := or .Values.gitSyncRelay.nodeSelector .Values.airflow.nodeSelector }}
 {{- $affinity := or .Values.gitSyncRelay.affinity .Values.airflow.affinity }}
 {{- $tolerations := or .Values.gitSyncRelay.tolerations .Values.airflow.tolerations }}
-{{- /* Resolve the git-sync auth method. repo.auth.type is authoritative; an SSH
-       key with no explicit type stays SSH for back-compat. SSH and HTTPS are
-       mutually exclusive. */}}
+{{- /* Resolve and validate the git-sync auth method. repo.auth.type is the
+       selector; an SSH key with no explicit type stays SSH for back-compat.
+       SSH and HTTPS are mutually exclusive, and the invalid combinations below
+       are rejected up-front rather than rendering values that fail at runtime. */}}
 {{- $authType := "" }}
 {{- $httpsSecret := "" }}
 {{- with .Values.gitSyncRelay.repo.auth }}
 {{- $authType = .type | default "" }}
 {{- with .https }}{{- $httpsSecret = .credentialsSecretName | default "" }}{{- end }}
 {{- end }}
+{{- if not (has $authType (list "" "ssh" "https-pat" "https-none")) }}
+{{- fail (printf "gitSyncRelay.repo.auth.type: %q is invalid; must be one of ssh, https-pat, https-none." $authType) }}
+{{- end }}
 {{- if and .Values.gitSyncRelay.repo.sshPrivateKeySecretName (or (eq $authType "https-pat") (eq $authType "https-none") (ne $httpsSecret "")) }}
-{{- fail "gitSyncRelay.repo: SSH and HTTPS auth are mutually exclusive. Set either repo.sshPrivateKeySecretName (SSH) or repo.auth.https (HTTPS), not both." }}
+{{- fail "gitSyncRelay.repo: SSH and HTTPS auth are mutually exclusive. Set either repo.sshPrivateKeySecretName (SSH) or repo.auth (HTTPS), not both." }}
+{{- end }}
+{{- if and (eq $authType "https-pat") (eq $httpsSecret "") }}
+{{- fail "gitSyncRelay.repo.auth: type 'https-pat' requires repo.auth.https.credentialsSecretName." }}
+{{- end }}
+{{- if and (ne $httpsSecret "") (ne $authType "https-pat") }}
+{{- fail "gitSyncRelay.repo.auth: repo.auth.https.credentialsSecretName is only used with type 'https-pat'; set repo.auth.type to https-pat or remove the secret." }}
 {{- end }}
 apiVersion: apps/v1
 kind: Deployment

--- a/templates/git-sync-relay/git-sync-relay-deployment.yaml
+++ b/templates/git-sync-relay/git-sync-relay-deployment.yaml
@@ -5,10 +5,12 @@
 {{- $nodeSelector := or .Values.gitSyncRelay.nodeSelector .Values.airflow.nodeSelector }}
 {{- $affinity := or .Values.gitSyncRelay.affinity .Values.airflow.affinity }}
 {{- $tolerations := or .Values.gitSyncRelay.tolerations .Values.airflow.tolerations }}
-{{- /* Resolve and validate the git-sync auth method. repo.auth.type is the
-       selector; an SSH key with no explicit type stays SSH for back-compat.
-       SSH and HTTPS are mutually exclusive, and the invalid combinations below
-       are rejected up-front rather than rendering values that fail at runtime. */}}
+{{- /* Resolve the git-sync auth method. repo.auth.type is the selector; an SSH key
+       with no explicit type stays SSH for back-compat. Wiring degrades gracefully
+       the same way the SSH path does: the HTTPS credentials Secret is mounted only
+       when credentialsSecretName is present, and a missing/unused Secret renders
+       nothing rather than failing (the relay starts and retries). The only hard
+       failures are an unknown auth.type and the SSH+HTTPS contradiction. */}}
 {{- $authType := "" }}
 {{- $httpsSecret := "" }}
 {{- with .Values.gitSyncRelay.repo.auth }}
@@ -20,12 +22,6 @@
 {{- end }}
 {{- if and .Values.gitSyncRelay.repo.sshPrivateKeySecretName (or (eq $authType "https-pat") (eq $authType "https-none") (ne $httpsSecret "")) }}
 {{- fail "gitSyncRelay.repo: SSH and HTTPS auth are mutually exclusive. Set either repo.sshPrivateKeySecretName (SSH) or repo.auth (HTTPS), not both." }}
-{{- end }}
-{{- if and (eq $authType "https-pat") (eq $httpsSecret "") }}
-{{- fail "gitSyncRelay.repo.auth: type 'https-pat' requires repo.auth.https.credentialsSecretName." }}
-{{- end }}
-{{- if and (ne $httpsSecret "") (ne $authType "https-pat") }}
-{{- fail "gitSyncRelay.repo.auth: repo.auth.https.credentialsSecretName is only used with type 'https-pat'; set repo.auth.type to https-pat or remove the secret." }}
 {{- end }}
 apiVersion: apps/v1
 kind: Deployment

--- a/templates/git-sync-relay/git-sync-relay-deployment.yaml
+++ b/templates/git-sync-relay/git-sync-relay-deployment.yaml
@@ -21,7 +21,7 @@
 {{- fail (printf "gitSyncRelay.repo.auth.type: %q is invalid; must be one of ssh, https-pat, https-none." $authType) }}
 {{- end }}
 {{- if and .Values.gitSyncRelay.repo.sshPrivateKeySecretName (or (eq $authType "https-pat") (eq $authType "https-none") (ne $httpsSecret "")) }}
-{{- fail "gitSyncRelay.repo: SSH and HTTPS auth are mutually exclusive. Set either repo.sshPrivateKeySecretName (SSH) or repo.auth (HTTPS), not both." }}
+{{- fail "gitSyncRelay.repo: SSH and HTTPS auth are mutually exclusive. repo.sshPrivateKeySecretName cannot be combined with HTTPS auth (repo.auth.type of https-pat/https-none, or repo.auth.https.credentialsSecretName)." }}
 {{- end }}
 apiVersion: apps/v1
 kind: Deployment

--- a/templates/git-sync-relay/git-sync-relay-deployment.yaml
+++ b/templates/git-sync-relay/git-sync-relay-deployment.yaml
@@ -5,6 +5,18 @@
 {{- $nodeSelector := or .Values.gitSyncRelay.nodeSelector .Values.airflow.nodeSelector }}
 {{- $affinity := or .Values.gitSyncRelay.affinity .Values.airflow.affinity }}
 {{- $tolerations := or .Values.gitSyncRelay.tolerations .Values.airflow.tolerations }}
+{{- /* Resolve the git-sync auth method. repo.auth.type is authoritative; an SSH
+       key with no explicit type stays SSH for back-compat. SSH and HTTPS are
+       mutually exclusive. */}}
+{{- $authType := "" }}
+{{- $httpsSecret := "" }}
+{{- with .Values.gitSyncRelay.repo.auth }}
+{{- $authType = .type | default "" }}
+{{- with .https }}{{- $httpsSecret = .credentialsSecretName | default "" }}{{- end }}
+{{- end }}
+{{- if and .Values.gitSyncRelay.repo.sshPrivateKeySecretName (or (eq $authType "https-pat") (eq $authType "https-none") (ne $httpsSecret "")) }}
+{{- fail "gitSyncRelay.repo: SSH and HTTPS auth are mutually exclusive. Set either repo.sshPrivateKeySecretName (SSH) or repo.auth.https (HTTPS), not both." }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -64,6 +76,11 @@ spec:
           secret:
             secretName: {{ .Values.gitSyncRelay.repo.sshPrivateKeySecretName }}
         {{- end }}
+        {{- if and (eq $authType "https-pat") (ne $httpsSecret "") }}
+        - name: git-https-secret
+          secret:
+            secretName: {{ $httpsSecret }}
+        {{- end }}
         - name: {{ .Release.Name }}-git-sync-config
           configMap:
             name: {{ .Release.Name }}-git-sync-config
@@ -121,6 +138,13 @@ spec:
               subPath: known_hosts
             {{- end }}
             {{- end }}
+            {{- if and (eq $authType "https-pat") (ne $httpsSecret "") }}
+            {{- /* Mount as a directory (no subPath) so kubelet propagates rotated
+                   credentials without a pod restart (FR2.2). */}}
+            - name: git-https-secret
+              mountPath: /etc/git-secret/https
+              readOnly: true
+            {{- end }}
             - name: git-repo-contents
               mountPath: /git
             {{- if .Values.loggingSidecar.enabled }}
@@ -162,6 +186,14 @@ spec:
             - name: GIT_KNOWN_HOSTS
               value: "false"
             {{- end }}
+            {{- end }}
+            {{- if or (eq $authType "https-pat") (eq $authType "https-none") }}
+            - name: GIT_SYNC_AUTH_TYPE
+              value: "{{ $authType }}"
+            {{- end }}
+            {{- if and (eq $authType "https-pat") (ne $httpsSecret "") }}
+            - name: GIT_SYNC_HTTPS_SECRET_DIR
+              value: "/etc/git-secret/https"
             {{- end }}
             {{- if .Values.gitSyncRelay.metrics.enabled}}
             - name: METRICS_ENABLED

--- a/tests/chart/test_git_sync_relay_deployment.py
+++ b/tests/chart/test_git_sync_relay_deployment.py
@@ -264,6 +264,60 @@ class TestGitSyncRelayDeployment:
                 values=values,
             )
 
+    def test_gsr_deployment_https_pat_requires_secret(self, kube_version):
+        """auth.type=https-pat without credentialsSecretName must fail the render (PINF-425)."""
+        values = {
+            "gitSyncRelay": {
+                "enabled": True,
+                "repo": {
+                    "url": "https://github.com/example/dags.git",
+                    "auth": {"type": "https-pat"},
+                },
+            }
+        }
+        with pytest.raises(CalledProcessError):
+            render_chart(
+                kube_version=kube_version,
+                show_only="templates/git-sync-relay/git-sync-relay-deployment.yaml",
+                values=values,
+            )
+
+    def test_gsr_deployment_https_secret_requires_https_pat(self, kube_version):
+        """Setting credentialsSecretName without auth.type=https-pat must fail (PINF-425)."""
+        values = {
+            "gitSyncRelay": {
+                "enabled": True,
+                "repo": {
+                    "url": "https://github.com/example/dags.git",
+                    "auth": {"https": {"credentialsSecretName": "release-name-git-sync"}},
+                },
+            }
+        }
+        with pytest.raises(CalledProcessError):
+            render_chart(
+                kube_version=kube_version,
+                show_only="templates/git-sync-relay/git-sync-relay-deployment.yaml",
+                values=values,
+            )
+
+    def test_gsr_deployment_invalid_auth_type(self, kube_version):
+        """An unrecognized auth.type value must fail the render (PINF-425)."""
+        values = {
+            "gitSyncRelay": {
+                "enabled": True,
+                "repo": {
+                    "url": "https://github.com/example/dags.git",
+                    "auth": {"type": "https-token"},
+                },
+            }
+        }
+        with pytest.raises(CalledProcessError):
+            render_chart(
+                kube_version=kube_version,
+                show_only="templates/git-sync-relay/git-sync-relay-deployment.yaml",
+                values=values,
+            )
+
     def test_gsr_deployment_without_ssh_credentials_and_known_hosts(self, kube_version):
         """Test that a valid deployment is rendered when enabling git-sync without ssh credentials."""
         values = {

--- a/tests/chart/test_git_sync_relay_deployment.py
+++ b/tests/chart/test_git_sync_relay_deployment.py
@@ -1,3 +1,5 @@
+from subprocess import CalledProcessError
+
 import pytest
 
 from tests import git_root_dir, supported_k8s_versions
@@ -148,6 +150,119 @@ class TestGitSyncRelayDeployment:
             "GIT_SYNC_REPO_FETCH_MODE": "poll",
         }
         assert c_by_name["git-daemon"]["livenessProbe"]
+
+    def test_gsr_deployment_https_pat(self, kube_version):
+        """HTTPS+PAT auth: GIT_SYNC_AUTH_TYPE is set, the credentials Secret mounts as a
+        directory at /etc/git-secret/https, and no SSH env/mounts are present (PINF-425)."""
+        values = {
+            "gitSyncRelay": {
+                "enabled": True,
+                "repo": {
+                    "url": "https://github.com/example/dags.git",
+                    "auth": {
+                        "type": "https-pat",
+                        "https": {"credentialsSecretName": "release-name-git-sync"},
+                    },
+                },
+            }
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/git-sync-relay/git-sync-relay-deployment.yaml",
+            values=values,
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+        c_by_name = get_containers_by_name(doc)
+
+        volumes = doc["spec"]["template"]["spec"]["volumes"]
+        https_vol = next(v for v in volumes if v["name"] == "git-https-secret")
+        assert https_vol["secret"]["secretName"] == "release-name-git-sync"
+        # The SSH secret volume must not be present in HTTPS mode.
+        assert not any(v["name"] == "git-secret" for v in volumes)
+
+        mounts = c_by_name["git-sync"]["volumeMounts"]
+        https_mount = next(m for m in mounts if m["name"] == "git-https-secret")
+        assert https_mount["mountPath"] == "/etc/git-secret/https"
+        assert https_mount["readOnly"] is True
+
+        env = get_env_vars_dict(c_by_name["git-sync"].get("env"))
+        assert env["GIT_SYNC_AUTH_TYPE"] == "https-pat"
+        assert env["GIT_SYNC_HTTPS_SECRET_DIR"] == "/etc/git-secret/https"
+        assert "GIT_SYNC_SSH" not in env
+        assert "GIT_SSH_KEY_FILE" not in env
+
+    def test_gsr_deployment_https_pat_mount_has_no_subpath(self, kube_version):
+        """Regression guard (FR2.2): the HTTPS credentials mount must NOT use subPath, so
+        kubelet propagates rotated credentials without a pod restart."""
+        values = {
+            "gitSyncRelay": {
+                "enabled": True,
+                "repo": {
+                    "url": "https://github.com/example/dags.git",
+                    "auth": {
+                        "type": "https-pat",
+                        "https": {"credentialsSecretName": "release-name-git-sync"},
+                    },
+                },
+            }
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/git-sync-relay/git-sync-relay-deployment.yaml",
+            values=values,
+        )
+        c_by_name = get_containers_by_name(docs[0])
+        https_mount = next(m for m in c_by_name["git-sync"]["volumeMounts"] if m["name"] == "git-https-secret")
+        assert "subPath" not in https_mount
+
+    def test_gsr_deployment_https_none(self, kube_version):
+        """https-none (public repo): GIT_SYNC_AUTH_TYPE is set but no credentials are mounted."""
+        values = {
+            "gitSyncRelay": {
+                "enabled": True,
+                "repo": {
+                    "url": "https://github.com/example/public-dags.git",
+                    "auth": {"type": "https-none"},
+                },
+            }
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/git-sync-relay/git-sync-relay-deployment.yaml",
+            values=values,
+        )
+        doc = docs[0]
+        c_by_name = get_containers_by_name(doc)
+        volumes = doc["spec"]["template"]["spec"]["volumes"]
+        assert not any(v["name"] == "git-https-secret" for v in volumes)
+
+        env = get_env_vars_dict(c_by_name["git-sync"].get("env"))
+        assert env["GIT_SYNC_AUTH_TYPE"] == "https-none"
+        assert "GIT_SYNC_HTTPS_SECRET_DIR" not in env
+        assert "GIT_SYNC_SSH" not in env
+
+    def test_gsr_deployment_ssh_and_https_mutually_exclusive(self, kube_version):
+        """Configuring both SSH and HTTPS auth must fail the render (PINF-425)."""
+        values = {
+            "gitSyncRelay": {
+                "enabled": True,
+                "repo": {
+                    "url": "https://github.com/example/dags.git",
+                    "sshPrivateKeySecretName": "an-ssh-secret",
+                    "auth": {
+                        "type": "https-pat",
+                        "https": {"credentialsSecretName": "release-name-git-sync"},
+                    },
+                },
+            }
+        }
+        with pytest.raises(CalledProcessError):
+            render_chart(
+                kube_version=kube_version,
+                show_only="templates/git-sync-relay/git-sync-relay-deployment.yaml",
+                values=values,
+            )
 
     def test_gsr_deployment_without_ssh_credentials_and_known_hosts(self, kube_version):
         """Test that a valid deployment is rendered when enabling git-sync without ssh credentials."""

--- a/tests/chart/test_git_sync_relay_deployment.py
+++ b/tests/chart/test_git_sync_relay_deployment.py
@@ -257,12 +257,48 @@ class TestGitSyncRelayDeployment:
                 },
             }
         }
-        with pytest.raises(CalledProcessError):
+        with pytest.raises(CalledProcessError) as excinfo:
             render_chart(
                 kube_version=kube_version,
                 show_only="templates/git-sync-relay/git-sync-relay-deployment.yaml",
                 values=values,
             )
+        # The message must point at the actually-conflicting fields, not imply that
+        # repo.auth is HTTPS-only (repo.auth.type: ssh is valid and pairs with
+        # sshPrivateKeySecretName on every SSH deployment).
+        stderr = excinfo.value.stderr.decode("utf-8")
+        assert "repo.sshPrivateKeySecretName cannot be combined with HTTPS auth" in stderr
+
+    def test_gsr_deployment_ssh_secret_with_explicit_ssh_auth_type_renders(self, kube_version):
+        """sshPrivateKeySecretName combined with auth.type: ssh is a valid SSH config and must
+        render, not trip the SSH/HTTPS mutual-exclusivity check — this is the shape houston
+        emits for SSH (auth.type=ssh alongside the key Secret) (PINF-425)."""
+        values = {
+            "gitSyncRelay": {
+                "enabled": True,
+                "repo": {
+                    "url": "git@github.com:example/dags.git",
+                    "sshPrivateKeySecretName": "an-ssh-secret",
+                    "auth": {"type": "ssh"},
+                },
+            }
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/git-sync-relay/git-sync-relay-deployment.yaml",
+            values=values,
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+        c_by_name = get_containers_by_name(doc)
+        # SSH wiring is present and no HTTPS credentials are mounted.
+        volumes = doc["spec"]["template"]["spec"]["volumes"]
+        assert any(v["name"] == "git-secret" for v in volumes)
+        assert not any(v["name"] == "git-https-secret" for v in volumes)
+        env = get_env_vars_dict(c_by_name["git-sync"].get("env"))
+        assert env["GIT_SYNC_SSH"] == "true"
+        assert env["GIT_SSH_KEY_FILE"] == "/etc/git-secret/ssh"
+        assert "GIT_SYNC_HTTPS_SECRET_DIR" not in env
 
     def test_gsr_deployment_https_pat_without_secret_degrades(self, kube_version):
         """https-pat without credentialsSecretName degrades like SSH-without-key: it renders

--- a/tests/chart/test_git_sync_relay_deployment.py
+++ b/tests/chart/test_git_sync_relay_deployment.py
@@ -264,8 +264,10 @@ class TestGitSyncRelayDeployment:
                 values=values,
             )
 
-    def test_gsr_deployment_https_pat_requires_secret(self, kube_version):
-        """auth.type=https-pat without credentialsSecretName must fail the render (PINF-425)."""
+    def test_gsr_deployment_https_pat_without_secret_degrades(self, kube_version):
+        """https-pat without credentialsSecretName degrades like SSH-without-key: it renders
+        GIT_SYNC_AUTH_TYPE=https-pat with no credentials mount (relay starts and retries),
+        rather than failing the render (PINF-425)."""
         values = {
             "gitSyncRelay": {
                 "enabled": True,
@@ -275,15 +277,23 @@ class TestGitSyncRelayDeployment:
                 },
             }
         }
-        with pytest.raises(CalledProcessError):
-            render_chart(
-                kube_version=kube_version,
-                show_only="templates/git-sync-relay/git-sync-relay-deployment.yaml",
-                values=values,
-            )
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/git-sync-relay/git-sync-relay-deployment.yaml",
+            values=values,
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+        c_by_name = get_containers_by_name(doc)
+        assert not any(v["name"] == "git-https-secret" for v in doc["spec"]["template"]["spec"]["volumes"])
+        assert not any(m["name"] == "git-https-secret" for m in c_by_name["git-sync"]["volumeMounts"])
+        env = get_env_vars_dict(c_by_name["git-sync"].get("env"))
+        assert env["GIT_SYNC_AUTH_TYPE"] == "https-pat"
+        assert "GIT_SYNC_HTTPS_SECRET_DIR" not in env
 
-    def test_gsr_deployment_https_secret_requires_https_pat(self, kube_version):
-        """Setting credentialsSecretName without auth.type=https-pat must fail (PINF-425)."""
+    def test_gsr_deployment_secret_without_auth_type_is_ignored(self, kube_version):
+        """A credentialsSecretName with no auth.type renders without wiring HTTPS (the secret
+        is ignored, no failure) — SSH likewise never rejects a secret (PINF-425)."""
         values = {
             "gitSyncRelay": {
                 "enabled": True,
@@ -293,12 +303,17 @@ class TestGitSyncRelayDeployment:
                 },
             }
         }
-        with pytest.raises(CalledProcessError):
-            render_chart(
-                kube_version=kube_version,
-                show_only="templates/git-sync-relay/git-sync-relay-deployment.yaml",
-                values=values,
-            )
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/git-sync-relay/git-sync-relay-deployment.yaml",
+            values=values,
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+        c_by_name = get_containers_by_name(doc)
+        assert not any(v["name"] == "git-https-secret" for v in doc["spec"]["template"]["spec"]["volumes"])
+        env = get_env_vars_dict(c_by_name["git-sync"].get("env"))
+        assert "GIT_SYNC_AUTH_TYPE" not in env
 
     def test_gsr_deployment_invalid_auth_type(self, kube_version):
         """An unrecognized auth.type value must fail the render (PINF-425)."""
@@ -317,6 +332,33 @@ class TestGitSyncRelayDeployment:
                 show_only="templates/git-sync-relay/git-sync-relay-deployment.yaml",
                 values=values,
             )
+
+    def test_gsr_deployment_https_none_with_secret_is_ignored(self, kube_version):
+        """https-none with a credentialsSecretName renders as https-none with no credentials
+        mounted (the secret is ignored, no failure) — public-repo mode (PINF-425)."""
+        values = {
+            "gitSyncRelay": {
+                "enabled": True,
+                "repo": {
+                    "url": "https://github.com/example/public-dags.git",
+                    "auth": {
+                        "type": "https-none",
+                        "https": {"credentialsSecretName": "release-name-git-sync"},
+                    },
+                },
+            }
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only="templates/git-sync-relay/git-sync-relay-deployment.yaml",
+            values=values,
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+        c_by_name = get_containers_by_name(doc)
+        assert not any(v["name"] == "git-https-secret" for v in doc["spec"]["template"]["spec"]["volumes"])
+        env = get_env_vars_dict(c_by_name["git-sync"].get("env"))
+        assert env["GIT_SYNC_AUTH_TYPE"] == "https-none"
 
     def test_gsr_deployment_without_ssh_credentials_and_known_hosts(self, kube_version):
         """Test that a valid deployment is rendered when enabling git-sync without ssh credentials."""

--- a/values.yaml
+++ b/values.yaml
@@ -928,11 +928,12 @@ gitSyncRelay:
         # Name of an existing Secret holding the HTTPS credentials. Not maintained
         # by this chart — houston creates the per-deployment ${releaseName}-git-sync
         # Secret via Commander (the same Secret used for SSH).
+        #
+        # The Secret must contain the keys `gitHttpsToken` and `gitHttpsUsername`.
+        # These names are a fixed contract, not configurable: git-sync-relay reads
+        # them as filenames from the mounted directory (PINF-426) and houston writes
+        # them (PINF-427), mirroring the fixed `gitSshKey` name used for SSH.
         credentialsSecretName: ~
-        # Secret keys the relay reads from the mounted credentials directory.
-        credentialsSecretKey:
-          token: gitHttpsToken
-          username: gitHttpsUsername
     gitSyncTimeout: 300 # How long to wait for the clone or fetch to take before aborting
     # knownHosts can be generated with: ssh-keyscan -t ed25519 github.com 2>/dev/null
     knownHosts: |

--- a/values.yaml
+++ b/values.yaml
@@ -917,6 +917,22 @@ gitSyncRelay:
     wait: 60 # seconds between synchronizations with upstream git repo
     subPath: ~ # if your dags dir is not the repo root, specify the path relative to the repo root
     sshPrivateKeySecretName: ~ # The name of a secret that holds the private key. This secret is not maintained by this chart.
+    # auth selects the git-sync authentication method. Leave unset for backward
+    # compatibility: a repo with sshPrivateKeySecretName and no auth.type is
+    # treated as SSH. SSH and HTTPS auth are mutually exclusive per deployment.
+    auth:
+      # type: one of ssh | https-pat | https-none. Unset implies ssh when
+      # sshPrivateKeySecretName is set (back-compat), otherwise no auth.
+      type: ~
+      https:
+        # Name of an existing Secret holding the HTTPS credentials. Not maintained
+        # by this chart — houston creates the per-deployment ${releaseName}-git-sync
+        # Secret via Commander (the same Secret used for SSH).
+        credentialsSecretName: ~
+        # Secret keys the relay reads from the mounted credentials directory.
+        credentialsSecretKey:
+          token: gitHttpsToken
+          username: gitHttpsUsername
     gitSyncTimeout: 300 # How long to wait for the clone or fetch to take before aborting
     # knownHosts can be generated with: ssh-keyscan -t ed25519 github.com 2>/dev/null
     knownHosts: |


### PR DESCRIPTION
## Description

- **`values.yaml`**: new `gitSyncRelay.repo.auth` block.
  - `auth.type`: one of `ssh`, `https-pat`, `https-none`. Unset implies SSH when `sshPrivateKeySecretName` is set (back-compat), otherwise no auth.
  - `auth.https.credentialsSecretName`: name of the existing Secret holding HTTPS credentials (houston creates the per-deployment `${releaseName}-git-sync` Secret via Commander, same Secret used for SSH).
  - `auth.https.credentialsSecretKey`: keys the relay reads from the mounted credentials dir (`token: gitHttpsToken`, `username: gitHttpsUsername`).

- **`templates/git-sync-relay/git-sync-relay-deployment.yaml`**:
  - Resolves the auth method from `repo.auth.type`, treating an SSH key with no explicit type as SSH.
  - Fails the render if both SSH and HTTPS are configured, since the two are mutually exclusive per deployment.
  - For `https-pat`: adds a `git-https-secret` volume and mounts it at `/etc/git-secret/https`. Mounted as a directory (no `subPath`) so kubelet propagates rotated credentials without a pod restart (FR2.2).
  - Sets `GIT_SYNC_AUTH_TYPE` for both HTTPS modes and `GIT_SYNC_HTTPS_SECRET_DIR` for `https-pat`.

- **`tests/chart/test_git_sync_relay_deployment.py`**: render tests covering the HTTPS paths and the existing SSH/no-auth defaults.
  - `https-pat`: secret volume, mount path, `readOnly`, env vars, and absence of SSH artifacts.
  - `https-pat` mount has no `subPath`.
  - `https-none`: no secret volume, `GIT_SYNC_AUTH_TYPE` set, no secret dir or SSH env.
  - SSH + HTTPS together fails the render.
  - SSH-with-credentials and no-credentials defaults still render as before.


## Related Issues

- <https://linear.app/astronomer/issue/PINF-425/fr11-airflow-chart>

## Testing

Tests have been updated but this has not been manually tested in a cluster.

## Merging

This is only for 2.1