### PR TITLE
PINF-1073 disable caching for index.yaml in internal helm repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,22 +135,6 @@ workflows:
 
       - approve-release-prod:
           type: approval
-          requires:
-            - "test-1-31-14-CeleryExecutor"
-            - "test-1-31-14-LocalExecutor"
-            - "test-1-31-14-KubernetesExecutor"
-            - "test-1-32-11-CeleryExecutor"
-            - "test-1-32-11-LocalExecutor"
-            - "test-1-32-11-KubernetesExecutor"
-            - "test-1-33-7-CeleryExecutor"
-            - "test-1-33-7-LocalExecutor"
-            - "test-1-33-7-KubernetesExecutor"
-            - "test-1-34-3-CeleryExecutor"
-            - "test-1-34-3-LocalExecutor"
-            - "test-1-34-3-KubernetesExecutor"
-            - "test-1-35-0-CeleryExecutor"
-            - "test-1-35-0-LocalExecutor"
-            - "test-1-35-0-KubernetesExecutor"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,8 +145,22 @@ workflows:
             - github-repo
             - gcp-astronomer-prod
           requires:
-            - approve-test-all
             - approve-release-prod
+            - "test-1-31-14-CeleryExecutor"
+            - "test-1-31-14-LocalExecutor"
+            - "test-1-31-14-KubernetesExecutor"
+            - "test-1-32-11-CeleryExecutor"
+            - "test-1-32-11-LocalExecutor"
+            - "test-1-32-11-KubernetesExecutor"
+            - "test-1-33-7-CeleryExecutor"
+            - "test-1-33-7-LocalExecutor"
+            - "test-1-33-7-KubernetesExecutor"
+            - "test-1-34-3-CeleryExecutor"
+            - "test-1-34-3-LocalExecutor"
+            - "test-1-34-3-KubernetesExecutor"
+            - "test-1-35-0-CeleryExecutor"
+            - "test-1-35-0-LocalExecutor"
+            - "test-1-35-0-KubernetesExecutor"
           filters:
             branches:
               only:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -32,12 +32,6 @@ workflows:
 {%- endfor %}
       - approve-release-prod:
           type: approval
-          requires:
-{%- for version in kube_versions %}
-{%- for executor in executors %}
-            - "test-{{ version | replace(".", "-") }}-{{ executor }}"
-{%- endfor %}
-{%- endfor %}
           filters:
             branches:
               only:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -42,8 +42,12 @@ workflows:
             - github-repo
             - gcp-astronomer-prod
           requires:
-            - approve-test-all
             - approve-release-prod
+{%- for version in kube_versions %}
+{%- for executor in executors %}
+            - "test-{{ version | replace(".", "-") }}-{{ executor }}"
+{%- endfor %}
+{%- endfor %}
           filters:
             branches:
               only:

--- a/bin/package-and-release-internal
+++ b/bin/package-and-release-internal
@@ -44,7 +44,9 @@ gcloud storage cp gs://${helm_repo}/index.yaml "index-orig.yaml"
 sha256sum index-orig.yaml
 helm repo index . --url "https://${helm_repo}" --merge "index-orig.yaml"
 sha256sum index.yaml
-gcloud storage cp --cache-control "public" index.yaml "gs://${helm_repo}/"
+# index.yaml must never be served stale from cache: CI/stage-cluster
+# upgrades poll right after a release and need to see the new version.
+gcloud storage cp --cache-control "no-cache, no-store, max-age=0" index.yaml "gs://${helm_repo}/"
 set +e
 diff index-orig.yaml index.yaml
 echo "$(date -Iseconds) Finished."

--- a/bin/package-and-release-internal
+++ b/bin/package-and-release-internal
@@ -43,8 +43,13 @@ update_index() {
   # clobber each other's merge.
   gen=$(gcloud storage objects describe "gs://${helm_repo}/index.yaml" --format="value(generation)" 2>/dev/null || echo 0)
   if [ "${gen}" -eq 0 ] ; then
-    echo "-> no existing index.yaml found in gs://${helm_repo}: creating a new one"
-    helm repo index . --url "https://${helm_repo}"
+    echo "!!! P0: gs://${helm_repo}/index.yaml is missing or unreadable !!!"
+    echo "Every previously published airflow-chart version would become undiscoverable via"
+    echo "'helm repo update' if we silently generated a replacement index.yaml here. Refusing"
+    echo "to proceed -- investigate immediately whether the object was actually deleted, or"
+    echo "the describe call failed for another reason (auth/permissions/network), before"
+    echo "re-running."
+    exit 1
   else
     echo "-> merging into existing index.yaml (generation ${gen}) from gs://${helm_repo}"
     rm -f index-orig.yaml

--- a/bin/package-and-release-internal
+++ b/bin/package-and-release-internal
@@ -36,17 +36,41 @@ else
   (cd airflow && bin/repo-state-report.py)
 fi
 
+update_index() {
+  # Update index.yaml transactionally: only overwrite it if nobody else has
+  # updated it since we last read it. The astronomer (platform) chart
+  # publishes to this same bucket, so concurrent releases can otherwise
+  # clobber each other's merge.
+  gen=$(gcloud storage objects describe "gs://${helm_repo}/index.yaml" --format="value(generation)" 2>/dev/null || echo 0)
+  if [ "${gen}" -eq 0 ] ; then
+    echo "-> no existing index.yaml found in gs://${helm_repo}: creating a new one"
+    helm repo index . --url "https://${helm_repo}"
+  else
+    echo "-> merging into existing index.yaml (generation ${gen}) from gs://${helm_repo}"
+    rm -f index-orig.yaml
+    gcloud storage cp "gs://${helm_repo}/index.yaml#${gen}" "index-orig.yaml"
+    sha256sum index-orig.yaml
+    helm repo index . --url "https://${helm_repo}" --merge "index-orig.yaml"
+    diff index-orig.yaml index.yaml || true
+  fi
+  sha256sum index.yaml
+  # index.yaml must never be served stale from cache: CI/stage-cluster
+  # upgrades poll right after a release and need to see the new version.
+  gcloud storage cp --cache-control "no-cache, no-store, max-age=0" --if-generation-match "${gen}" index.yaml "gs://${helm_repo}/"
+}
+
 helm package airflow --dependency-update --app-version "${app_version}" "${extra_args[@]}"
 gcloud storage cp "${filename}" "gs://${helm_repo}/"
 
-rm -f index-orig.yaml
-gcloud storage cp gs://${helm_repo}/index.yaml "index-orig.yaml"
-sha256sum index-orig.yaml
-helm repo index . --url "https://${helm_repo}" --merge "index-orig.yaml"
-sha256sum index.yaml
-# index.yaml must never be served stale from cache: CI/stage-cluster
-# upgrades poll right after a release and need to see the new version.
-gcloud storage cp --cache-control "no-cache, no-store, max-age=0" index.yaml "gs://${helm_repo}/"
-set +e
-diff index-orig.yaml index.yaml
+attempt=1
+until update_index ; do
+  echo "Index update failed (attempt ${attempt})"
+  if (( attempt++ == 3 )) ; then
+    echo "ERROR: failed to update index after 3 attempts!"
+    exit 1
+  fi
+  echo "Retrying in 5 seconds..."
+  sleep 5
+done
+
 echo "$(date -Iseconds) Finished."


### PR DESCRIPTION
## Description

- Do not cache index.yaml for internal repo
- Make index.yaml update transactional
- Enable pre-approving a prod release instead of having to wait until all tests succeed. Test failures will still prevent a prod release.

## Related Issues

https://linear.app/astronomer/issue/PINF-1073

## Testing

This is only for internal helm, which is tested on every PR. This log shows that the new logic is working as expected. https://app.circleci.com/pipelines/gh/astronomer/airflow-chart/3580/workflows/283ceed4-0db6-4386-9aab-3217e023c275/jobs/44060/parallel-runs/0/steps/0-102

## Merging

This should be merged everywhere so that cache behavior is consistent with all working branches.