### PR TITLE
PINF-989 Add resources field to the pgbouncer-certgenerator containers

### DIFF
--- a/templates/generate-ssl.yaml
+++ b/templates/generate-ssl.yaml
@@ -87,6 +87,7 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             readOnlyRootFilesystem: true
+          resources: {{- toYaml .Values.certgenerator.resources | nindent 12 }}
           volumeMounts:
             - name: tmp
               mountPath: /tmp

--- a/tests/chart/test_pgbouncer_certgenerator.py
+++ b/tests/chart/test_pgbouncer_certgenerator.py
@@ -36,6 +36,27 @@ class TestPgbouncersslFeature:
         assert "RoleBinding" == jmespath.search("kind", docs[2])
         assert docs[3]["spec"]["template"]["spec"]["affinity"] == {}
         assert docs[3]["spec"]["template"]["spec"]["containers"][0]["securityContext"]["readOnlyRootFilesystem"] is True
+        assert docs[3]["spec"]["template"]["spec"]["containers"][0]["resources"] == {
+            "limits": {"cpu": "200m", "memory": "256Mi"},
+            "requests": {"cpu": "100m", "memory": "128Mi"},
+        }
+
+    def test_pgbouncer_certgenerator_resources_are_overridable(self, kube_version):
+        """Test that certgenerator.resources overrides the defaults."""
+        resources = {
+            "limits": {"cpu": "1", "memory": "1Gi"},
+            "requests": {"cpu": "500m", "memory": "512Mi"},
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "airflow": {"pgbouncer": {"enabled": True, "sslmode": "require"}},
+                "certgenerator": {"resources": resources},
+            },
+            show_only="templates/generate-ssl.yaml",
+        )
+        assert len(docs) == 4
+        assert docs[3]["spec"]["template"]["spec"]["containers"][0]["resources"] == resources
 
     def test_pgbouncer_certgenerator_with_custom_registry_secret(self, kube_version):
         """Test pgbouncer certgenerator sslmode opts result."""

--- a/values.yaml
+++ b/values.yaml
@@ -1025,6 +1025,13 @@ gitSyncRelay:
 certgenerator:
   extraAnnotations: {}
   affinity: {}
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
 
 # Labels that are attached to all pods created by the airflow-chart, but not the sub-charts.
 labels: {}


### PR DESCRIPTION
## Description

The pgbouncer-certgenerator container in the SSL pre-install/pre-upgrade hook Job had no resources field at all, unlike every other container in the chart. Add certgenerator.resources (defaulted, overridable) and wire it into the container, following the same pattern as authSidecar and gitSyncRelay's resources defaults.

## Related Issues

https://linear.app/astronomer/issue/PINF-989

## Testing

There are tests included, but some chart code was changed. Normal testing of these features is sufficient.

## Merging

release-1.18