### PR TITLE
PINF-1234: fix pgbouncer ssl certgenerator Kyverno policy compatibility

### DIFF
--- a/templates/generate-ssl.yaml
+++ b/templates/generate-ssl.yaml
@@ -87,6 +87,10 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           resources: {{- toYaml .Values.certgenerator.resources | nindent 12 }}
           volumeMounts:
             - name: tmp

--- a/tests/chart/test_pgbouncer_certgenerator.py
+++ b/tests/chart/test_pgbouncer_certgenerator.py
@@ -35,7 +35,11 @@ class TestPgbouncersslFeature:
         assert expected_rbac in docs[1]["rules"]
         assert "RoleBinding" == jmespath.search("kind", docs[2])
         assert docs[3]["spec"]["template"]["spec"]["affinity"] == {}
-        assert docs[3]["spec"]["template"]["spec"]["containers"][0]["securityContext"]["readOnlyRootFilesystem"] is True
+        assert docs[3]["spec"]["template"]["spec"]["containers"][0]["securityContext"] == {
+            "readOnlyRootFilesystem": True,
+            "allowPrivilegeEscalation": False,
+            "capabilities": {"drop": ["ALL"]},
+        }
         assert docs[3]["spec"]["template"]["spec"]["containers"][0]["resources"] == {
             "limits": {"cpu": "200m", "memory": "256Mi"},
             "requests": {"cpu": "100m", "memory": "128Mi"},


### PR DESCRIPTION
## Description

Title: PINF-1234: Fix pgbouncer ssl certgenerator Kyverno policy compatibility

## Summary
- Adds `allowPrivilegeEscalation: false` and `capabilities.drop: [ALL]` to the `pgbouncer-certgenerator` container's `securityContext` in `templates/generate-ssl.yaml`, alongside the existing `readOnlyRootFilesystem: true`.
- Fixes the ssl cert generator job failing Kyverno policy checks.


## Test plan
- [x] Updated `tests/chart/test_pgbouncer_certgenerator.py` to assert the full `securityContext` object
- [x] `uv run pytest tests/chart/test_pgbouncer_certgenerator.py` — 35 passed

## Related Issues
https://linear.app/astronomer/issue/PINF-1234/pgbouncer-ssl-cert-generator-job-fails-kyverno-policy

## Testing

```
1. Verify the rendered manifest (fastest sanity check)

helm template . --set airflow.pgbouncer.enabled=true --set airflow.pgbouncer.sslmode=require \
  --show-only templates/generate-ssl.yaml
Confirm the pgbouncer-certgenerator container's securityContext now shows all three fields:

securityContext:
  readOnlyRootFilesystem: true
  allowPrivilegeEscalation: false
  capabilities:
    drop:
      - ALL
```

## Merging

Merge into main
