### PR TITLE
PINF-989 fill k8s security testing gaps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
   run_pre_commit:
     resource_class: small
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2026-07
+      - image: quay.io/astronomer/ci-pre-commit:2026-08
     steps:
       - checkout
       - run:
@@ -205,7 +205,7 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-07
+      - image: quay.io/astronomer/ci-helm-release:2026-08
     parallelism: 8
     steps:
       - setup_remote_docker:
@@ -224,7 +224,7 @@ jobs:
 
   build-and-release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-07
+      - image: quay.io/astronomer/ci-helm-release:2026-08
     steps:
       - checkout
       - run:
@@ -265,7 +265,7 @@ jobs:
           path: test-results
   release-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-07
+      - image: quay.io/astronomer/ci-helm-release:2026-08
     steps:
       - checkout
       - run:
@@ -274,7 +274,7 @@ jobs:
 
   release-public:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-07
+      - image: quay.io/astronomer/ci-helm-release:2026-08
     steps:
       - checkout
       - publish-github-release

--- a/tests/chart/test_container_security_context.py
+++ b/tests/chart/test_container_security_context.py
@@ -65,9 +65,9 @@ def test_all_containers_have_hardened_security_context(kube_version):
     )
 
 
-# mountPropagation isn't a securityContext field, so it's not part of hardening_problems() above --
-# a separate PSA/Kyverno-adjacent control (Restricted forbids the two unsafe values). Not
-# currently a PSA control itself, but a real customer ask (PINF-986: MountPropagation).
+# mountPropagation isn't a securityContext field, so it's not part of hardening_problems() above,
+# and Pod Security Admission doesn't validate it either -- this is a Kyverno/OPA-style customer
+# policy control instead, forbidding the two unsafe values (PINF-986: MountPropagation).
 UNSAFE_MOUNT_PROPAGATION = {"HostToContainer", "Bidirectional"}
 
 

--- a/tests/chart/test_container_security_context.py
+++ b/tests/chart/test_container_security_context.py
@@ -65,6 +65,35 @@ def test_all_containers_have_hardened_security_context(kube_version):
     )
 
 
+# mountPropagation isn't a securityContext field, so it's not part of hardening_problems() above --
+# a separate PSA/Kyverno-adjacent control (Restricted forbids the two unsafe values). Not
+# currently a PSA control itself, but a real customer ask (PINF-986: MountPropagation).
+UNSAFE_MOUNT_PROPAGATION = {"HostToContainer", "Bidirectional"}
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+def test_no_containers_use_unsafe_mount_propagation(kube_version):
+    """Render the whole chart and assert no volumeMount sets an unsafe mountPropagation."""
+    docs = render_chart(kube_version=kube_version, values=get_all_features())
+
+    offenders = {}
+    checked = 0
+    for doc in docs:
+        if doc.get("metadata", {}).get("name") in EXCLUDED_DOCS:
+            continue
+        owner = f"{doc['kind']}/{doc['metadata']['name']}"
+        for name, container in get_containers_by_name(doc, include_init_containers=True).items():
+            checked += 1
+            for mount in container.get("volumeMounts") or []:
+                if mount.get("mountPropagation") in UNSAFE_MOUNT_PROPAGATION:
+                    offenders[f"{owner}:{name}:{mount['name']}"] = mount["mountPropagation"]
+
+    assert checked, "No containers were rendered; cannot validate mountPropagation"
+    assert not offenders, "volumeMounts with an unsafe mountPropagation (mount: value):\n" + "\n".join(
+        f"  {key}: {value}" for key, value in sorted(offenders.items())
+    )
+
+
 # --- git-sync-relay PSS-Restricted conformance (PINF-585 follow-up) -----------------
 #
 # git-sync-relay is not processed by houston's securityHardeningConfig, so unlike

--- a/tests/chart/test_dag_server_service.py
+++ b/tests/chart/test_dag_server_service.py
@@ -27,3 +27,6 @@ class TestDagServerService:
         assert doc["kind"] == "Service"
         assert doc["apiVersion"] == "v1"
         assert doc["metadata"]["name"] == "release-name-dag-server"
+        # No serviceType override exists for this Service -- it must stay unset so Kubernetes'
+        # own default (ClusterIP) applies. (PINF-986: ServiceOnlyAllowClusterIP)
+        assert "type" not in doc["spec"]

--- a/tests/chart/test_git_sync_relay_service.py
+++ b/tests/chart/test_git_sync_relay_service.py
@@ -28,6 +28,9 @@ class TestGitSyncRelayService:
         assert doc["kind"] == "Service"
         assert doc["apiVersion"] == "v1"
         assert doc["metadata"]["name"] == "release-name-git-sync-relay"
+        # No serviceType override exists for this Service -- it must stay unset so Kubernetes'
+        # own default (ClusterIP) applies. (PINF-986: ServiceOnlyAllowClusterIP)
+        assert "type" not in doc["spec"]
 
     @pytest.mark.parametrize("repoShareMode,", ["git_daemon", "shared_volume"])
     @pytest.mark.parametrize("repoFetchMode", ["poll", "webhook"])
@@ -53,6 +56,7 @@ class TestGitSyncRelayService:
         assert doc["kind"] == "Service"
         assert doc["apiVersion"] == "v1"
         assert doc["metadata"]["name"] == "release-name-git-sync-relay"
+        assert "type" not in doc["spec"]
         ports = get_service_ports_by_name(doc)
         if repoFetchMode == "webhook":
             assert ports["webhook"]["port"] == 8000


### PR DESCRIPTION
## Description

- Neither the dag-server nor git-sync-relay Service template sets `spec.type` at all, so both already default to `ClusterIP` -- just untested. Added an assertion to each existing "enabled" test confirming `type` stays absent from the rendered spec.
- Added a chart-wide sweep asserting no `volumeMount` sets `mountPropagation` to `HostToContainer` or `Bidirectional`, following the same render-everything-and-report-offenders pattern as the existing hardened-securityContext sweep in the same file.

Closes PINF-986's `ServiceOnlyAllowClusterIP` Airflow-Deployment-tier leg and `MountPropagation` checklist rows for this chart.

## Related Issues

https://linear.app/astronomer/issue/PINF-986

## Testing

No special testing needed. These are all test changes, filling gaps in our test coverage to validate features.

## Merging

release-1.18
