### PR TITLE
PINF-774 git-sync private-ca trust

### DIFF
--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -512,26 +512,68 @@ Strips fsGroup and runAsUser on OpenShift to comply with restricted-v2 SCC.
 {{/*
 Private-CA trust for the git-sync container. When global.privateCaCerts is set
 (each entry is a Secret with a `cert.pem` key, synced into this deployment's
-namespace by commander), mount each bundle under /usr/local/share/ca-certificates
-so update-ca-certificates trusts it. Mirrors the astronomer chart's
+namespace by commander), the git-sync container trusts those CAs: each bundle is
+mounted under /usr/local/share/ca-certificates and update-ca-certificates runs
+over a writable emptyDir overlay of /etc/ssl/certs, so it works as the non-root
+relay user (readOnlyRootFilesystem is enforced). Mirrors the astronomer chart's
 custom_ca_volumes / custom_ca_volume_mounts so the same operator-provided CA
-Secrets work here. Paired with a writable emptyDir over /etc/ssl/certs (see the
-deployment template) so update-ca-certificates can run as the non-root relay user.
+Secrets work here.
+
+The four helpers below emit the volumes, the copier initContainer, the volume
+mounts, and the UPDATE_CA_CERTS env. Each is a no-op unless global.privateCaCerts
+is set, so callers include them unconditionally (no repeated guard at the call
+site).
 */}}
 {{- define "gitSyncRelay.customCaVolumes" }}
+{{- if .Values.global.privateCaCerts }}
+- name: etc-ssl-certs
+  emptyDir: {}
 {{- range .Values.global.privateCaCerts }}
 - name: {{ . }}
   secret:
     secretName: {{ . }}
 {{- end }}
 {{- end }}
+{{- end }}
+
+{{- define "gitSyncRelay.customCaInitContainer" }}
+{{- if .Values.global.privateCaCerts }}
+- name: etc-ssl-certs-copier
+  image: "{{ .Values.gitSyncRelay.images.gitSync.repository }}:{{ .Values.gitSyncRelay.images.gitSync.tag }}"
+  securityContext: {{- toYaml .Values.gitSyncRelay.gitSync.securityContext | nindent 4 }}
+  command:
+    - sh
+    - -c
+    - |
+      if [ -d /etc/ssl/certs ]; then
+        cp -r /etc/ssl/certs/* /etc/ssl/certs_copy/
+      else
+        echo "No /etc/ssl/certs directory found, skipping copy."
+      fi
+  volumeMounts:
+    - name: etc-ssl-certs
+      mountPath: /etc/ssl/certs_copy
+  resources: {{- toYaml .Values.gitSyncRelay.gitSync.resources | nindent 4 }}
+{{- end }}
+{{- end }}
 
 {{- define "gitSyncRelay.customCaVolumeMounts" }}
+{{- if .Values.global.privateCaCerts }}
+- name: etc-ssl-certs
+  mountPath: /etc/ssl/certs
 {{- range $secret_name := .Values.global.privateCaCerts }}
 - name: {{ $secret_name }}
   mountPath: /usr/local/share/ca-certificates/{{ $secret_name }}.pem
   subPath: cert.pem
   readOnly: true
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "gitSyncRelay.customCaEnv" }}
+{{- if .Values.global.privateCaCerts }}
+- name: UPDATE_CA_CERTS
+  value: "true"
 {{- end }}
 {{- end }}
 

--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -570,7 +570,7 @@ The same index is used in customCaVolumeMounts so each mount matches its volume.
   mountPath: /etc/ssl/certs
 {{- range $index, $secret_name := .Values.global.privateCaCerts }}
 - name: private-ca-{{ $index }}
-  mountPath: /usr/local/share/ca-certificates/private-ca-{{ $index }}.crt
+  mountPath: /usr/local/share/ca-certificates/private-ca-{{ $index }}.pem
   subPath: cert.pem
   readOnly: true
 {{- end }}

--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -524,14 +524,21 @@ mounts, and the UPDATE_CA_CERTS env. Each is a no-op unless global.privateCaCert
 is set, so callers include them unconditionally (no repeated guard at the call
 site).
 */}}
+{{/*
+Volume names must be DNS-1123 labels (no dots, <=63 chars, unique), but Secret
+names are DNS-1123 subdomains (may contain dots, up to 253 chars). Derive the
+volume name from the list index (private-ca-N) so it is always valid and can
+never collide; the real Secret name stays on `secretName` / the mount filename.
+The same index is used in customCaVolumeMounts so each mount matches its volume.
+*/}}
 {{- define "gitSyncRelay.customCaVolumes" }}
 {{- if .Values.global.privateCaCerts }}
 - name: etc-ssl-certs
   emptyDir: {}
-{{- range .Values.global.privateCaCerts }}
-- name: {{ . }}
+{{- range $index, $secret_name := .Values.global.privateCaCerts }}
+- name: private-ca-{{ $index }}
   secret:
-    secretName: {{ . }}
+    secretName: {{ $secret_name }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -546,7 +553,7 @@ site).
     - -c
     - |
       if [ -d /etc/ssl/certs ]; then
-        cp -r /etc/ssl/certs/* /etc/ssl/certs_copy/
+        cp -r /etc/ssl/certs/. /etc/ssl/certs_copy/
       else
         echo "No /etc/ssl/certs directory found, skipping copy."
       fi
@@ -561,9 +568,9 @@ site).
 {{- if .Values.global.privateCaCerts }}
 - name: etc-ssl-certs
   mountPath: /etc/ssl/certs
-{{- range $secret_name := .Values.global.privateCaCerts }}
-- name: {{ $secret_name }}
-  mountPath: /usr/local/share/ca-certificates/{{ $secret_name }}.pem
+{{- range $index, $secret_name := .Values.global.privateCaCerts }}
+- name: private-ca-{{ $index }}
+  mountPath: /usr/local/share/ca-certificates/private-ca-{{ $index }}.crt
   subPath: cert.pem
   readOnly: true
 {{- end }}

--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -510,6 +510,32 @@ Strips fsGroup and runAsUser on OpenShift to comply with restricted-v2 SCC.
 {{- end }}
 
 {{/*
+Private-CA trust for the git-sync container. When global.privateCaCerts is set
+(each entry is a Secret with a `cert.pem` key, synced into this deployment's
+namespace by commander), mount each bundle under /usr/local/share/ca-certificates
+so update-ca-certificates trusts it. Mirrors the astronomer chart's
+custom_ca_volumes / custom_ca_volume_mounts so the same operator-provided CA
+Secrets work here. Paired with a writable emptyDir over /etc/ssl/certs (see the
+deployment template) so update-ca-certificates can run as the non-root relay user.
+*/}}
+{{- define "gitSyncRelay.customCaVolumes" }}
+{{- range .Values.global.privateCaCerts }}
+- name: {{ . }}
+  secret:
+    secretName: {{ . }}
+{{- end }}
+{{- end }}
+
+{{- define "gitSyncRelay.customCaVolumeMounts" }}
+{{- range $secret_name := .Values.global.privateCaCerts }}
+- name: {{ $secret_name }}
+  mountPath: /usr/local/share/ca-certificates/{{ $secret_name }}.pem
+  subPath: cert.pem
+  readOnly: true
+{{- end }}
+{{- end }}
+
+{{/*
 dag-deploy pod-level securityContext
 Strips fsGroup and runAsUser on OpenShift to comply with restricted-v2 SCC.
 */}}

--- a/templates/git-sync-relay/git-sync-relay-deployment.yaml
+++ b/templates/git-sync-relay/git-sync-relay-deployment.yaml
@@ -110,7 +110,33 @@ spec:
         {{- end }}
         - emptyDir: {}
           name: tmp
+        {{- if .Values.global.privateCaCerts }}
+        {{- /* Writable overlay for the read-only image trust store, seeded by the
+               etc-ssl-certs-copier initContainer, so update-ca-certificates can run
+               as the non-root relay user (readOnlyRootFilesystem is enforced). */}}
+        - name: etc-ssl-certs
+          emptyDir: {}
+        {{- include "gitSyncRelay.customCaVolumes" . | nindent 8 }}
+        {{- end }}
       initContainers:
+        {{- if .Values.global.privateCaCerts }}
+        - name: etc-ssl-certs-copier
+          image: "{{ .Values.gitSyncRelay.images.gitSync.repository }}:{{ .Values.gitSyncRelay.images.gitSync.tag }}"
+          securityContext: {{- toYaml .Values.gitSyncRelay.gitSync.securityContext | nindent 12 }}
+          command:
+            - sh
+            - -c
+            - |
+              if [ -d /etc/ssl/certs ]; then
+                cp -r /etc/ssl/certs/* /etc/ssl/certs_copy/
+              else
+                echo "No /etc/ssl/certs directory found, skipping copy."
+              fi
+          volumeMounts:
+            - name: etc-ssl-certs
+              mountPath: /etc/ssl/certs_copy
+          resources: {{- toYaml .Values.gitSyncRelay.gitSync.resources | nindent 12 }}
+        {{- end }}
         - name: git-config-manager
           command: ["git", "config", "--global", "--add", "safe.directory", "/git"]
           image: "{{ .Values.gitSyncRelay.images.gitSync.repository }}:{{ .Values.gitSyncRelay.images.gitSync.tag }}"
@@ -159,7 +185,16 @@ spec:
             {{- end }}
             - name: tmp
               mountPath: /tmp
+            {{- if .Values.global.privateCaCerts }}
+            - name: etc-ssl-certs
+              mountPath: /etc/ssl/certs
+            {{- include "gitSyncRelay.customCaVolumeMounts" . | nindent 12 }}
+            {{- end }}
           env:
+            {{- if .Values.global.privateCaCerts }}
+            - name: UPDATE_CA_CERTS
+              value: "true"
+            {{- end }}
             - name: GIT_SYNC_ROOT
               value: "/git"
             - name: GIT_SYNC_REPO

--- a/templates/git-sync-relay/git-sync-relay-deployment.yaml
+++ b/templates/git-sync-relay/git-sync-relay-deployment.yaml
@@ -110,33 +110,9 @@ spec:
         {{- end }}
         - emptyDir: {}
           name: tmp
-        {{- if .Values.global.privateCaCerts }}
-        {{- /* Writable overlay for the read-only image trust store, seeded by the
-               etc-ssl-certs-copier initContainer, so update-ca-certificates can run
-               as the non-root relay user (readOnlyRootFilesystem is enforced). */}}
-        - name: etc-ssl-certs
-          emptyDir: {}
         {{- include "gitSyncRelay.customCaVolumes" . | nindent 8 }}
-        {{- end }}
       initContainers:
-        {{- if .Values.global.privateCaCerts }}
-        - name: etc-ssl-certs-copier
-          image: "{{ .Values.gitSyncRelay.images.gitSync.repository }}:{{ .Values.gitSyncRelay.images.gitSync.tag }}"
-          securityContext: {{- toYaml .Values.gitSyncRelay.gitSync.securityContext | nindent 12 }}
-          command:
-            - sh
-            - -c
-            - |
-              if [ -d /etc/ssl/certs ]; then
-                cp -r /etc/ssl/certs/* /etc/ssl/certs_copy/
-              else
-                echo "No /etc/ssl/certs directory found, skipping copy."
-              fi
-          volumeMounts:
-            - name: etc-ssl-certs
-              mountPath: /etc/ssl/certs_copy
-          resources: {{- toYaml .Values.gitSyncRelay.gitSync.resources | nindent 12 }}
-        {{- end }}
+        {{- include "gitSyncRelay.customCaInitContainer" . | nindent 8 }}
         - name: git-config-manager
           command: ["git", "config", "--global", "--add", "safe.directory", "/git"]
           image: "{{ .Values.gitSyncRelay.images.gitSync.repository }}:{{ .Values.gitSyncRelay.images.gitSync.tag }}"
@@ -185,16 +161,9 @@ spec:
             {{- end }}
             - name: tmp
               mountPath: /tmp
-            {{- if .Values.global.privateCaCerts }}
-            - name: etc-ssl-certs
-              mountPath: /etc/ssl/certs
             {{- include "gitSyncRelay.customCaVolumeMounts" . | nindent 12 }}
-            {{- end }}
           env:
-            {{- if .Values.global.privateCaCerts }}
-            - name: UPDATE_CA_CERTS
-              value: "true"
-            {{- end }}
+            {{- include "gitSyncRelay.customCaEnv" . | nindent 12 }}
             - name: GIT_SYNC_ROOT
               value: "/git"
             - name: GIT_SYNC_REPO

--- a/tests/chart/test_git_sync_relay_deployment.py
+++ b/tests/chart/test_git_sync_relay_deployment.py
@@ -96,8 +96,8 @@ class TestGitSyncRelayDeployment:
         c_by_name = get_containers_by_name(docs[0])
         gs_mounts = {m["name"]: m for m in c_by_name["git-sync"]["volumeMounts"]}
         assert gs_mounts["etc-ssl-certs"]["mountPath"] == "/etc/ssl/certs"
-        # Mounted as .crt (content is PEM) so update-ca-certificates picks it up.
-        assert gs_mounts["private-ca-0"]["mountPath"] == "/usr/local/share/ca-certificates/private-ca-0.crt"
+        # PEM content mounted with a .pem name; ap-base's update-ca-certificates picks it up.
+        assert gs_mounts["private-ca-0"]["mountPath"] == "/usr/local/share/ca-certificates/private-ca-0.pem"
         assert gs_mounts["private-ca-0"]["subPath"] == "cert.pem"
         git_sync_env = get_env_vars_dict(c_by_name["git-sync"].get("env"))
         assert git_sync_env["UPDATE_CA_CERTS"] == "true"
@@ -124,8 +124,8 @@ class TestGitSyncRelayDeployment:
         assert vols["private-ca-1"]["secret"]["secretName"] == "corp.intermediate.ca"
 
         gs_mounts = {m["name"]: m for m in get_containers_by_name(docs[0])["git-sync"]["volumeMounts"]}
-        assert gs_mounts["private-ca-0"]["mountPath"] == "/usr/local/share/ca-certificates/private-ca-0.crt"
-        assert gs_mounts["private-ca-1"]["mountPath"] == "/usr/local/share/ca-certificates/private-ca-1.crt"
+        assert gs_mounts["private-ca-0"]["mountPath"] == "/usr/local/share/ca-certificates/private-ca-0.pem"
+        assert gs_mounts["private-ca-1"]["mountPath"] == "/usr/local/share/ca-certificates/private-ca-1.pem"
 
     def test_gsr_deployment_gsr_repo_share_mode_volume(self, kube_version):
         """Test that a valid deployment is rendered when git-sync-relay is enabled with repoShareMode=shared_volume."""

--- a/tests/chart/test_git_sync_relay_deployment.py
+++ b/tests/chart/test_git_sync_relay_deployment.py
@@ -82,7 +82,9 @@ class TestGitSyncRelayDeployment:
         # Volumes: writable trust-store overlay + the CA secret.
         vols = {v["name"]: v for v in spec["volumes"]}
         assert "etc-ssl-certs" in vols and "emptyDir" in vols["etc-ssl-certs"]
-        assert vols["my-private-ca"]["secret"]["secretName"] == "my-private-ca"
+        # Volume name is derived from the list index (DNS-1123-safe), not the raw
+        # Secret name; the Secret name stays on secretName.
+        assert vols["private-ca-0"]["secret"]["secretName"] == "my-private-ca"
 
         # initContainer seeds the emptyDir from the image trust store.
         inits = {c["name"]: c for c in spec["initContainers"]}
@@ -94,10 +96,36 @@ class TestGitSyncRelayDeployment:
         c_by_name = get_containers_by_name(docs[0])
         gs_mounts = {m["name"]: m for m in c_by_name["git-sync"]["volumeMounts"]}
         assert gs_mounts["etc-ssl-certs"]["mountPath"] == "/etc/ssl/certs"
-        assert gs_mounts["my-private-ca"]["mountPath"] == "/usr/local/share/ca-certificates/my-private-ca.pem"
-        assert gs_mounts["my-private-ca"]["subPath"] == "cert.pem"
+        # Mounted as .crt (content is PEM) so update-ca-certificates picks it up.
+        assert gs_mounts["private-ca-0"]["mountPath"] == "/usr/local/share/ca-certificates/private-ca-0.crt"
+        assert gs_mounts["private-ca-0"]["subPath"] == "cert.pem"
         git_sync_env = get_env_vars_dict(c_by_name["git-sync"].get("env"))
         assert git_sync_env["UPDATE_CA_CERTS"] == "true"
+
+    def test_gsr_deployment_private_ca_names_are_index_based(self, kube_version):
+        """Volume names are index-derived (private-ca-N), so a Secret name that is
+        not a valid volume name (e.g. contains a dot) or would collide is handled.
+        Each CA maps to its own indexed volume + matching .crt mount."""
+        values = {
+            "gitSyncRelay": {"enabled": True},
+            # Dotted Secret names are valid Secret names but invalid volume names.
+            "global": {"privateCaCerts": ["corp.root.ca", "corp.intermediate.ca"]},
+        }
+
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["templates/git-sync-relay/git-sync-relay-deployment.yaml"],
+            values=values,
+        )
+        spec = docs[0]["spec"]["template"]["spec"]
+
+        vols = {v["name"]: v for v in spec["volumes"]}
+        assert vols["private-ca-0"]["secret"]["secretName"] == "corp.root.ca"
+        assert vols["private-ca-1"]["secret"]["secretName"] == "corp.intermediate.ca"
+
+        gs_mounts = {m["name"]: m for m in get_containers_by_name(docs[0])["git-sync"]["volumeMounts"]}
+        assert gs_mounts["private-ca-0"]["mountPath"] == "/usr/local/share/ca-certificates/private-ca-0.crt"
+        assert gs_mounts["private-ca-1"]["mountPath"] == "/usr/local/share/ca-certificates/private-ca-1.crt"
 
     def test_gsr_deployment_gsr_repo_share_mode_volume(self, kube_version):
         """Test that a valid deployment is rendered when git-sync-relay is enabled with repoShareMode=shared_volume."""

--- a/tests/chart/test_git_sync_relay_deployment.py
+++ b/tests/chart/test_git_sync_relay_deployment.py
@@ -55,6 +55,49 @@ class TestGitSyncRelayDeployment:
         assert spec["nodeSelector"] == {}
         assert spec["affinity"] == {}
         assert spec["tolerations"] == []
+        # Private-CA trust is off unless global.privateCaCerts is set.
+        assert "etc-ssl-certs" not in {v["name"] for v in spec["volumes"]}
+        assert "etc-ssl-certs-copier" not in {c["name"] for c in spec.get("initContainers", [])}
+        assert "UPDATE_CA_CERTS" not in git_sync_env
+        git_sync_mounts = {m["name"] for m in c_by_name["git-sync"].get("volumeMounts", [])}
+        assert "etc-ssl-certs" not in git_sync_mounts
+
+    def test_gsr_deployment_private_ca_enabled(self, kube_version):
+        """When global.privateCaCerts is set, the git-sync container trusts the CA(s):
+        a writable /etc/ssl/certs emptyDir (seeded by an initContainer), the CA secret
+        mounted under /usr/local/share/ca-certificates, and UPDATE_CA_CERTS=true."""
+        values = {
+            "gitSyncRelay": {"enabled": True},
+            "global": {"privateCaCerts": ["my-private-ca"]},
+        }
+
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["templates/git-sync-relay/git-sync-relay-deployment.yaml"],
+            values=values,
+        )
+        assert len(docs) == 1
+        spec = docs[0]["spec"]["template"]["spec"]
+
+        # Volumes: writable trust-store overlay + the CA secret.
+        vols = {v["name"]: v for v in spec["volumes"]}
+        assert "etc-ssl-certs" in vols and "emptyDir" in vols["etc-ssl-certs"]
+        assert vols["my-private-ca"]["secret"]["secretName"] == "my-private-ca"
+
+        # initContainer seeds the emptyDir from the image trust store.
+        inits = {c["name"]: c for c in spec["initContainers"]}
+        assert "etc-ssl-certs-copier" in inits
+        copier_mounts = {m["name"]: m for m in inits["etc-ssl-certs-copier"]["volumeMounts"]}
+        assert copier_mounts["etc-ssl-certs"]["mountPath"] == "/etc/ssl/certs_copy"
+
+        # git-sync container: writable trust store + CA mount + UPDATE_CA_CERTS.
+        c_by_name = get_containers_by_name(docs[0])
+        gs_mounts = {m["name"]: m for m in c_by_name["git-sync"]["volumeMounts"]}
+        assert gs_mounts["etc-ssl-certs"]["mountPath"] == "/etc/ssl/certs"
+        assert gs_mounts["my-private-ca"]["mountPath"] == "/usr/local/share/ca-certificates/my-private-ca.pem"
+        assert gs_mounts["my-private-ca"]["subPath"] == "cert.pem"
+        git_sync_env = get_env_vars_dict(c_by_name["git-sync"].get("env"))
+        assert git_sync_env["UPDATE_CA_CERTS"] == "true"
 
     def test_gsr_deployment_gsr_repo_share_mode_volume(self, kube_version):
         """Test that a valid deployment is rendered when git-sync-relay is enabled with repoShareMode=shared_volume."""

--- a/values.yaml
+++ b/values.yaml
@@ -2,6 +2,15 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+global:
+  # Names of Secrets (each with a `cert.pem` key) holding customer private CA
+  # bundles to trust. Houston/commander populate this per deployment with the
+  # names of the CA Secrets synced into the deployment namespace (via the
+  # astronomer.io/commander-sync annotation). When set, the git-sync container
+  # trusts them via update-ca-certificates (see the git-sync-relay deployment).
+  # Mirrors the astronomer chart's global.privateCaCerts.
+  privateCaCerts: []
+
 airflow:
   # group of airflow user
   gid: 50000


### PR DESCRIPTION
## Description

**PINF-774: Wire private-CA trust into the git-sync-relay deployment**

Mount customer private CAs into the git-sync container and run `update-ca-certificates`, so HTTPS+PAT clone works against private-CA-signed Git hosts. All wiring is gated on `global.privateCaCerts` (empty by default, so existing renders are unchanged). Mirrors the platform components' pattern.

## Changes

- `templates/git-sync-relay/git-sync-relay-deployment.yaml` (gated on `global.privateCaCerts`):
  - writable `etc-ssl-certs` emptyDir mounted over `/etc/ssl/certs`
  - `etc-ssl-certs-copier` initContainer to seed it from the image's certs
  - mount each CA Secret under `/usr/local/share/ca-certificates/<name>.pem`
  - set `UPDATE_CA_CERTS=true` on the git-sync container
- `templates/_helpers.yaml`: new `gitSyncRelay.customCaVolumes` / `gitSyncRelay.customCaVolumeMounts` helpers ranging over `global.privateCaCerts` (each Secret keyed `cert.pem`).
- `values.yaml`: document `global.privateCaCerts`.

## Notes

- Non-root / OpenShift safe: `/etc/ssl/certs` is a writable emptyDir made group-writable by the pod `fsGroup`, so `update-ca-certificates` runs without root.

## Related Issues

- https://linear.app/astronomer/issue/PINF-774

## Testing

I have manually tested https private-ca trust end-to-end in k3d against a local forgejo instance.

## Merging

This is only for APC 2.1 (airflow-chart version 1.18)