### PR TITLE
backport security context changes

### DIFF
--- a/.agents/skills/chart-tests/SKILL.md
+++ b/.agents/skills/chart-tests/SKILL.md
@@ -8,7 +8,7 @@ description: Use when writing, editing, reviewing, or running Helm chart tests f
 ## Critical Rules
 
 1. **Run tests through the project's managed environment** — `make unittest-chart`, `uv run pytest`, `.venv/bin/python -m pytest`, and `.venv/bin/pytest` are all valid. Don't hand-roll a separate venv with `pip install`.
-2. **Wrapper values are top-level; sub-chart values MUST be nested under `airflow`** (see [Wrapper values vs. sub-chart values](#wrapper-values-vs-sub-chart-values--critical))
+2. **Parent-chart values are top-level; sub-chart values MUST be nested under `airflow`** (see [Parent-chart values vs. sub-chart values](#parent-chart-values-vs-sub-chart-values--critical))
 3. **No `helm unittest` plugin** — all tests are pytest-based using `render_chart()`
 
 ---
@@ -57,11 +57,11 @@ def test_some_feature(kube_version):
     assert docs[0]["kind"] == "StatefulSet"
 ```
 
-### Wrapper values vs. sub-chart values — CRITICAL
+### Parent-chart values vs. sub-chart values — CRITICAL
 
-This is a wrapper chart. There are two kinds of values:
+This is an umbrella (parent) chart. There are two kinds of values:
 
-**1. The wrapper's own values** — used by templates under top-level `templates/`. These are set at the top level of `values.yaml`: `dagDeploy`, `gitSyncRelay`, `authSidecar`, `loggingSidecar`, `extraObjects`, `ingress`, `sccEnabled`, `platform`, etc. Set them directly:
+**1. The parent chart's own values** — used by templates under top-level `templates/`. These are set at the top level of `values.yaml`: `dagDeploy`, `gitSyncRelay`, `authSidecar`, `loggingSidecar`, `extraObjects`, `ingress`, `sccEnabled`, `platform`, etc. Set them directly:
 
 ```python
 values = {"dagDeploy": {"enabled": True}}
@@ -87,7 +87,7 @@ docs = render_chart(
 
 ### Using `show_only`
 
-Always use `show_only` to target the specific template being tested. Wrapper templates use the `templates/` prefix; sub-chart templates use the `charts/airflow/templates/` prefix:
+Always use `show_only` to target the specific template being tested. Parent-chart templates use the `templates/` prefix; sub-chart templates use the `charts/airflow/templates/` prefix:
 
 ```python
 docs = render_chart(

--- a/.agents/skills/circleci/SKILL.md
+++ b/.agents/skills/circleci/SKILL.md
@@ -59,6 +59,8 @@ The generator injects a small set of computed variables into the template at ren
 
 Always edit `.circleci/config.yml.j2` (or `bin/generate_circleci_config.py` for the injected values), then regenerate and commit both the template and the generated `config.yml`. The chart's K8s test matrix is driven entirely by `metadata.yaml`, so adding/removing a tested Kubernetes version is a `metadata.yaml` edit followed by a regenerate.
 
+> **CI runs only on kind (vanilla Kubernetes), never OpenShift.** The matrix is `kube_versions` × `executors` on kind. OpenShift-specific behavior (e.g. `openshift.enabled=true` SCC / UID-range handling, PINF-559) is **not** exercised in CI and must be verified manually — a change can be green in CI and still break only on OpenShift. See `CLAUDE.md`.
+
 ---
 
 ## Version Pinning

--- a/.agents/skills/helm-chart/SKILL.md
+++ b/.agents/skills/helm-chart/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: helm-chart
-description: Use for Helm chart work - creating charts, modifying existing charts, values design, testing. For the Astronomer airflow-chart repository, this is the wrapper chart around the upstream Apache Airflow chart.
+description: Use for Helm chart work - creating charts, modifying existing charts, values design, testing. For the Astronomer airflow-chart repository, this is the umbrella chart whose single dependency is the upstream Apache Airflow chart.
 ---
 
 # Helm Chart Work Guide
@@ -9,16 +9,16 @@ description: Use for Helm chart work - creating charts, modifying existing chart
 
 This repository (`astronomer/airflow-chart`) is **Astronomer's Helm chart for Apache Airflow**. The chart is named `airflow` (see `Chart.yaml`), but the repo and the packaged release are `airflow-chart`.
 
-It is a **wrapper chart**: it declares the upstream Astronomer Airflow chart as a dependency (`dependencies:` in `Chart.yaml`, pinned to a `*-astro` version) and layers Astronomer-specific resources on top. A single `values.yaml` controls both the wrapper's own resources and the bundled `airflow` sub-chart.
+It is an **umbrella (parent) chart**: it declares the upstream Astronomer Airflow chart as a dependency (`dependencies:` in `Chart.yaml`, pinned to a `*-astro` version) and layers Astronomer-specific resources on top. A single `values.yaml` controls both the parent chart's own resources and the bundled `airflow` sub-chart.
 
-- The bundled sub-chart is downloaded to `charts/airflow/` by `helm dep update` (run `make charts`). Sub-chart values are nested under the `airflow:` key in `values.yaml`.
-- The wrapper's own resources live at the top-level `templates/` directory and add things like the DAG-deploy server, git-sync relay, auth sidecars, OpenShift SCC, logging sidecar, and ingress.
+- The sub-chart is downloaded to `charts/airflow/` by `helm dep update` (run `make charts`). Sub-chart values are nested under the `airflow:` key in `values.yaml`.
+- The parent chart's own resources live at the top-level `templates/` directory and add things like the DAG-deploy server, git-sync relay, auth sidecars, OpenShift SCC, logging sidecar, and ingress.
 
 For testing, use the [chart-tests skill](../chart-tests/SKILL.md) — it covers `render_chart()`, sub-chart values nesting under `airflow`, parametrized tests, and `uv run pytest` usage.
 
 ### Template layout
 
-The wrapper's templates live under top-level `templates/`. Two patterns coexist — follow whichever the surrounding code already uses; we do not retroactively rename files.
+The parent chart's templates live under top-level `templates/`. Two patterns coexist — follow whichever the surrounding code already uses; we do not retroactively rename files.
 
 **Component subdirectories.** Multi-file components get their own subdirectory, and the component name is repeated in the filename so the file is identifiable from its basename alone: `api-server/`, `dag-deploy/`, `flower/`, `git-sync-relay/`, `webserver/`.
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,7 @@ jobs:
   run_pre_commit:
     resource_class: small
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2026-06
+      - image: quay.io/astronomer/ci-pre-commit:2026-07
     steps:
       - checkout
       - run:
@@ -207,7 +207,7 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-06
+      - image: quay.io/astronomer/ci-helm-release:2026-07
     parallelism: 8
     steps:
       - setup_remote_docker:
@@ -226,7 +226,7 @@ jobs:
 
   build-and-release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-06
+      - image: quay.io/astronomer/ci-helm-release:2026-07
     steps:
       - checkout
       - run:
@@ -267,7 +267,7 @@ jobs:
           path: test-results
   release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-06
+      - image: quay.io/astronomer/ci-helm-release:2026-07
     steps:
       - checkout
       - run:
@@ -276,7 +276,7 @@ jobs:
 
   release-public:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-06
+      - image: quay.io/astronomer/ci-helm-release:2026-07
     steps:
       - checkout
       - publish-github-release

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,6 +16,7 @@ RUN apt update && apt install -y \
     nodejs \
     npm \
     procps \
+    ripgrep \
     unzip \
     vim \
     wget \

--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,7 @@
 *.swp
 *.tgz
 .DS_Store
-.agents
-.circleci
-.claude
 .claude/settings.local.json
-.github
 .vscode
 /.idea/
 /.vscode/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "charliermarsh.ruff",
+        "ms-python.vscode-pylance",
+        "ms-python.python"
+    ]
+}

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,21 @@
+{
+  "inputs": [],
+  "servers": {
+    "Linear": {
+      "args": [
+        "https://mcp.linear.app/mcp",
+        "mcp-remote"
+      ],
+      "command": "npx",
+      "type": "stdio"
+    },
+    "Notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
+    },
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/"
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# CLAUDE.md
+
+Guidance for Claude Code (and humans) working in the `airflow-chart` repo.
+
+## What this chart is
+
+This repo contains a single Helm **umbrella chart** — a parent chart that declares a
+dependency (a _subchart_) and adds its own templates on top.
+
+- **Parent chart:** named `airflow` (`Chart.yaml` → `name: airflow`). The repository is
+  `airflow-chart`; the chart it contains is `airflow`.
+- **Dependency / subchart:** the parent declares exactly one entry under `Chart.yaml`
+  `dependencies:` — the upstream Astronomer Airflow chart, which is **also named `airflow`**.
+  `helm dependency update` (aka `make charts`) fetches it into `charts/`.
+- **The two `airflow`s are different charts.** "Parent `airflow`" = this repo's umbrella
+  chart. "Subchart `airflow`" = the upstream chart it depends on. They share a name — that
+  collision is the main thing to keep straight.
+
+### How values reach each chart (Helm value scoping)
+
+Helm routes any values nested under a top-level key that matches a subchart's name into
+that subchart. Because the subchart is named `airflow`:
+
+- Keys **under `airflow:`** in `values.yaml` configure the **subchart** (upstream Airflow) —
+  e.g. `airflow.redis.*`, `airflow.pgbouncer.*`, `airflow.dags.gitSync.*`.
+- **Top-level keys** (not under `airflow:`) configure the **parent chart's own resources** —
+  e.g. `gitSyncRelay.*`, `dagDeploy.*`, `authSidecar.*`, `loggingSidecar.*`, `ingress.*`.
+
+### Where templates live
+
+- **Parent templates:** top-level `templates/` — Astronomer-specific resources layered on
+  top of the subchart (git-sync-relay, dag-deploy server, auth/logging sidecars, ingress,
+  OpenShift SCC, …).
+- **Subchart templates:** `charts/airflow/templates/` (present after `make charts`) — the
+  upstream chart. Do not edit these; they are a fetched dependency.
+
+## Testing & CI
+
+- Chart (render) tests: `make unittest-chart`, or `uv run pytest tests/chart/`. The tested
+  Kubernetes versions come from `metadata.yaml`.
+- Functional / e2e tests run in CircleCI against **kind** clusters, across the
+  `CeleryExecutor`, `LocalExecutor`, and `KubernetesExecutor`.
+
+**Important — OpenShift is NOT exercised in CI.** CI runs only on kind (vanilla Kubernetes). OpenShift-specific behavior — e.g. the restricted-v2 SCC UID-range stripping in the `gitSyncRelay.podSecurityContext` helper (PINF-559), and anything gated on `openshift.enabled=true` — must be verified manually. A change can be fully green in CI and still break only on OpenShift.
+
+## CI config
+
+`.circleci/config.yml` is a generated file — edit `.circleci/config.yml.j2` and/or
+`bin/generate_circleci_config.py`, then regenerate. Never edit `config.yml` directly. See
+the `circleci` skill.

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v2 is Helm 3
 apiVersion: v2
 name: airflow
-version: 1.18.0
+version: 1.17.37
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v2 is Helm 3
 apiVersion: v2
 name: airflow
-version: 1.17.36
+version: 1.18.0
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:

--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -349,7 +349,8 @@ Create the name of the cleanup service account to use
   resources: {{- toYaml .Values.loggingSidecar.resources | nindent 4 }}
   {{- end }}
   securityContext:
-    readOnlyRootFilesystem: true
+    {{- $required := dict "readOnlyRootFilesystem" true }}
+    {{- toYaml (merge $required (.Values.loggingSidecar.securityContext | default dict)) | nindent 4 }}
   env:
   - name: VECTOR_CONFIG
     value: /etc/sidecar-logging/vector-config.yaml
@@ -392,11 +393,8 @@ Create the name of the cleanup service account to use
   resources: {{- toYaml .Values.authSidecar.resources | nindent 4 }}
   {{- end }}
   securityContext:
-  {{- if .Values.authSidecar.securityContext }}
     {{- $required := dict "readOnlyRootFilesystem" true }}
-    {{- toYaml (merge $required .Values.authSidecar.securityContext ) | nindent 4 }}
-  {{- end }}
-    readOnlyRootFilesystem: true
+    {{- toYaml (merge $required (.Values.authSidecar.securityContext | default dict)) | nindent 4 }}
   ports:
   - containerPort: {{ .Values.authSidecar.port }}
     name: auth-proxy

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -162,7 +162,7 @@ spec:
                   name: flower-ui
                   {{- end }}
 {{- end }}
-{{- if and .Values.dagDeploy.enabled  }}
+{{- if .Values.dagDeploy.enabled  }}
 ---
 kind: Ingress
 apiVersion: networking.k8s.io/v1

--- a/tests/chart/test_auth_sidecar.py
+++ b/tests/chart/test_auth_sidecar.py
@@ -231,7 +231,11 @@ class TestAuthSidecar:
 
         common_pod_manager_test_cases(docs, 1, "release-name-dag-server", "StatefulSet")
         c_by_name = get_containers_by_name(docs[0])
-        assert c_by_name["auth-proxy"]["securityContext"] == {**securityContext, "readOnlyRootFilesystem": True}
+        assert c_by_name["auth-proxy"]["securityContext"] == {
+            **securityContext,
+            "readOnlyRootFilesystem": True,
+            "capabilities": {"drop": ["ALL"]},
+        }
 
     def test_auth_sidecar_resources_with_dag_server_enabled(self, kube_version):
         """Test auth sidecar resource overrides"""

--- a/tests/chart/test_container_security_context.py
+++ b/tests/chart/test_container_security_context.py
@@ -1,0 +1,168 @@
+"""Cross-cutting test for hardened container securityContext defaults.
+
+Acceptance criteria: *every* container the chart renders must run with a
+hardened container securityContext:
+
+  - readOnlyRootFilesystem: true
+  - allowPrivilegeEscalation: false
+  - capabilities.drop: [ALL]
+
+This renders the chart with all features enabled and reports every container
+that does not meet the requirement, so newly-added containers are covered
+automatically rather than being silently skipped.
+"""
+
+import pytest
+
+from tests import supported_k8s_versions
+from tests.utils import get_all_features, get_containers_by_name
+from tests.utils.chart import render_chart
+
+# The bundled postgresql is a test-only dependency, not something this chart ships.
+EXCLUDED_DOCS = {"release-name-postgresql", "release-name-postgresql-hl"}
+
+
+def hardening_problems(container: dict) -> dict:
+    """Return the securityContext fields that are not hardened for a container.
+
+    An empty dict means the container is fully hardened. Each entry maps the
+    offending field to the (wrong) value actually found, so failures are
+    actionable.
+    """
+    security_context = container.get("securityContext") or {}
+    problems = {}
+    if security_context.get("readOnlyRootFilesystem") is not True:
+        problems["readOnlyRootFilesystem"] = security_context.get("readOnlyRootFilesystem")
+    if security_context.get("allowPrivilegeEscalation") is not False:
+        problems["allowPrivilegeEscalation"] = security_context.get("allowPrivilegeEscalation")
+    drop = (security_context.get("capabilities") or {}).get("drop")
+    if drop != ["ALL"]:
+        problems["capabilities.drop"] = drop
+    return problems
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+def test_all_containers_have_hardened_security_context(kube_version):
+    """Render the whole chart and assert no container lacks the hardened securityContext."""
+    docs = render_chart(kube_version=kube_version, values=get_all_features())
+
+    offenders = {}
+    checked = 0
+    for doc in docs:
+        if doc.get("metadata", {}).get("name") in EXCLUDED_DOCS:
+            continue
+        owner = f"{doc['kind']}/{doc['metadata']['name']}"
+        for name, container in get_containers_by_name(doc, include_init_containers=True).items():
+            checked += 1
+            if problems := hardening_problems(container):
+                offenders[f"{owner}:{name}"] = problems
+
+    # Guard against a render/enumeration regression that would make the assertion vacuous.
+    assert checked, "No containers were rendered; cannot validate securityContext hardening"
+    assert not offenders, "Containers without a hardened securityContext (field: actual value):\n" + "\n".join(
+        f"  {key}: {value}" for key, value in sorted(offenders.items())
+    )
+
+
+# --- git-sync-relay PSS-Restricted conformance (PINF-585 follow-up) -----------------
+#
+# git-sync-relay is not processed by houston's securityHardeningConfig, so unlike
+# redis/statsd/pgbouncer/gitSync its restricted set must come from the chart values. The
+# cross-cutting test above only enforces the universal three-field container floor; these
+# tests additionally pin the pod-level securityContext — runAsNonRoot and the seccompProfile
+# (set pod-level to match the platform chart) — across both vanilla and OpenShift (PINF-559).
+
+GIT_SYNC_RELAY_DEPLOYMENT = "templates/git-sync-relay/git-sync-relay-deployment.yaml"
+
+# Every git-sync-relay container carries the restricted container securityContext.
+# seccompProfile is set once at the pod level (not per-container) — see the pod tests below.
+RESTRICTED_CONTAINER_SECURITY_CONTEXT = {
+    "readOnlyRootFilesystem": True,
+    "allowPrivilegeEscalation": False,
+    "capabilities": {"drop": ["ALL"]},
+}
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+@pytest.mark.parametrize("openshift_enabled", [False, True], ids=["vanilla", "openshift"])
+def test_git_sync_relay_containers_are_pss_restricted(kube_version, openshift_enabled):
+    """All three git-sync-relay containers carry the full PSS-Restricted container
+    securityContext, in both vanilla and OpenShift modes."""
+    docs = render_chart(
+        kube_version=kube_version,
+        values={
+            "gitSyncRelay": {"enabled": True, "repoShareMode": "git_daemon"},
+            "openshift": {"enabled": openshift_enabled},
+        },
+        show_only=[GIT_SYNC_RELAY_DEPLOYMENT],
+    )
+    assert len(docs) == 1
+    containers = get_containers_by_name(docs[0], include_init_containers=True)
+    # git-config-manager (init), git-sync, and the git-daemon sidecar (git_daemon mode).
+    for name in ("git-config-manager", "git-sync", "git-daemon"):
+        assert name in containers, f"expected '{name}' container in git-sync-relay deployment"
+        assert containers[name]["securityContext"] == RESTRICTED_CONTAINER_SECURITY_CONTEXT
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+def test_git_sync_relay_pod_security_context_vanilla(kube_version):
+    """Vanilla: the pod runs as non-root with the chart's UID/fsGroup and a seccomp profile."""
+    docs = render_chart(
+        kube_version=kube_version,
+        values={"gitSyncRelay": {"enabled": True}, "openshift": {"enabled": False}},
+        show_only=[GIT_SYNC_RELAY_DEPLOYMENT],
+    )
+    pod_security_context = docs[0]["spec"]["template"]["spec"]["securityContext"]
+    assert pod_security_context == {
+        "fsGroup": 65533,
+        "runAsUser": 50000,
+        "runAsNonRoot": True,
+        "seccompProfile": {"type": "RuntimeDefault"},
+    }
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+def test_git_sync_relay_pod_security_context_openshift(kube_version):
+    """OpenShift (PINF-559): runAsUser/fsGroup are stripped for the restricted-v2 SCC,
+    but runAsNonRoot and the seccomp profile are preserved."""
+    docs = render_chart(
+        kube_version=kube_version,
+        values={"gitSyncRelay": {"enabled": True}, "openshift": {"enabled": True}},
+        show_only=[GIT_SYNC_RELAY_DEPLOYMENT],
+    )
+    pod_security_context = docs[0]["spec"]["template"]["spec"]["securityContext"]
+    assert pod_security_context == {
+        "runAsNonRoot": True,
+        "seccompProfile": {"type": "RuntimeDefault"},
+    }
+
+
+# --- Sidecar securityContext: enforced readOnlyRootFilesystem floor + null-safety --------
+#
+# auth_sidecar_container_spec and logging_sidecar_container_spec render their securityContext
+# as `merge $required (.Values.<sidecar>.securityContext | default dict)`, where
+# $required forces `readOnlyRootFilesystem: true`. Even when a user sets the override to null
+# (or unsets it), the result must be the enforced `{readOnlyRootFilesystem: true}` floor —
+# never `securityContext: null` and never dropping readOnlyRootFilesystem.
+# Both containers render into the dag-server StatefulSet when their feature is enabled.
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+@pytest.mark.parametrize(
+    "component,container",
+    [("authSidecar", "auth-proxy"), ("loggingSidecar", "sidecar-log-consumer")],
+)
+def test_sidecar_security_context_null_keeps_enforced_floor(kube_version, component, container):
+    """A null/unset sidecar securityContext override still renders the enforced
+    readOnlyRootFilesystem floor, not `null` and not an empty map."""
+    docs = render_chart(
+        kube_version=kube_version,
+        values={"dagDeploy": {"enabled": True}, component: {"enabled": True, "securityContext": None}},
+        show_only=["templates/dag-deploy/dag-server-statefulset.yaml"],
+    )
+    assert len(docs) == 1
+    containers = get_containers_by_name(docs[0])
+    assert container in containers, f"expected '{container}' container in the dag-server pod"
+    security_context = containers[container]["securityContext"]
+    assert security_context == {"readOnlyRootFilesystem": True}, (
+        f"{container} securityContext should keep the enforced readOnlyRootFilesystem floor "
+        f"when the override is null, got {security_context!r}"
+    )

--- a/tests/chart/test_dag_server_statefulset.py
+++ b/tests/chart/test_dag_server_statefulset.py
@@ -145,6 +145,7 @@ class TestDagServerStatefulSet:
         assert container_spec["containers"][0]["securityContext"] == {
             "allowPrivilegeEscalation": False,
             "readOnlyRootFilesystem": True,
+            "capabilities": {"drop": ["ALL"]},
         }
 
     def test_dag_server_openshift_strips_incompatible_security_context(self, kube_version):

--- a/tests/chart/test_git_sync_relay_deployment.py
+++ b/tests/chart/test_git_sync_relay_deployment.py
@@ -304,7 +304,13 @@ class TestGitSyncRelayDeployment:
         assert doc["kind"] == "Deployment"
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "release-name-git-sync-relay"
-        assert gsrsecuritycontext == doc["spec"]["template"]["spec"]["securityContext"]
+        # runAsNonRoot: true and seccompProfile are PSS-Restricted chart defaults that merge in
+        # alongside overrides (pod-level securityContext).
+        assert doc["spec"]["template"]["spec"]["securityContext"] == {
+            **gsrsecuritycontext,
+            "runAsNonRoot": True,
+            "seccompProfile": {"type": "RuntimeDefault"},
+        }
 
     def test_gsr_deployment_openshift_strips_incompatible_security_context(self, kube_version):
         """Test that fsGroup and runAsUser are stripped from pod securityContext when OpenShift is enabled,

--- a/tests/enable_all_features.yaml
+++ b/tests/enable_all_features.yaml
@@ -17,6 +17,10 @@ airflow:
         name: usr-local-airflow-copier
         securityContext:
           readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
         volumeMounts:
           - mountPath: /usr_local_airflow_copy
             name: usr-local-airflow
@@ -40,6 +44,10 @@ airflow:
         name: usr-local-airflow-copier
         securityContext:
           readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
         volumeMounts:
           - mountPath: /usr_local_airflow_copy
             name: usr-local-airflow
@@ -64,6 +72,10 @@ airflow:
         name: usr-local-airflow-copier
         securityContext:
           readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
         volumeMounts:
           - mountPath: /usr_local_airflow_copy
             name: usr-local-airflow
@@ -108,6 +120,10 @@ airflow:
         name: usr-local-airflow-copier
         securityContext:
           readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
         volumeMounts:
           - mountPath: /usr_local_airflow_copy
             name: usr-local-airflow
@@ -132,6 +148,10 @@ airflow:
         name: usr-local-airflow-copier
         securityContext:
           readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
         volumeMounts:
           - mountPath: /usr_local_airflow_copy
             name: usr-local-airflow
@@ -156,6 +176,10 @@ airflow:
         name: usr-local-airflow-copier
         securityContext:
           readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
         volumeMounts:
           - mountPath: /usr_local_airflow_copy
             name: usr-local-airflow
@@ -179,6 +203,10 @@ airflow:
         name: usr-local-airflow-copier
         securityContext:
           readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
         volumeMounts:
           - mountPath: /usr_local_airflow_copy
             name: usr-local-airflow
@@ -204,6 +232,10 @@ airflow:
         name: usr-local-airflow-copier
         securityContext:
           readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
         volumeMounts:
           - mountPath: /usr_local_airflow_copy
             name: usr-local-airflow
@@ -233,6 +265,10 @@ airflow:
         name: usr-local-airflow-copier
         securityContext:
           readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
         volumeMounts:
           - mountPath: /usr_local_airflow_copy
             name: usr-local-airflow

--- a/values.yaml
+++ b/values.yaml
@@ -79,6 +79,9 @@ airflow:
       securityContexts:
         container:
           readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
 
   # Airflow api server settings
   apiServer:
@@ -115,6 +118,9 @@ airflow:
     securityContexts:
       container:
         readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
     securityContext:
       # Set user to redis:999
       runAsUser: 999
@@ -149,9 +155,15 @@ airflow:
       securityContexts:
         container:
           readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
     securityContexts:
       container:
         readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
 
   # Elasticsearch logging configuration
   elasticsearch:
@@ -432,6 +444,9 @@ airflow:
     securityContexts:
       container:
         readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
     overrideMappings:
       # Map dot separated stats to labels
       - match: airflow.operator_successes_(.*)
@@ -668,7 +683,13 @@ authSidecar:
   tag: 1.27.4-1
   pullPolicy: IfNotPresent
   port: 8084
-  securityContext: {}
+  # Hardened container securityContext. allowPrivilegeEscalation and capabilities are
+  # overridable here; readOnlyRootFilesystem is enforced by the chart (see _helpers.yaml).
+  securityContext:
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: [ALL]
   resources: {}
   livenessProbe: {}
   readinessProbe: {}
@@ -706,6 +727,13 @@ loggingSidecar:
   resources: {}
   livenessProbe: {}
   readinessProbe: {}
+  # Hardened container securityContext. allowPrivilegeEscalation and capabilities are
+  # overridable here; readOnlyRootFilesystem is enforced by the chart (see _helpers.yaml).
+  securityContext:
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: [ALL]
 
 # Ingress configuration
 ingress:
@@ -821,7 +849,11 @@ dagDeploy:
   securityContexts:
     pod:
       runAsUser: 50000
-    container: {}
+    container:
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
 
   flower:
     extraVolumeMounts:
@@ -848,14 +880,29 @@ gitSyncRelay:
   securityContext:
     fsGroup: 65533
     runAsUser: 50000
+    # PSS-Restricted requires run-as-non-root and a seccomp profile. Both are set at the
+    # pod level (seccomp pod-level matches the platform chart convention and covers every
+    # container in the pod). The gitSyncRelay.podSecurityContext helper preserves these on
+    # OpenShift while stripping runAsUser/fsGroup for the restricted-v2 SCC (PINF-559).
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   terminationGracePeriodSeconds: 30
+  # git-sync-relay is not processed by houston's securityHardeningConfig, so these
+  # container securityContexts are the only place the restricted container set is applied.
   gitDaemon:
     securityContext:
       readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
   gitSync:
     webhookPort: 8000
     securityContext:
       readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
   images:
     gitDaemon:
       repository: "quay.io/astronomer/ap-git-daemon"


### PR DESCRIPTION
## Description

### securityContext hardening — `values.yaml`

Adds `allowPrivilegeEscalation: false` + `capabilities.drop: [ALL]` to the container
securityContexts of:

- `airflow.dags.gitSync` (sub-chart git-sync sidecar)
- `airflow.redis`
- `airflow.pgbouncer` — both the `metricsExporterSidecar` and the pgbouncer container
- `airflow.statsd`
- `dagDeploy.securityContexts.container`
- git-sync-relay `gitDaemon` and `gitSync` containers

Plus:

- `authSidecar.securityContext` and `loggingSidecar.securityContext`: changed from
  `{}`/absent to hardened **overridable** defaults (`readOnlyRootFilesystem` +
  `allowPrivilegeEscalation: false` + `capabilities.drop: [ALL]`).
- `gitSyncRelay.securityContext` (pod-level): adds `runAsNonRoot: true` and
  `seccompProfile.type: RuntimeDefault`.

### `templates/_helpers.yaml`

- `logging_sidecar_container_spec`: emits `securityContext` from
  `.Values.loggingSidecar.securityContext` (was hardcoded `readOnlyRootFilesystem: true`).
- `auth_sidecar_container_spec`: emits `securityContext` from
  `.Values.authSidecar.securityContext` (was a forced `$required` merge with a duplicated
  `readOnlyRootFilesystem`).

### `tests/enable_all_features.yaml`

- Adds `allowPrivilegeEscalation: false` + `capabilities.drop: [ALL]` to the 9
  `usr-local-airflow-copier` fixture init containers.

### Tests

- `tests/chart/test_container_security_context.py` *(new)* — cross-cutting "every rendered
  container is hardened" test (with a guard against vacuous pass) + git-sync-relay
  PSS-Restricted tests (container set, plus pod-level `runAsNonRoot`/`seccompProfile`,
  vanilla & OpenShift).
- `tests/chart/test_auth_sidecar.py` — expected `auth-proxy` securityContext gains
  `capabilities: {drop: [ALL]}`.
- `tests/chart/test_dag_server_statefulset.py` — expected `dag-server` container
  securityContext gains `capabilities: {drop: [ALL]}`.
- `tests/chart/test_git_sync_relay_deployment.py` — override test's expected pod
  securityContext gains `runAsNonRoot: true` + `seccompProfile`.


## Related Issues

- <https://linear.app/astronomer/issue/PINF-585>

## Testing

Unit tests are passing. I have deployed these changes in a local k3d cluster and observed that it functioned correctly.

## Merging

This is only for APC 1.2.x

This should be merged at the same time as https://github.com/astronomer/houston-api/pull/2681