### PR TITLE
PINF-951 startup probes, requests, limits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,7 +249,7 @@ jobs:
         default: "LocalExecutor"
       kube_version:
         type: string
-        default: "1.27.3"
+        default: "1.35.0"
     steps:
       - attach_workspace:
           at: /tmp/workspace

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -136,7 +136,7 @@ jobs:
         default: "LocalExecutor"
       kube_version:
         type: string
-        default: "1.27.3"
+        default: "{{ kube_versions[-1] }}"
     steps:
       - attach_workspace:
           at: /tmp/workspace

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,16 @@ that subchart. Because the subchart is named `airflow`:
 - **Subchart templates:** `charts/airflow/templates/` (present after `make charts`) — the
   upstream chart. Do not edit these; they are a fetched dependency.
 
+## Sharp edge: `authSidecar` / `loggingSidecar` are easy to miss in any pod-spec feature
+
+Both are **top-level parent-chart keys** (see value scoping above) that add an extra container to a pod — but neither is defined inline in the pod template you'd naturally go looking at. They're rendered by shared helpers in `templates/_helpers.yaml`: `auth_sidecar_container_spec` (~line 406) and `logging_sidecar_container_spec` (~line 363), then `{{ include }}`'d into `templates/dag-deploy/dag-server-statefulset.yaml` and `templates/git-sync-relay/git-sync-relay-deployment.yaml`. Values defaults live at `values.yaml:692-746`.
+
+**Why this bites people:** if you're adding or auditing a pod-spec feature (security context, resources, probes, env vars, volume mounts, labels, image/registry override, network policy, etc.) by reading `dag-server-statefulset.yaml` or `git-sync-relay-deployment.yaml` top to bottom, you will see the `{{ include "auth_sidecar_container_spec" . }}` / `{{ include "logging_sidecar_container_spec" . }}` lines, but the actual container spec — and therefore whatever field you're checking or adding — lives in `_helpers.yaml`, not the file you're looking at. Grepping the calling template for the field name (e.g. `resources:`) will miss it entirely.
+
+**Concrete history:** this exact blind spot caused two rounds of missed coverage in the K8s Security Policy Compatibility project (`employment-astronomer` vault, `projects/2026-05-11-k8s-security-policy-compatibility/`) — first on startup probes (found 2026-07-08, fixed 2026-07-17 via PINF-951), then again on resource limits (`resources: {}` defaults for both helpers, found 2026-07-13, fixed 2026-07-17 via PINF-969 — both on this same branch).
+
+**Rule of thumb:** when adding or auditing ANY chart-wide pod-spec convention, explicitly `grep -rn "authSidecar\|loggingSidecar\|auth_sidecar\|logging_sidecar"` in this repo (and its siblings — the astronomer platform chart has an unrelated, independently-implemented `global.authSidecar` copy-pasted into several platform components, and houston-api has a third, separately-implemented `authSideCar`/`extraContainers` injection onto rendered Airflow pods; note the inconsistent casing across all three — `authSidecar` here, `authSideCar` in houston-api). Don't assume a per-file audit caught it.
+
 ## Testing & CI
 
 - Chart (render) tests: `make unittest-chart`, or `uv run pytest tests/chart/`. The tested

--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: airflow
-  repository: https://github.com/astronomer/apc-airflow/releases/download/oss-helm-chart/1.17.12-astro
-  version: 1.17.12-astro
-digest: sha256:786484e0515192f437b16b8b684caf0ee1cfb90d4518e477d0e6e9f2aa03aa14
-generated: "2026-06-03T16:33:56.707856+05:30"
+  repository: https://github.com/astronomer/apc-airflow/releases/download/oss-helm-chart/1.17.13-astro
+  version: 1.17.13-astro
+digest: sha256:b340ce72d3365352958fd674726ad1320d36de5a14090f5bba6e200ee7bb1494
+generated: "2026-07-21T12:54:37.879794-04:00"

--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: airflow
-  repository: https://github.com/astronomer/apc-airflow/releases/download/oss-helm-chart/1.17.13-astro
-  version: 1.17.13-astro
-digest: sha256:b340ce72d3365352958fd674726ad1320d36de5a14090f5bba6e200ee7bb1494
-generated: "2026-07-21T12:54:37.879794-04:00"
+  repository: https://github.com/astronomer/apc-airflow/releases/download/oss-helm-chart/1.17.14-astro
+  version: 1.17.14-astro
+digest: sha256:7d771fd86cf173b723ca37afed77efa03bb95d67c47416ab899fef8136739360
+generated: "2026-07-21T14:49:59.587504-04:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -9,5 +9,5 @@ keywords:
   - airflow
 dependencies:
   - name: airflow
-    version: 1.17.12-astro
-    repository: https://github.com/astronomer/apc-airflow/releases/download/oss-helm-chart/1.17.12-astro
+    version: 1.17.13-astro
+    repository: https://github.com/astronomer/apc-airflow/releases/download/oss-helm-chart/1.17.13-astro

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -9,5 +9,5 @@ keywords:
   - airflow
 dependencies:
   - name: airflow
-    version: 1.17.13-astro
-    repository: https://github.com/astronomer/apc-airflow/releases/download/oss-helm-chart/1.17.13-astro
+    version: 1.17.14-astro
+    repository: https://github.com/astronomer/apc-airflow/releases/download/oss-helm-chart/1.17.14-astro

--- a/bin/run-ci
+++ b/bin/run-ci
@@ -62,6 +62,7 @@ set -x
 
 # shellcheck disable=SC2086
 helm install \
+  --debug \
   -n airflow \
   --set airflow.executor="$EXECUTOR" \
   --set airflow.pgbouncer.enabled=true \

--- a/bin/run-ci
+++ b/bin/run-ci
@@ -6,12 +6,24 @@ PATH="/tmp/bin:$PATH"
 
 function get_debugging_info {
   echo "Failed to deploy Airflow!"
-  echo "Printing description and logs where containers in pod are not ready..."
-  for pod in $(kubectl get pods -n airflow | grep -v NAME | grep -v 1/1 | grep -v 2/2 | grep -v 3/3 | grep -v Completed | awk '{ print $1 }'); do
+  echo "Printing description and logs where pods are not healthy..."
+  # A Job pod (e.g. airflow-create-user) can show READY=1/1 STATUS=Running between
+  # crash-loop restarts, which used to slip past a naive "READY == N/N" filter and
+  # never get its describe/logs captured. Treat a pod as healthy only if it's
+  # Completed, or Running/ready with zero restarts.
+  for pod in $(kubectl get pods -n airflow --no-headers | awk '
+      {
+        split($2, ready, "/")
+        restarts = $4
+        sub(/\(.*/, "", restarts)
+        healthy = ($3 == "Completed") || ($3 == "Running" && ready[1] == ready[2] && restarts == 0)
+        if (!healthy) print $1
+      }'); do
     echo "======================="
     set -x
     kubectl describe pod -n airflow "$pod"
-    kubectl logs -n airflow "$pod" | tail -n 30
+    kubectl logs -n airflow "$pod" --previous --tail=30 || true
+    kubectl logs -n airflow "$pod" --tail=30
     set +x
     echo "======================="
   done

--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -395,6 +395,19 @@ Create the name of the cleanup service account to use
 {{- if .Values.loggingSidecar.readinessProbe  }}
   readinessProbe: {{ tpl (toYaml .Values.loggingSidecar.readinessProbe) . | nindent 4 }}
 {{- end }}
+{{- if .Values.loggingSidecar.startupProbe  }}
+  startupProbe: {{ tpl (toYaml .Values.loggingSidecar.startupProbe) . | nindent 4 }}
+{{- else }}
+  startupProbe:
+    exec:
+      command:
+      - sh
+      - -c
+      - test -f /etc/sidecar-logging/vector-config.yaml
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    failureThreshold: 6
+{{- end }}
   volumeMounts:
   - mountPath: /etc/sidecar-logging
     name: config-volume
@@ -438,6 +451,18 @@ Create the name of the cleanup service account to use
       scheme: HTTP
     initialDelaySeconds: 10
     periodSeconds: 10
+{{- end }}
+{{- if .Values.authSidecar.startupProbe  }}
+  startupProbe: {{ tpl (toYaml .Values.authSidecar.startupProbe) . | nindent 4 }}
+{{- else }}
+  startupProbe:
+    httpGet:
+      path: /healthz
+      port: {{ .Values.authSidecar.port }}
+      scheme: HTTP
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    failureThreshold: 6
 {{- end }}
   volumeMounts:
   - mountPath: /var/lib/nginx/logs

--- a/templates/dag-deploy/dag-server-statefulset.yaml
+++ b/templates/dag-deploy/dag-server-statefulset.yaml
@@ -105,6 +105,20 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
         {{ end }}
+        {{- if .Values.dagDeploy.startupProbe }}
+          startupProbe: {{- tpl (toYaml .Values.dagDeploy.startupProbe) . | nindent 12 }}
+        {{- else }}
+          startupProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /healthz
+              port: {{ .Values.dagDeploy.ports.dagServerHttp }}
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+        {{- end }}
           volumeMounts:
           - name: tmp
             mountPath: /tmp

--- a/templates/git-sync-relay/git-sync-relay-deployment.yaml
+++ b/templates/git-sync-relay/git-sync-relay-deployment.yaml
@@ -221,6 +221,9 @@ spec:
           {{- if .Values.gitSyncRelay.gitSync.readinessProbe }}
           readinessProbe: {{- tpl (toYaml .Values.gitSyncRelay.gitSync.readinessProbe) . | nindent 12 }}
           {{- end }}
+          {{- if .Values.gitSyncRelay.gitSync.startupProbe }}
+          startupProbe: {{- tpl (toYaml .Values.gitSyncRelay.gitSync.startupProbe) . | nindent 12 }}
+          {{- end }}
           resources: {{- toYaml .Values.gitSyncRelay.gitSync.resources | nindent 12 }}
         {{- if eq .Values.gitSyncRelay.repoShareMode "git_daemon" }}
         - name: git-daemon
@@ -246,6 +249,18 @@ spec:
           {{- end }}
           {{- if .Values.gitSyncRelay.gitDaemon.readinessProbe }}
           readinessProbe: {{- tpl (toYaml .Values.gitSyncRelay.gitDaemon.readinessProbe) . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.gitSyncRelay.gitDaemon.startupProbe }}
+          startupProbe: {{- tpl (toYaml .Values.gitSyncRelay.gitDaemon.startupProbe) . | nindent 12 }}
+          {{- else }}
+          startupProbe:
+            exec:
+              command:
+              - touch
+              - /git/.git/git-daemon-export-ok
+            initialDelaySeconds: 0
+            periodSeconds: 15
+            failureThreshold: 6
           {{- end }}
           resources: {{- toYaml .Values.gitSyncRelay.gitDaemon.resources | nindent 12 }}
         {{- end }}

--- a/templates/git-sync-relay/git-sync-relay-deployment.yaml
+++ b/templates/git-sync-relay/git-sync-relay-deployment.yaml
@@ -256,7 +256,8 @@ spec:
           startupProbe:
             exec:
               command:
-              - touch
+              - test
+              - -f
               - /git/.git/git-daemon-export-ok
             initialDelaySeconds: 0
             periodSeconds: 15

--- a/tests/chart/test_dag_server_statefulset.py
+++ b/tests/chart/test_dag_server_statefulset.py
@@ -6,7 +6,11 @@ from tests.utils.chart import render_chart
 
 readinessProbe = {"httpGet": {"initialDelaySeconds": 20, "periodSeconds": 20, "path": "/rhealthz", "port": 8080, "scheme": "HTTP"}}
 livenessProbe = {"httpGet": {"initialDelaySeconds": 20, "periodSeconds": 20, "path": "/chealthz", "port": 8080, "scheme": "HTTP"}}
-startupProbe = {"httpGet": {"initialDelaySeconds": 20, "periodSeconds": 20, "path": "/shealthz", "port": 8080, "scheme": "HTTP"}}
+startupProbe = {
+    "httpGet": {"path": "/shealthz", "port": 8080, "scheme": "HTTP"},
+    "initialDelaySeconds": 20,
+    "periodSeconds": 20,
+}
 resources = {
     "requests": {"cpu": 99.9, "memory": "777Mi"},
     "limits": {"cpu": 66.6, "memory": "888Mi"},

--- a/tests/chart/test_dag_server_statefulset.py
+++ b/tests/chart/test_dag_server_statefulset.py
@@ -6,6 +6,7 @@ from tests.utils.chart import render_chart
 
 readinessProbe = {"httpGet": {"initialDelaySeconds": 20, "periodSeconds": 20, "path": "/rhealthz", "port": 8080, "scheme": "HTTP"}}
 livenessProbe = {"httpGet": {"initialDelaySeconds": 20, "periodSeconds": 20, "path": "/chealthz", "port": 8080, "scheme": "HTTP"}}
+startupProbe = {"httpGet": {"initialDelaySeconds": 20, "periodSeconds": 20, "path": "/shealthz", "port": 8080, "scheme": "HTTP"}}
 resources = {
     "requests": {"cpu": 99.9, "memory": "777Mi"},
     "limits": {"cpu": 66.6, "memory": "888Mi"},
@@ -29,6 +30,7 @@ def common_default_tests(doc):
     assert c_by_name["dag-server"]["image"].startswith("quay.io/astronomer/ap-dag-deploy:")
     assert c_by_name["dag-server"]["image"].startswith("quay.io/astronomer/ap-dag-deploy:")
     assert c_by_name["dag-server"]["livenessProbe"]
+    assert c_by_name["dag-server"]["startupProbe"]
 
 
 @pytest.mark.parametrize("kube_version", supported_k8s_versions)
@@ -320,8 +322,15 @@ class TestDagServerStatefulSet:
         assert "sidecar-log-consumer" in c_by_name
 
     def test_dag_server_statefulset_liveness_and_readiness_probes_with_dag_server_enabled(self, kube_version):
-        """Test that a valid statefulset is rendered when dag-server is enabled with readiness and liveness probes."""
-        values = {"dagDeploy": {"enabled": True, "readinessProbe": readinessProbe, "livenessProbe": livenessProbe}}
+        """Test that a valid statefulset is rendered when dag-server is enabled with readiness, liveness, and startup probes."""
+        values = {
+            "dagDeploy": {
+                "enabled": True,
+                "readinessProbe": readinessProbe,
+                "livenessProbe": livenessProbe,
+                "startupProbe": startupProbe,
+            }
+        }
 
         docs = render_chart(
             kube_version=kube_version,
@@ -336,13 +345,24 @@ class TestDagServerStatefulSet:
         c_by_name = get_containers_by_name(doc)
         assert readinessProbe == c_by_name["dag-server"]["readinessProbe"]
         assert livenessProbe == c_by_name["dag-server"]["livenessProbe"]
+        assert startupProbe == c_by_name["dag-server"]["startupProbe"]
 
     def test_dag_server_statefulset_with_probes_and_authproxy_enabled(self, kube_version):
-        """Test that a valid statefulset is rendered when dag-server and authsidecar is enabled with readiness and liveness probes."""
+        """Test that a valid statefulset is rendered when dag-server and authsidecar is enabled with readiness, liveness, and startup probes."""
         values = {
             "dagDeploy": {"enabled": True},
-            "authSidecar": {"enabled": True, "readinessProbe": readinessProbe, "livenessProbe": livenessProbe},
-            "loggingSidecar": {"enabled": True, "readinessProbe": readinessProbe, "livenessProbe": livenessProbe},
+            "authSidecar": {
+                "enabled": True,
+                "readinessProbe": readinessProbe,
+                "livenessProbe": livenessProbe,
+                "startupProbe": startupProbe,
+            },
+            "loggingSidecar": {
+                "enabled": True,
+                "readinessProbe": readinessProbe,
+                "livenessProbe": livenessProbe,
+                "startupProbe": startupProbe,
+            },
         }
 
         docs = render_chart(
@@ -370,8 +390,10 @@ class TestDagServerStatefulSet:
         assert "sidecar-log-consumer" in c_by_name
         assert readinessProbe == c_by_name["auth-proxy"]["readinessProbe"]
         assert livenessProbe == c_by_name["auth-proxy"]["livenessProbe"]
+        assert startupProbe == c_by_name["auth-proxy"]["startupProbe"]
         assert readinessProbe == c_by_name["sidecar-log-consumer"]["readinessProbe"]
         assert livenessProbe == c_by_name["sidecar-log-consumer"]["livenessProbe"]
+        assert startupProbe == c_by_name["sidecar-log-consumer"]["startupProbe"]
 
         assert c_by_name["auth-proxy"]["volumeMounts"] == [
             {"mountPath": "/var/lib/nginx/logs", "name": "nginx-access-logs"},

--- a/tests/chart/test_dag_server_statefulset.py
+++ b/tests/chart/test_dag_server_statefulset.py
@@ -109,6 +109,22 @@ class TestDagServerStatefulSet:
         c_by_name = get_containers_by_name(doc)
         assert c_by_name["dag-server"]["resources"] == resources
 
+    def test_dag_server_statefulset_resources_have_default(self, kube_version):
+        """Test that Dag Server statefulset gets a real default resources block, not an empty one."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["templates/dag-deploy/dag-server-statefulset.yaml"],
+            values={"dagDeploy": {"enabled": True}},
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+
+        c_by_name = get_containers_by_name(doc)
+        assert c_by_name["dag-server"]["resources"] == {
+            "limits": {"cpu": "250m", "memory": "512Mi"},
+            "requests": {"cpu": "100m", "memory": "256Mi"},
+        }
+
     def test_dag_server_statefulset_with_securitycontext_overrides(self, kube_version):
         """Test that dag-server statefulset are configurable with custom securitycontext."""
         dag_server_pod_securitycontext = {
@@ -402,6 +418,15 @@ class TestDagServerStatefulSet:
             {"mountPath": "/tmp", "name": "tmp"},  # noqa: S108
             {"mountPath": "/var/lib/nginx/tmp", "name": "nginx-tmp"},
         ]
+
+        assert c_by_name["auth-proxy"]["resources"] == {
+            "limits": {"cpu": "200m", "memory": "256Mi"},
+            "requests": {"cpu": "100m", "memory": "128Mi"},
+        }
+        assert c_by_name["sidecar-log-consumer"]["resources"] == {
+            "limits": {"cpu": "200m", "memory": "256Mi"},
+            "requests": {"cpu": "100m", "memory": "128Mi"},
+        }
 
     def test_dag_server_service_account_with_template(self, kube_version):
         """Test dag-server service account with template."""

--- a/tests/chart/test_git_sync_relay_deployment.py
+++ b/tests/chart/test_git_sync_relay_deployment.py
@@ -8,6 +8,7 @@ from tests.utils.chart import render_chart
 
 readinessProbe = {"httpGet": {"initialDelaySeconds": 20, "periodSeconds": 20, "path": "/rhealthz", "port": 8080, "scheme": "HTTP"}}
 livenessProbe = {"httpGet": {"initialDelaySeconds": 20, "periodSeconds": 20, "path": "/chealthz", "port": 8080, "scheme": "HTTP"}}
+startupProbe = {"httpGet": {"initialDelaySeconds": 20, "periodSeconds": 20, "path": "/shealthz", "port": 8080, "scheme": "HTTP"}}
 
 
 @pytest.mark.parametrize("kube_version", supported_k8s_versions)
@@ -42,6 +43,11 @@ class TestGitSyncRelayDeployment:
         assert c_by_name["git-sync"]["image"].startswith("quay.io/astronomer/ap-git-sync-relay:")
         assert c_by_name["git-daemon"]["image"].startswith("quay.io/astronomer/ap-git-daemon:")
         assert c_by_name["git-daemon"]["livenessProbe"]
+        assert c_by_name["git-daemon"]["startupProbe"]
+        # git-sync has no hardcoded probe fallback (customer-configurable only), unlike git-daemon
+        assert "livenessProbe" not in c_by_name["git-sync"]
+        assert "readinessProbe" not in c_by_name["git-sync"]
+        assert "startupProbe" not in c_by_name["git-sync"]
         assert "annotations" not in doc["metadata"]
         assert "annotations" not in doc["spec"]["template"]["metadata"]
 
@@ -221,6 +227,7 @@ class TestGitSyncRelayDeployment:
             "GIT_SYNC_REPO_FETCH_MODE": "poll",
         }
         assert c_by_name["git-daemon"]["livenessProbe"]
+        assert c_by_name["git-daemon"]["startupProbe"]
 
     def test_gsr_deployment_https_pat(self, kube_version):
         """HTTPS+PAT auth: GIT_SYNC_AUTH_TYPE is set, the credentials Secret mounts as a
@@ -516,6 +523,7 @@ class TestGitSyncRelayDeployment:
             "GIT_SYNC_REPO_FETCH_MODE": "poll",
         }
         assert c_by_name["git-daemon"]["livenessProbe"]
+        assert c_by_name["git-daemon"]["startupProbe"]
 
     def test_gsr_deployment_with_metrics_enabled(self, kube_version):
         """Test that metrics env vars are set when gitSyncRelay.metrics.enabled is true."""
@@ -706,12 +714,20 @@ class TestGitSyncRelayDeployment:
         assert [{"name": "gscsecret"}] == doc["spec"]["template"]["spec"]["imagePullSecrets"]
 
     def test_gsr_deployment_with_custom_probes(self, kube_version):
-        """Test git-sync-relay deployment with custom liveness and readiness probes."""
+        """Test git-sync-relay deployment with custom liveness, readiness, and startup probes."""
         values = {
             "gitSyncRelay": {
                 "enabled": True,
-                "gitSync": {"readinessProbe": readinessProbe, "livenessProbe": livenessProbe},
-                "gitDaemon": {"readinessProbe": readinessProbe, "livenessProbe": livenessProbe},
+                "gitSync": {
+                    "readinessProbe": readinessProbe,
+                    "livenessProbe": livenessProbe,
+                    "startupProbe": startupProbe,
+                },
+                "gitDaemon": {
+                    "readinessProbe": readinessProbe,
+                    "livenessProbe": livenessProbe,
+                    "startupProbe": startupProbe,
+                },
             }
         }
 
@@ -728,8 +744,10 @@ class TestGitSyncRelayDeployment:
         c_by_name = get_containers_by_name(doc)
         assert readinessProbe == c_by_name["git-daemon"]["readinessProbe"]
         assert livenessProbe == c_by_name["git-daemon"]["livenessProbe"]
+        assert startupProbe == c_by_name["git-daemon"]["startupProbe"]
         assert readinessProbe == c_by_name["git-sync"]["readinessProbe"]
         assert livenessProbe == c_by_name["git-sync"]["livenessProbe"]
+        assert startupProbe == c_by_name["git-sync"]["startupProbe"]
 
     def test_gsr_deployment_with_repo_fetch_mode_webhook(self, kube_version):
         """Test git-sync-relay deployment with repoFetchMode=webhook."""
@@ -806,6 +824,10 @@ class TestGitSyncRelayDeployment:
             {"mountPath": "/tmp", "name": "tmp"},  # noqa: S108
             {"mountPath": "/var/lib/nginx/tmp", "name": "nginx-tmp"},
         ]
+        assert c_by_name["auth-proxy"]["livenessProbe"]
+        assert c_by_name["auth-proxy"]["readinessProbe"]
+        assert c_by_name["auth-proxy"]["startupProbe"]
+        assert c_by_name["sidecar-log-consumer"]["startupProbe"]
 
     def test_git_sync_service_account_with_template(self, kube_version):
         """Test git-sync-relay service account with template."""

--- a/tests/chart/test_git_sync_relay_deployment.py
+++ b/tests/chart/test_git_sync_relay_deployment.py
@@ -8,7 +8,11 @@ from tests.utils.chart import render_chart
 
 readinessProbe = {"httpGet": {"initialDelaySeconds": 20, "periodSeconds": 20, "path": "/rhealthz", "port": 8080, "scheme": "HTTP"}}
 livenessProbe = {"httpGet": {"initialDelaySeconds": 20, "periodSeconds": 20, "path": "/chealthz", "port": 8080, "scheme": "HTTP"}}
-startupProbe = {"httpGet": {"initialDelaySeconds": 20, "periodSeconds": 20, "path": "/shealthz", "port": 8080, "scheme": "HTTP"}}
+startupProbe = {
+    "httpGet": {"path": "/shealthz", "port": 8080, "scheme": "HTTP"},
+    "initialDelaySeconds": 20,
+    "periodSeconds": 20,
+}
 
 
 @pytest.mark.parametrize("kube_version", supported_k8s_versions)

--- a/tests/chart/test_git_sync_relay_deployment.py
+++ b/tests/chart/test_git_sync_relay_deployment.py
@@ -48,6 +48,14 @@ class TestGitSyncRelayDeployment:
         assert "livenessProbe" not in c_by_name["git-sync"]
         assert "readinessProbe" not in c_by_name["git-sync"]
         assert "startupProbe" not in c_by_name["git-sync"]
+        assert c_by_name["git-sync"]["resources"] == {
+            "limits": {"cpu": "200m", "memory": "256Mi"},
+            "requests": {"cpu": "100m", "memory": "128Mi"},
+        }
+        assert c_by_name["git-daemon"]["resources"] == {
+            "limits": {"cpu": "100m", "memory": "128Mi"},
+            "requests": {"cpu": "50m", "memory": "64Mi"},
+        }
         assert "annotations" not in doc["metadata"]
         assert "annotations" not in doc["spec"]["template"]["metadata"]
 

--- a/values.yaml
+++ b/values.yaml
@@ -702,7 +702,13 @@ authSidecar:
     allowPrivilegeEscalation: false
     capabilities:
       drop: [ALL]
-  resources: {}
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
   livenessProbe: {}
   readinessProbe: {}
   startupProbe: {}
@@ -737,7 +743,13 @@ loggingSidecar:
   indexPattern: "%Y.%m.%d"
   indexNamePrefix: vector
   image: quay.io/astronomer/ap-vector:0.45.0-1
-  resources: {}
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
   livenessProbe: {}
   readinessProbe: {}
   startupProbe: {}
@@ -855,13 +867,13 @@ dagDeploy:
     name: ~
     create: true
 
-  resources: {}
-  #  limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  #  requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  resources:
+    limits:
+      cpu: 250m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
 
   # This setting tells kubernetes that its ok to evict
   # when it wants to scale a node down.
@@ -917,6 +929,13 @@ gitSyncRelay:
       allowPrivilegeEscalation: false
       capabilities:
         drop: [ALL]
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
     livenessProbe: {}
     readinessProbe: {}
     startupProbe: {}
@@ -927,6 +946,13 @@ gitSyncRelay:
       allowPrivilegeEscalation: false
       capabilities:
         drop: [ALL]
+    resources:
+      limits:
+        cpu: 200m
+        memory: 256Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
     livenessProbe: {}
     readinessProbe: {}
     startupProbe: {}

--- a/values.yaml
+++ b/values.yaml
@@ -705,6 +705,7 @@ authSidecar:
   resources: {}
   livenessProbe: {}
   readinessProbe: {}
+  startupProbe: {}
   ingressAllowedNamespaces: ~
   annotations: {}
 
@@ -739,6 +740,7 @@ loggingSidecar:
   resources: {}
   livenessProbe: {}
   readinessProbe: {}
+  startupProbe: {}
   # Hardened container securityContext. allowPrivilegeEscalation and capabilities are
   # overridable here; readOnlyRootFilesystem is enforced by the chart (see _helpers.yaml).
   securityContext:
@@ -827,6 +829,7 @@ dagDeploy:
       imagePullPolicy: IfNotPresent
   livenessProbe: {}
   readinessProbe: {}
+  startupProbe: {}
   terminationGracePeriodSeconds: 30
   podAnnotations: {}
   annotations: {}
@@ -914,6 +917,9 @@ gitSyncRelay:
       allowPrivilegeEscalation: false
       capabilities:
         drop: [ALL]
+    livenessProbe: {}
+    readinessProbe: {}
+    startupProbe: {}
   gitSync:
     webhookPort: 8000
     securityContext:
@@ -921,6 +927,9 @@ gitSyncRelay:
       allowPrivilegeEscalation: false
       capabilities:
         drop: [ALL]
+    livenessProbe: {}
+    readinessProbe: {}
+    startupProbe: {}
   images:
     gitDaemon:
       repository: "quay.io/astronomer/ap-git-daemon"


### PR DESCRIPTION
## Description

- Add `startupProbe` support (PINF-951) to `dag-server`, `git-sync`, `git-daemon`, and the shared `auth_sidecar_container_spec`/`logging_sidecar_container_spec` helpers (auth-proxy, sidecar-log-consumer) used by both `dag-server` and `git-sync-relay` pods -- the airflow-chart-owned templates PINF-691 didn't reach.
- Populate default resource requests/limits (PINF-969) for `dagDeploy`, `gitSyncRelay.gitSync`, and `gitSyncRelay.gitDaemon` -- this chart's 3 originally-ticketed empty knobs.
- Also fix 2 knobs the ticket's count missed: `authSidecar.resources` and `loggingSidecar.resources` were still `resources: {}`, which their templates guard with `{{- if }}` -- meaning the field was omitted from the rendered manifest entirely, not just empty.
- Update `CLAUDE.md`'s authSidecar/loggingSidecar sharp-edge note now that both gaps (probes, resources) are fixed.
- Copilot review follow-ups: `git-daemon`'s new default `startupProbe` used a mutating `touch` exec check (creates the file, defeating the point of a readiness signal); switched to a non-mutating `test -f`. Fixed the `startupProbe` test fixtures in `test_git_sync_relay_deployment.py`/`test_dag_server_statefulset.py`, which nested `initialDelaySeconds`/`periodSeconds` inside `httpGet` instead of as top-level probe fields -- not a real bug (the template does a raw passthrough, so the test still validated override behavior), but not a valid Kubernetes Probe shape either, which is what these fixtures are meant to demonstrate.

## Related Issues

Closes [PINF-951](https://linear.app/astronomer/issue/PINF-951/airflow-chart-add-missing-startup-probes-to-dag-server-and-git-sync), [PINF-969](https://linear.app/astronomer/issue/PINF-969/astronomer-airflow-chart-complete-default-resource-requestslimits) (airflow-chart slice)

## Testing

`uv run pytest tests/chart/` -- all chart render tests green, including `test_dag_server_statefulset.py` and `test_git_sync_relay_deployment.py` (260 passed) covering both the new startupProbe defaults/overrides and the resource defaults/overrides.

## Merging

This is for APC release-2.1, which is release-1.18 in this repo
