### PR TITLE
PINF-1178 - add default auth_manager config

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -430,6 +430,7 @@ airflow:
       flower_url_prefix: ""
     core:
       execution_api_server_url: '{{ (printf "http://%s-api-server:%d/%s/airflow/execution/" (include "airflow.fullname" .) (int .Values.ports.apiServer) .Release.Name )  -}}'
+      auth_manager: "airflow.auth.managers.fab.fab_auth_manager.FabAuthManager"
 
     webserver:
       expose_config: non-sensitive-only


### PR DESCRIPTION
## Description

This PR adds default auth_manager config to auth manager class instead of provider

for AF2 instead of 
`airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager`
we now set 
`airflow.auth.managers.fab.fab_auth_manager.FabAuthManager`

why was this change needed in some of the airflow version airflow fab providers was not available as default and requires a seperate package update to utilize the provider rather , we adopt our own approach to loading the class directly into the config mimicing the 0.37 approach

## Related Issues

https://linear.app/astronomer/issue/PINF-1178/older-astro-runtime-9x-fails-to-start-airflow-webserver

## Testing

QA should able to deploy 9.x version without any issues and also other versions should work as expected

for AF3 we always inject the auth_manager env vars from the api - no action has to be taken for airflow3
<img width="1042" height="104" alt="image" src="https://github.com/user-attachments/assets/5648268a-64e9-46e5-920c-c6dcecaffdde" />


## Merging

merge to master , release-1.17, release-1.18
