### PR TITLE
PINF-1068 Bump chart versions

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: airflow
-  repository: https://github.com/astronomer/apc-airflow/releases/download/oss-helm-chart/1.17.14-astro
-  version: 1.17.14-astro
-digest: sha256:7d771fd86cf173b723ca37afed77efa03bb95d67c47416ab899fef8136739360
-generated: "2026-07-21T14:49:59.587504-04:00"
+  repository: https://github.com/astronomer/apc-airflow/releases/download/oss-helm-chart/1.17.15-astro
+  version: 1.17.15-astro
+digest: sha256:4abf65ee0264a6868ce05ca0bb2fffda73889c7a5847cc6e9049fbe13edf3bd3
+generated: "2026-07-21T18:37:22.732846-04:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 # apiVersion v2 is Helm 3
 apiVersion: v2
 name: airflow
-version: 1.18.5
+version: 1.18.6
 description: Helm chart to deploy the Astronomer Platform Airflow module
 icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:
@@ -9,5 +9,5 @@ keywords:
   - airflow
 dependencies:
   - name: airflow
-    version: 1.17.14-astro
-    repository: https://github.com/astronomer/apc-airflow/releases/download/oss-helm-chart/1.17.14-astro
+    version: 1.17.15-astro
+    repository: https://github.com/astronomer/apc-airflow/releases/download/oss-helm-chart/1.17.15-astro


### PR DESCRIPTION
## Description

airflow-chart version 1.18.6 with apc-airflow 1.17.15-astro

## Related Issues

https://linear.app/astronomer/issue/PINF-1068

## Testing

No special testing needed, this just bumps the airflow dependency. If CI passes then we're good.

## Merging

Merge only to release-1.18